### PR TITLE
Feature/negative extrude

### DIFF
--- a/core/util.scad
+++ b/core/util.scad
@@ -107,3 +107,29 @@ function cardinal(p) =
         [ position(min(len(search("wW", p)), 1), min(len(search("eE", p)), 1)),
           position(min(len(search("sS", p)), 1), min(len(search("nN", p)), 1)) ]
 ;
+
+/**
+ * Computes a size value, and its offset, of an object to be used as a negative for a `difference()` operation.
+ * An alignment value will be added according to the parameter `direction` to counter the wall alignment issue.
+ *
+ * @param Number [value] - The value of the size to adjust. If the value is negative, the offset will be adjusted
+ *                         to allow top to bottom position (below the origin).
+ * @param Number|String [direction] - Tells on what sides adjust the size to make sure the difference won't
+ *                                    produce dummy walls.
+ * @param Boolean [center] - Whether or not center the position on the axis.
+ * @returns Vector - A 2D vector that contains the adjusted size and its offset.
+ */
+function align(value, direction, center) =
+    let(
+        direction = cardinal(uor(direction, 2))[1],
+        value = divisor(value),
+        absv = abs(value),
+        adjust = direction ? (direction == 2 ? ALIGN2 : ALIGN) : 0,
+        offset = center ? (direction == 2 || direction == 0 ? 0 : direction * ALIGN / 2)
+                        : (direction == 2 || direction == -1 ? -ALIGN : 0)
+    )
+    [
+        absv + adjust,
+        offset + (value < 0 && !center ? value : 0)
+    ]
+;

--- a/operator/extrude/negative.scad
+++ b/operator/extrude/negative.scad
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2017 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operators that extrude children modules with respect to particular rules.
+ *
+ * @package operator/extrude
+ * @author jsconan
+ */
+
+/**
+ * Extrudes linearly the children modules, and apply a wall adjustment to ensure
+ * the final object will not produce artifacts after a `difference()` operation.
+ *
+ * @param Number [height] - The height of the extrusion. If the value is negative,
+ *                          the extrusion will be made top to bottom (below the origin).
+ * @param Number|String [direction] - Tells on what sides adjust the height to make sure
+ *                                    the difference won't produce dummy walls.
+ * @param Boolean [center] - Whether or not center the extrusion on the vertical axis.
+ * @param Number [convexity] - If the extrusion fails for a non-trivial 2D shape,
+ *                             try setting the convexity parameter.
+ * @param Number [twist] - The number of degrees of through which the shape is extruded.
+ * @param Number [slices] - Defines the number of intermediate points along the Z axis
+ *                          of the extrusion.
+ * @param Number|Vector [scale] - Scales the 2D shape by this value over the height of
+ *                                the extrusion.
+ */
+module negativeExtrude(height, direction, center, convexity, twist, slices, scale) {
+    center = boolean(center);
+    convexity = numberOr(convexity, 10);
+    height = align(height=height, direction=direction, center=center);
+
+    translateZ(height[1]) {
+        linear_extrude(height=height[0], center=center, convexity=convexity, twist=twist, slices=slices, scale=scale) {
+            children();
+        }
+    }
+}

--- a/operators.scad
+++ b/operators.scad
@@ -40,6 +40,8 @@ include <operator/distribute/mirror.scad>
 include <operator/distribute/rotate.scad>
 include <operator/distribute/translate.scad>
 
+include <operator/extrude/negative.scad>
+
 include <operator/repeat/mirror.scad>
 include <operator/repeat/rotate.scad>
 include <operator/repeat/translate.scad>

--- a/test/core/util.scad
+++ b/test/core/util.scad
@@ -24,6 +24,7 @@
  */
 
 use <../../full.scad>
