### PR TITLE
Feature/build box

### DIFF
--- a/core/constants.scad
+++ b/core/constants.scad
@@ -97,3 +97,21 @@ ALIGN = 0.005;
  * @type Number
  */
 ALIGN2 = 2 * ALIGN;
+
+/**
+ * The default size of the build plate.
+ * @type Number
+ */
+DEFAULT_BUILD_PLATE_SIZE = 200;
+
+/**
+ * The default size of the build volume.
+ * @type Number
+ */
+DEFAULT_BUILD_VOLUME_SIZE = DEFAULT_BUILD_PLATE_SIZE;
+
+/**
+ * The default size of a cell on the build plate.
+ * @type Number
+ */
+DEFAULT_BUILD_PLATE_CELL = 10;

--- a/core/constants.scad
+++ b/core/constants.scad
@@ -33,10 +33,28 @@
  */
 
 /**
+ * The name of the development rendering mode.
+ * @type String
+ */
+MODE_DEV = "dev";
+
+/**
+ * The name of the production rendering mode.
+ * @type String
+ */
+MODE_PROD = "prod";
+
+/**
+ * The name of the dirty rendering mode.
+ * @type String
+ */
+MODE_DIRTY = "dirty";
+
+/**
  * The name of the default rendering mode.
  * @type String
  */