+include <../../core/constants.scad>
 
 /**
  * Part of the camelSCAD library.
@@ -34,7 +35,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreUtil() {
-    testPackage("core/util.scad", 4) {
+    testPackage("core/util.scad", 5) {
         // test core/util/position()
         testModule("position()", 5) {
             testUnit("no parameter", 1) {
@@ -162,6 +163,43 @@ module testCoreUtil() {
                 assertEqual(cardinal("1"), [0, 0], "String containing numbers should produce [0, 0]");
                 assertEqual(cardinal(["1", "2", "3"]), [0, 0], "An array of strings containing numbers should produce [0, 0]");
                 assertEqual(cardinal(["n", "e"]), [1, 1], "An array of strings could produce positions");
+            }
+        }
+        // test core/util/align()
+        testModule("align()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(align(), [1 + ALIGN2, -ALIGN], "Should return a default value, with default adjustment");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(align("1", "0", "false"), [1, 0], "Cannot adjust dimension from strings, should return a default value, without adjustment");
+                assertEqual(align(true, true, true), [1, 0], "Cannot adjust dimension from booleans, should return a default value, without adjustment");
+                assertEqual(align([1], [2], [3]), [1, 0], "Cannot adjust dimension from vectors, should return a default value, without adjustment");
+            }
+            testUnit("number", 10) {
+                assertEqual(align(42), [42 + ALIGN2, -ALIGN], "When only the value is provided, the result should be this value with the default adjustment");
+                assertEqual(align(42, direction=2), [42 + ALIGN2, -ALIGN], "Dimension, with alignment on both edges, not centered");
+                assertEqual(align(42, direction=1), [42 + ALIGN, 0], "Dimension, with alignment on top, not centered");
+                assertEqual(align(42, direction=0), [42, 0], "dimension, without alignment and not centered");
+                assertEqual(align(42, direction=-1), [42 + ALIGN, -ALIGN], "Dimension, with alignment on bottom, not centered");
+
+                assertEqual(align(42, center=true), [42 + ALIGN2, 0], "When only the value is provided, but centered, the result should be this value with the a centered adjustment");
+                assertEqual(align(42, direction=2, center=true), [42 + ALIGN2, 0], "Dimension, with alignment on both edges, centered");
+                assertEqual(align(42, direction=1, center=true), [42 + ALIGN, ALIGN / 2], "Dimension, with alignment on top, centered");
+                assertEqual(align(42, direction=0, center=true), [42, 0], "dimension, without alignment and centered");
+                assertEqual(align(42, direction=-1, center=true), [42 + ALIGN, -ALIGN / 2], "Dimension, with alignment on bottom, centered");
+            }
+            testUnit("number and string", 10) {
+                assertEqual(align(42, direction="ns"), [42 + ALIGN2, -ALIGN], "Dimension, with alignment on both edges, not centered");
+                assertEqual(align(42, direction="n"), [42 + ALIGN, 0], "Dimension, with alignment on top, not centered");
+                assertEqual(align(42, direction=""), [42, 0], "dimension, without alignment and not centered");
+                assertEqual(align(42, direction="we"), [42, 0], "dimension, with wrong alignment and not centered");
+                assertEqual(align(42, direction="s"), [42 + ALIGN, -ALIGN], "Dimension, with alignment on bottom, not centered");
+
+                assertEqual(align(42, direction="ns", center=true), [42 + ALIGN2, 0], "Dimension, with alignment on both edges, centered");
+                assertEqual(align(42, direction="n", center=true), [42 + ALIGN, ALIGN / 2], "Dimension, with alignment on top, centered");
+                assertEqual(align(42, direction="", center=true), [42, 0], "dimension, without alignment and centered");
+                assertEqual(align(42, direction="we", center=true), [42, 0], "dimension, with wrong alignment and centered");
+                assertEqual(align(42, direction="s", center=true), [42 + ALIGN, -ALIGN / 2], "Dimension, with alignment on bottom, centered");
             }
         }
     }


### PR DESCRIPTION
New operator module: `negativeExtrude(height, direction, center, convexity, twist, slices, scale)`.
Extrudes linearly the children modules, and apply a wall adjustment to ensure the final object will not produce artifacts after a `difference()` operation.

New core function: `align(value, direction, center)`.
Computes a size value, and its offset, of an object to be used as a negative for a `difference()` operation. An alignment value will be added according to the parameter `direction` to counter the wall alignment issue.