-DEFAULT_MODE = "dev";
+DEFAULT_MODE = MODE_DEV;
 
 /**
  * Degrees in a circle.

--- a/core/mode.scad
+++ b/core/mode.scad
@@ -38,9 +38,9 @@
  * @type Vector
  */
 MODES = [
-    ["dirty", 6, 2],
-    ["dev", 1, 1.5],
-    ["prod", .5, .5]
+    [MODE_DIRTY, 6, 2],
+    [MODE_DEV, 1, 1.5],
+    [MODE_PROD, .5, .5]
 ];
 
 /**

--- a/operator/distribute/grid.scad
+++ b/operator/distribute/grid.scad
@@ -35,11 +35,9 @@
 /**
  * Distributes the children modules on a grid with the provided `interval`, up to `line` elements per lines.
  *
- * @param Vector [interval] - The interval between each elements.
+ * @param Vector [intervalX] - The interval between each columns.
+ * @param Vector [intervalY] - The interval between each lines.
  * @param Number [line] - The max number of elements per lines.
- * @param Number [x] - The X interval between each elements (will overwrite the X coordinate in the `interval` vector).
- * @param Number [y] - The Y interval between each elements (will overwrite the Y coordinate in the `interval` vector).
- * @param Number [z] - The Z interval between each elements (will overwrite the Z coordinate in the `interval` vector).
  */
 module distributeGrid(intervalX = [1, 0, 0],
                       intervalY = [0, 1, 0],

--- a/operator/distribute/mirror.scad
+++ b/operator/distribute/mirror.scad
@@ -38,9 +38,12 @@
  *
  * @param Vector [interval] - The interval between each elements.
  * @param Vector [axis] - The normal vector of the mirroring plan around which mirror the elements.
- * @param Number [x] - The X interval between each elements (will overwrite the X coordinate in the `interval` vector).
- * @param Number [y] - The Y interval between each elements (will overwrite the Y coordinate in the `interval` vector).
- * @param Number [z] - The Z interval between each elements (will overwrite the Z coordinate in the `interval` vector).
+ * @param Number [intervalX] - The X interval between each repeated children
+ *                             (will overwrite the X coordinate in the `interval` vector).
+ * @param Number [intervalY] - The Y interval between each repeated children
+ *                             (will overwrite the Y coordinate in the `interval` vector).
+ * @param Number [intervalZ] - The Z interval between each repeated children
+ *                             (will overwrite the Z coordinate in the `interval` vector).
  * @param Number [axisX] - The X-coordinate of the normal vector of the mirroring plan around which mirror the elements
  *                         (will overwrite the X coordinate in the `axis` vector).
  * @param Number [axisY] - The Y-coordinate of the normal vector of the mirroring plan around which mirror the elements
@@ -50,10 +53,10 @@
  */
 module distributeMirror(interval = [0, 0, 0],
                         axis     = [1, 0, 0],
-                        x, y, z,
+                        intervalX, intervalY, intervalZ,
                         axisX, axisY, axisZ) {
 
-    interval = apply3D(interval, x, y, z);
+    interval = apply3D(interval, intervalX, intervalY, intervalZ);
     axis = apply3D(axis, axisX, axisY, axisZ);
 
     for (i = [0 : $children - 1]) {

--- a/operator/distribute/rotate.scad
+++ b/operator/distribute/rotate.scad
@@ -40,9 +40,12 @@
  * @param Vector [axis] - The rotation axis around which rotate the elements.
  * @param Vector [interval] - The interval between each elements.
  * @param Vector [origin] - The rotate origin.
- * @param Number [x] - The X interval between each elements (will overwrite the X coordinate in the `interval` vector).
- * @param Number [y] - The Y interval between each elements (will overwrite the Y coordinate in the `interval` vector).
- * @param Number [z] - The Z interval between each elements (will overwrite the Z coordinate in the `interval` vector).
+ * @param Number [intervalX] - The X interval between each repeated children
+ *                             (will overwrite the X coordinate in the `interval` vector).
+ * @param Number [intervalY] - The Y interval between each repeated children
+ *                             (will overwrite the Y coordinate in the `interval` vector).
+ * @param Number [intervalZ] - The Z interval between each repeated children
+ *                             (will overwrite the Z coordinate in the `interval` vector).
  * @param Number [axisX] - The X axis factor (will overwrite the X coordinate in the `axis` vector).
  * @param Number [axisY] - The Y axis factor (will overwrite the Y coordinate in the `axis` vector).
  * @param Number [axisZ] - The Z axis factor (will overwrite the Z coordinate in the `axis` vector).
@@ -54,11 +57,11 @@ module distributeRotate(angle    = 360,
                         axis     = [0, 0, 1],
                         interval = [0, 0, 0],
                         origin   = [0, 0, 0],
-                        x, y, z,
+                        intervalX, intervalY, intervalZ,
                         axisX, axisY, axisZ,
                         originX, originY, originZ) {
 
-    interval = apply3D(interval, x, y, z);
+    interval = apply3D(interval, intervalX, intervalY, intervalZ);
     origin = apply3D(origin, originX, originY, originZ);
     angle = deg(angle);
     partAngle = angle / (angle % 360 ? $children - 1 : $children);

--- a/operator/distribute/translate.scad
+++ b/operator/distribute/translate.scad
@@ -36,14 +36,17 @@
  * Distributes the children modules with the provided `interval`.
  *
  * @param Vector [interval] - The interval between each elements.
- * @param Number [x] - The X interval between each elements (will overwrite the X coordinate in the `interval` vector).
- * @param Number [y] - The Y interval between each elements (will overwrite the Y coordinate in the `interval` vector).
- * @param Number [z] - The Z interval between each elements (will overwrite the Z coordinate in the `interval` vector).
+ * @param Number [intervalX] - The X interval between each repeated children
+ *                             (will overwrite the X coordinate in the `interval` vector).
+ * @param Number [intervalY] - The Y interval between each repeated children
+ *                             (will overwrite the Y coordinate in the `interval` vector).
+ * @param Number [intervalZ] - The Z interval between each repeated children
+ *                             (will overwrite the Z coordinate in the `interval` vector).
  */
 module distribute(interval = [0, 0, 0],
-                  x, y, z) {
+                  intervalX, intervalY, intervalZ) {
 
-    interval = apply3D(interval, x, y, z);
+    interval = apply3D(interval, intervalX, intervalY, intervalZ);
 
     for (i = [0 : $children - 1]) {
         translate(interval * i) {

--- a/operator/repeat/mirror.scad
+++ b/operator/repeat/mirror.scad
@@ -39,12 +39,12 @@
  * @param Number [count] - The number of times the children must be repeated.
  * @param Vector [interval] - The interval between each repeated children.
  * @param Vector [axis] - The normal vector of the mirroring plan around which mirror the children.
- * @param Number [x] - The X interval between each repeated children
- *                     (will overwrite the X coordinate in the `interval` vector).
- * @param Number [y] - The Y interval between each repeated children
- *                     (will overwrite the Y coordinate in the `interval` vector).
- * @param Number [z] - The Z interval between each repeated children
- *                     (will overwrite the Z coordinate in the `interval` vector).
+ * @param Number [intervalX] - The X interval between each repeated children
+ *                             (will overwrite the X coordinate in the `interval` vector).
+ * @param Number [intervalY] - The Y interval between each repeated children
+ *                             (will overwrite the Y coordinate in the `interval` vector).
+ * @param Number [intervalZ] - The Z interval between each repeated children
+ *                             (will overwrite the Z coordinate in the `interval` vector).
  * @param Number [axisX] - The X-coordinate of the normal vector of the mirroring plan around which mirror the children
  *                         (will overwrite the X coordinate in the `axis` vector).
  * @param Number [axisY] - The Y-coordinate of the normal vector of the mirroring plan around which mirror the children
@@ -55,10 +55,10 @@
 module repeatMirror(count    = 2,
                     interval = [0, 0, 0],
                     axis     = [1, 0, 0],
-                    x, y, z,
+                    intervalX, intervalY, intervalZ,
                     axisX, axisY, axisZ) {
 
-    interval = apply3D(interval, x, y, z);
+    interval = apply3D(interval, intervalX, intervalY, intervalZ);
     axis = apply3D(axis, axisX, axisY, axisZ);
 
     for (i = [0 : count - 1]) {

--- a/operator/repeat/rotate.scad
+++ b/operator/repeat/rotate.scad
@@ -40,12 +40,12 @@
  * @param Vector [axis] - The rotation axis around which rotate the children.
  * @param Vector [interval] - The interval between each repeated children.
  * @param Vector [origin] - The rotate origin.
- * @param Number [x] - The X interval between each repeated children
- *                     (will overwrite the X coordinate in the `interval` vector).
- * @param Number [y] - The Y interval between each repeated children
- *                     (will overwrite the Y coordinate in the `interval` vector).
- * @param Number [z] - The Z interval between each repeated children
- *                     (will overwrite the Z coordinate in the `interval` vector).
+ * @param Number [intervalX] - The X interval between each repeated children
+ *                             (will overwrite the X coordinate in the `interval` vector).
+ * @param Number [intervalY] - The Y interval between each repeated children
+ *                             (will overwrite the Y coordinate in the `interval` vector).
+ * @param Number [intervalZ] - The Z interval between each repeated children
+ *                             (will overwrite the Z coordinate in the `interval` vector).
  * @param Number [axisX] - The X axis factor (will overwrite the X coordinate in the `axis` vector).
  * @param Number [axisY] - The Y axis factor (will overwrite the Y coordinate in the `axis` vector).
  * @param Number [axisZ] - The Z axis factor (will overwrite the Z coordinate in the `axis` vector).
@@ -58,11 +58,11 @@ module repeatRotate(count    = 2,
                     axis     = [0, 0, 1],
                     interval = [0, 0, 0],
                     origin   = [0, 0, 0],
-                    x, y, z,
+                    intervalX, intervalY, intervalZ,
                     axisX, axisY, axisZ,
                     originX, originY, originZ) {
 
-    interval = apply3D(interval, x, y, z);
+    interval = apply3D(interval, intervalX, intervalY, intervalZ);
     origin = apply3D(origin, originX, originY, originZ);
     angle = deg(angle);
     partAngle = angle / (angle % 360 ? count - 1 : count);

--- a/operator/repeat/translate.scad
+++ b/operator/repeat/translate.scad
@@ -37,18 +37,18 @@
  *
  * @param Number [count] - The number of times the children must be repeated.
  * @param Vector [interval] - The interval between each repeated children.
- * @param Number [x] - The X interval between each repeated children
- *                     (will overwrite the X coordinate in the `interval` vector).
- * @param Number [y] - The Y interval between each repeated children
- *                     (will overwrite the Y coordinate in the `interval` vector).
- * @param Number [z] - The Z interval between each repeated children
- *                     (will overwrite the Z coordinate in the `interval` vector).
+ * @param Number [intervalX] - The X interval between each repeated children
+ *                             (will overwrite the X coordinate in the `interval` vector).
+ * @param Number [intervalY] - The Y interval between each repeated children
+ *                             (will overwrite the Y coordinate in the `interval` vector).
+ * @param Number [intervalZ] - The Z interval between each repeated children
+ *                             (will overwrite the Z coordinate in the `interval` vector).
  */
 module repeat(count    = 2,
               interval = [0, 0, 0],
-              x, y, z) {
+              intervalX, intervalY, intervalZ) {
 
-    interval = apply3D(interval, x, y, z);
+    interval = apply3D(interval, intervalX, intervalY, intervalZ);
 
     for (i = [0 : count - 1]) {
         translate(interval * i) {

--- a/shape/context/build-box.scad
+++ b/shape/context/build-box.scad
@@ -64,7 +64,7 @@ function sizeBuildPlate(size, cell, l, w, cl, cw) =
 ;
 
 /**
- * Creates a build plate vizualization at the origin.
+ * Creates a build plate visualization at the origin.
  *
  * @param Number|Vector [size] - The size of the build plate.
  * @param Number|Vector [cell] - The size of each cell on the build plate.
@@ -103,7 +103,7 @@ module buildPlate(size=DEFAULT_BUILD_PLATE_SIZE, cell=DEFAULT_BUILD_PLATE_CELL, 
 }
 
 /**
- * Creates a build volume vizualization at the origin.
+ * Creates a build volume visualization at the origin.
  *
  * @param Number|Vector [size] - The size of the build box.
  * @param Number|Vector [cell] - The size of each cell on the build plate.
@@ -120,8 +120,8 @@ module buildVolume(size=DEFAULT_BUILD_VOLUME_SIZE, l, w, h) {
 }
 
 /**
- * Creates a build box vizualization at the origin.
- * A build box contains vizualizations for a build plate and a build volume.
+ * Creates a build box visualization at the origin.
+ * A build box contains visualizations for a build plate and a build volume.
  * It also applies a render mode.
  * @param String [mode] - The mode to apply on the children modules.
  * @param Number|Vector [size] - The size of the build volume.

--- a/shape/context/build-box.scad
+++ b/shape/context/build-box.scad
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2017 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Build box visualization.
+ *
+ * @package shape/context
+ * @author jsconan
+ */
+
+/**
+ * Computes the size of the build plate.
+ *
+ * @param Number|Vector [size] - The size of the build plate.
+ * @param Number|Vector [cell] - The size of each cell on the build plate.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [cl] - The length of a cell.
+ * @param Number [cw] - The width of cell.
+ * @returns Vector - Returns the size vector.
+ */
+function sizeBuildPlate(size, cell, l, w, cl, cw) =
+    let(
+        size = apply2D(uor(size, DEFAULT_BUILD_PLATE_SIZE), l, w),
+        cell = apply2D(uor(cell, DEFAULT_BUILD_PLATE_CELL), cl, cw),
+        nb = [
+            cell[0] ? floor(size[0] / cell[0]) : 0,
+            cell[1] ? floor(size[1] / cell[1]) : 0
+        ],
+        count = [
+            nb[0] + 1,
+            nb[1] + 1
+        ],
+        offset = [
+            cell[0] ? -nb[0] * cell[0] / 2 : 0,
+            cell[1] ? -nb[1] * cell[1] / 2 : 0
+        ]
+    )
+    [ size, cell, count, offset ]
+;
+
+/**
+ * Creates a build plate vizualization at the origin.
+ *
+ * @param Number|Vector [size] - The size of the build plate.
+ * @param Number|Vector [cell] - The size of each cell on the build plate.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [cl] - The length of a cell.
+ * @param Number [cw] - The width of cell.
+ */
+module buildPlate(size=DEFAULT_BUILD_PLATE_SIZE, cell=DEFAULT_BUILD_PLATE_CELL, l, w, cl, cw) {
+    size = sizeBuildPlate(size=size, cell=cell, l=l, w=w, cl=cl, cw=cw);
+    plateSize = size[0];
+    cellSize = size[1];
+    cellCount = size[2];
+    cellOffset = size[3];
+
+    plateHeight = 1;
+    lineWidth = .5;
+
+    %color([1, 1, 1, .2]) {
+        negativeExtrude(height=-plateHeight, direction=0) {
+            rectangle(plateSize);
+        }
+        negativeExtrude(height=-plateHeight, direction=2) {
+            translateX(cellOffset[0]) {
+                repeat(count=cellCount[0], intervalX=cellSize[0]) {
+                    rectangle([lineWidth, plateSize[1]]);
+                }
+            }
+            translateY(cellOffset[1]) {
+                repeat(count=cellCount[1], intervalY=cellSize[1]) {
+                    rectangle([plateSize[0], lineWidth]);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Creates a build volume vizualization at the origin.
+ *
+ * @param Number|Vector [size] - The size of the build box.
+ * @param Number|Vector [cell] - The size of each cell on the build plate.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [h] - The overall height.
+ * @param Number [cl] - The length of a cell.
+ * @param Number [cw] - The width of cell.
+ */
+module buildVolume(size=DEFAULT_BUILD_VOLUME_SIZE, l, w, h) {
+    %color([1, 1, 1, .1]) {
+        box(size=size, l=l, w=w, h=w);
+    }
+}
+
+/**
+ * Creates a build box vizualization at the origin.
+ * A build box contains vizualizations for a build plate and a build volume.
+ * It also applies a render mode.
+ * @param String [mode] - The mode to apply on the children modules.
+ * @param Number|Vector [size] - The size of the build volume.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [h] - The overall height.
+ */
+module buildBox(size, cell, mode, l, w, h, cl, cw) {
+    size = apply3D(uor(size, DEFAULT_BUILD_PLATE_SIZE), l, w, h);
+
+    buildPlate(size=size, cell=cell, l=l, w=w, cl=cl, cw=cw);
+    buildVolume(size=size, l=l, w=w, h=h);
+
+    applyMode(mode) {
+        children();
+    }
+}

--- a/shapes.scad
+++ b/shapes.scad
@@ -43,3 +43,5 @@ include <shape/2D/polygon.scad>
 include <shape/3D/ellipsoid.scad>
 include <shape/3D/rounded.scad>
 include <shape/3D/polyhedron.scad>
+
+include <shape/context/build-box.scad>

--- a/test/shape/context/build-box.scad
+++ b/test/shape/context/build-box.scad
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2017 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * coarchs of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * coarchs or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+use <../../../full.scad>
+include <../../../core/constants.scad>
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Unit tests: Build box visualization.
+ *
+ * @package test/shape/context
+ * @author jsconan
+ */
+module testShapeContextBuildBox() {
+    testPackage("shape/context/build-box.scad", 1) {
+        // test shape/context/build-box/sizeBuildPlate()
+        testModule("sizeBuildPlate()", 2) {
+            defaultSize = [DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE];
+            defaultCell = [DEFAULT_BUILD_PLATE_CELL, DEFAULT_BUILD_PLATE_CELL];
+            defaultCount = [floor(DEFAULT_BUILD_PLATE_SIZE / DEFAULT_BUILD_PLATE_CELL) + 1, floor(DEFAULT_BUILD_PLATE_SIZE / DEFAULT_BUILD_PLATE_CELL) + 1];
+            defaultOffset = -[floor(DEFAULT_BUILD_PLATE_SIZE / DEFAULT_BUILD_PLATE_CELL) * DEFAULT_BUILD_PLATE_CELL, floor(DEFAULT_BUILD_PLATE_SIZE / DEFAULT_BUILD_PLATE_CELL) * DEFAULT_BUILD_PLATE_CELL] / 2;
+
+            testUnit("default values", 3) {
+                assertEqual(sizeBuildPlate(), [defaultSize, defaultCell, defaultCount, defaultOffset], "Should always return a size even if not parameter has been provided");
+                assertEqual(sizeBuildPlate("12", "12", "12", "12", "12", "12"), [[0, 0], [0, 0], [1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (string)");
+                assertEqual(sizeBuildPlate(true, true, true, true, true, true), [[0, 0], [0, 0], [1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (boolean)");
+            }
+            testUnit("compute size", 15) {
+                assertEqual(sizeBuildPlate(100), [[100, 100], defaultCell, [11, 11], [-50, -50]], "Should extend the size of the plate to a vector, and use the default cell size");
+                assertEqual(sizeBuildPlate(100, 5), [[100, 100], [5, 5], [21, 21], [-50, -50]], "Should extend the size of the plate and the cell to vectors");
+
+                assertEqual(sizeBuildPlate(100, l=200), [[200, 100], defaultCell, [21, 11], [-100, -50]], "Should extend the size of the plate to a vector, replace the length, and use the default cell size");
+                assertEqual(sizeBuildPlate(100, w=200), [[100, 200], defaultCell, [11, 21], [-50, -100]], "Should extend the size of the plate to a vector, replace the width, and use the default cell size");
+
+                assertEqual(sizeBuildPlate(100, 5, cl=10), [[100, 100], [10, 5], [11, 21], [-50, -50]], "Should extend the size of the plate and the cell to vectors, and replpace the cell length");
+                assertEqual(sizeBuildPlate(100, 5, cw=10), [[100, 100], [5, 10], [21, 11], [-50, -50]], "Should extend the size of the plate and the cell to vectors, and replpace the cell width");
+
+                assertEqual(sizeBuildPlate([200, 100]), [[200, 100], defaultCell, [21, 11], [-100, -50]], "Should use the size of the plate as a vector, and use the default cell size");
+                assertEqual(sizeBuildPlate([200, 100], [20, 10]), [[200, 100], [20, 10], [11, 11], [-100, -50]], "Should use the size of the plate and the cell as vectors");
+
+                assertEqual(sizeBuildPlate([200, 100], l=100), [[100, 100], defaultCell, [11, 11], [-50, -50]], "Should use the size of the plate as a vector, and use the default cell size, and replace the length");
+                assertEqual(sizeBuildPlate([100, 200], w=100), [[100, 100], defaultCell, [11, 11], [-50, -50]], "Should use the size of the plate as a vector, and use the default cell size, and replace the width");
+
+                assertEqual(sizeBuildPlate([200, 100], [20, 10], cl=10), [[200, 100], [10, 10], [21, 11], [-100, -50]], "Should use the size of the plate and the cell as vectors, and replade the cell length");
+                assertEqual(sizeBuildPlate([200, 100], [10, 20], cw=10), [[200, 100], [10, 10], [21, 11], [-100, -50]], "Should use the size of the plate and the cell as vectors, and replade the cell width");
+
+                assertEqual(sizeBuildPlate(l=200, w=100), [[200, 100], defaultCell, [21, 11], [-100, -50]], "Should accept the size as components, and use the default cell size");
+                assertEqual(sizeBuildPlate(cl=20, cw=10), [defaultSize, [20, 10], [11, 21], [-100, -100]], "Should accept the cell as components, and use the default size");
+                assertEqual(sizeBuildPlate(l=200, w=100, cl=20, cw=10), [[200, 100], [20, 10], [11, 11], [-100, -50]], "Should accept the size of the plate and the cell as components");
+            }
+        }
+    }
+}
+
+testShapeContextBuildBox();

--- a/test/suite.scad
+++ b/test/suite.scad
@@ -57,6 +57,8 @@ use <shape/3D/ellipsoid.scad>
 use <shape/3D/rounded.scad>
 use <shape/3D/polyhedron.scad>
 
+use <shape/context/build-box.scad>
+
 testCoreVersion();
 testCoreType();
 testCoreLogic();
@@ -81,3 +83,5 @@ testShape2dPolygon();
 testShape3dEllipsoid();
 testShape3dRounded();
 testShape3dPolyhedron();
+
+testShapeContextBuildBox();


### PR DESCRIPTION
New shapes, intended to help visualizing the build box:

- `buildPlate(size, cell, l, w, cl, cw)`: Creates a build plate visualization at the origin.
- `buildVolume(size, l, w, h)`: Creates a build volume visualization at the origin.

New operator, intended to set the render mode and to visualize the build box: `buildBox(size, cell, mode, l, w, h, cl, cw)`.

New constants that represent the render modes.
Also fixed parameters in the array operators, with better consistency in naming.