### PR TITLE
Feature/hex grid

### DIFF
--- a/core.scad
+++ b/core.scad
@@ -38,6 +38,7 @@ include <core/type.scad>
 include <core/logic.scad>
 include <core/list.scad>
 include <core/maths.scad>
+include <core/hex.scad>
 include <core/line.scad>
 include <core/vector.scad>
 include <core/vector-2d.scad>

--- a/core/constants.scad
+++ b/core/constants.scad
@@ -63,6 +63,12 @@ DEFAULT_MODE = MODE_DEV;
 DEGREES = 360;
 
 /**
+ * Useful value for computations based on hexagons.
+ * @type Number
+ */
+SQRT3 = sqrt(3);
+
+/**
  * Minimum value for $fa and $fs.
  * @type Number
  */

--- a/core/hex.scad
+++ b/core/hex.scad
@@ -1,0 +1,237 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2017 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operations on hex grids.
+ *
+ * @package core/hex
+ * @author jsconan
+ */
+
+/**
+ * Computes the logical coordinates of cells placed on a radial hex grid.
+ * A hex grid is built from several hexagons put aside and has the shape of a bigger hexagon.
+ * The number of ranges will define the size of the grid.
+ * The number of hexagons will be `1 + 3 * range * (range + 1)`.
+ *
+ * @param Number n - The number of ranges to compute.
+ * @returns Vector[] - Will return an array of 2D coordinates
+ */
+function radialHexGrid(n) =
+    let(
+        n = abs(float(n))
+    )
+    [
+        for(x = [-n : n])
+            for(y = [max(-n, -x - n) : min(n, -x + n)])
+                [x, -x - y]
+    ]
+;
+
+/**
+ * Computes the physical coordinates of a cell in a radial hex grid based on its logical coordinates.
+ *
+ * @param Vector|Number hex - The logical coordinates in the hex grid
+ * @param Vector|Number [size] - The size of a cell in the hex grid
+ * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
+ * @param Number [x] - The logical X-coordinate in the hex grid
+ * @param Number [y] - The logical Y-coordinate in the hex grid
+ * @param Number [l] - The length of a cell in the hex grid
+ * @param Number [w] - The width of a cell in the hex grid
+ * @returns Vector - Physical coordinates
+ */
+function radialHexCoord(hex, size, pointy, x, y, l, w) =
+    let(
+        hex = apply2D(hex, x, y),
+        size = divisor2D(apply2D(size, l, w))
+    )
+    pointy
+   ?[
+        size[0] * SQRT3 * (hex[0] + hex[1] / 2),
+        size[1] * hex[1] * 1.5
+    ]
+   :[
+        size[0] * hex[0] * 1.5,
+        size[1] * SQRT3 * (hex[1] + hex[0] / 2)
+    ]
+;
+
+/**
+ * Computes the physical coordinates of a cell in a linear hex grid based on its logical coordinates.
+ *
+ * @param Vector|Number hex - The logical coordinates in the hex grid
+ * @param Vector|Number [size] - The size of a cell in the hex grid
+ * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
+ * @param Boolean [even] - Tells if the first hexagons should be below the line (default: false).
+ * @param Number [x] - The logical X-coordinate in the hex grid
+ * @param Number [y] - The logical Y-coordinate in the hex grid
+ * @param Number [l] - The length of a cell in the hex grid
+ * @param Number [w] - The width of a cell in the hex grid
+ * @returns Vector - Physical coordinates
+ */
+function linearHexCoord(hex, size, even, pointy, x, y, l, w) =
+    let(
+        hex = apply2D(hex, x, y),
+        size = divisor2D(apply2D(size, l, w)),
+        offset = even ? -0.5 : 0.5
+    )
+    pointy
+   ?[
+        size[0] * SQRT3 * (hex[0] + offset * (hex[1] % 2)),
+        size[1] * hex[1] * 1.5
+    ]
+   :[
+        size[0] * hex[0] * 1.5,
+        size[1] * SQRT3 * (hex[1] + offset * (hex[0] % 2))
+    ]
+;
+
+/**
+ * Computes the size of a hex grid based on the size of one cell and the number of cells.
+ *
+ * @param Vector|Number [size] - The size of a cell in the hex grid
+ * @param Vector|Number [count] - The number of cells in the hex grid
+ * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
+ * @param Boolean [linear] - Tells if grid is linear instead of radial (default: false).
+ * @param Number [l] - The length of a cell in the hex grid
+ * @param Number [w] - The width of a cell in the hex grid
+ * @param Number [cx] - The number of cells per lines
+ * @param Number [cy] - The number of cells per columns
+ * @returns Vector - The size of the overall hex grid
+ */
+function sizeHexGrid(size, count, pointy, linear, l, w, cx, cy) =
+    let(
+        size = apply2D(size, l, w),
+        count = divisor2D(apply2D(count, cx, cy)),
+        linear = linear ? .5 : 0
+    )
+    pointy
+   ?[
+        size[0] * SQRT3 * (count[0] + linear) / 2,
+        size[1] * (4 + 3 * (count[1] - 1)) / 4,
+    ]
+   :[
+        size[0] * (4 + 3 * (count[0] - 1)) / 4,
+        size[1] * SQRT3 * (count[1] + linear) / 2
+    ]
+;
+
+/**
+ * Computes the size of a cell in a hex grid based on the size of the grid and the number of cells.
+ *
+ * @param Vector|Number [size] - The size of the hex grid
+ * @param Vector|Number [count] - The number of cells in the hex grid
+ * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
+ * @param Boolean [linear] - Tells if grid is linear instead of radial (default: false).
+ * @param Number [l] - The length of the hex grid
+ * @param Number [w] - The width of the hex grid
+ * @param Number [cx] - The number of cells per lines
+ * @param Number [cy] - The number of cells per columns
+ * @returns Vector - The size of the overall hex grid
+ */
+function sizeHexCell(size, count, pointy, linear, l, w, cx, cy) =
+    let(
+        size = apply2D(size, l, w),
+        count = divisor2D(apply2D(count, cx, cy)),
+        linear = linear ? .5 : 0
+    )
+    pointy
+   ?[
+        size[0] * 2 / (count[0] + linear) / SQRT3,
+        size[1] * 4 / (4 + 3 * (count[1] - 1))
+    ]
+   :[
+        size[0] * 4 / (4 + 3 * (count[0] - 1)),
+        size[1] * 2 / (count[1] + linear) / SQRT3
+    ]
+;
+
+/**
+ * Computes the number of a cells in a hex grid that fits the provided size.
+ *
+ * @param Vector|Number [size] - The size of the hex grid
+ * @param Vector|Number [cell] - The size of a cell in the hex grid
+ * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
+ * @param Boolean [linear] - Tells if grid is linear instead of radial (default: false).
+ * @param Number [l] - The length of the hex grid
+ * @param Number [w] - The width of the hex grid
+ * @param Number [cl] - The length of a cell
+ * @param Number [cw] - The width of a cell
+ * @returns Vector|Number - The number of cells in the linear hex grid or
+ *                          the number of ranges in the radial hex grid.
+ */
+function countHexCell(size, cell, pointy, linear, l, w, cl, cw) =
+    let(
+        size = divisor2D(apply2D(size, l, w)),
+        cell = divisor2D(apply2D(cell, cl, cw)),
+        linear = linear ? .5 : 0,
+        count = pointy
+       ?[
+            floor(size[0] * 2 / cell[0] / SQRT3 - linear),
+            floor((size[1] * 4 / cell[1] - 1) / 3)
+        ]
+       :[
+            floor((size[0] * 4 / cell[0] - 1) / 3),
+            floor(size[1] * 2 / cell[1] / SQRT3 - linear)
+        ]
+    )
+    linear ? count : floor((min(count) - 1) / 2)
+;
+
+/**
+ * Computes the offset of a hex grid in order to center it.
+ *
+ * @param Vector|Number [size] - The size of a cell in the hex grid
+ * @param Vector|Number [count] - The number of cells in the hex grid
+ * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
+ * @param Boolean [linear] - Tells if grid is linear instead of radial (default: false).
+ * @param Boolean [even] - Tells if the first hexagons of a the linear grid should be below the line (default: false).
+ * @param Number [l] - The length of a cell in the hex grid
+ * @param Number [w] - The width of a cell in the hex grid
+ * @param Number [cx] - The number of cells per lines
+ * @param Number [cy] - The number of cells per columns
+ * @returns Vector - The size of the overall hex grid
+ */
+function offsetHexGrid(size, count, pointy, linear, even, l, w, cx, cy) =
+    !linear
+   ?[0, 0]
+   :let(
+       size = apply2D(size, l, w),
+       count = divisor2D(apply2D(count, cx, cy)),
+       even = even ? 2 : 1,
+       linear = linear ? .5 : 0
+    )
+    pointy
+   ?[
+        size[0] * SQRT3 * ((even - (count[0] + linear))) / 4,
+        -size[1] * (count[1] - 1) * 3 / 8,
+    ]
+   :[
+        -size[0] * (count[0] - 1) * 3 / 8,
+        size[1] * SQRT3 * ((even - (count[1] + linear))) / 4,
+    ]
+;

--- a/core/hex.scad
+++ b/core/hex.scad
@@ -179,7 +179,7 @@ function sizeHexCell(size, count, pointy, linear, l, w, cx, cy) =
 ;
 
 /**
- * Computes the number of a cells in a hex grid that fits the provided size.
+ * Computes the number of cells in a hex grid that fits the provided size.
  *
  * @param Vector|Number [size] - The size of the hex grid.
  * @param Vector|Number [cell] - The size of a cell in the hex grid.
@@ -209,17 +209,17 @@ function countHexCell(size, cell, pointy, linear, l, w, cl, cw) =
 ;
 
 /**
- * Computes the physical coordinates of a cell in a radial hex grid based on its logical coordinates.
+ * Computes the physical coordinates of a cell in a hex grid based on its logical coordinates.
  *
  * @param Vector|Number hex - The logical coordinates in the hex grid.
- * @param Vector|Number [size] - The size of a cell in the hex grid.
+ * @param Vector|Number [size] - The size the cell.
  * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
  * @param Boolean [linear] - Tells if the grid is linear instead of radial (default: false).
  * @param Boolean [even] - Tells if the first hexagons should be below the line (default: false).
  * @param Number [x] - The logical X-coordinate in the hex grid.
  * @param Number [y] - The logical Y-coordinate in the hex grid.
- * @param Number [l] - The length of a cell in the hex grid.
- * @param Number [w] - The width of a cell in the hex grid.
+ * @param Number [l] - The length of the cell.
+ * @param Number [w] - The width of the cell.
  * @returns Vector - Physical coordinates.
  */
 function coordHexCell(hex, size, pointy, linear, even, x, y, l, w) =

--- a/core/hex.scad
+++ b/core/hex.scad
@@ -35,15 +35,16 @@
 /**
  * Computes the logical coordinates of cells placed on a radial hex grid.
  * A hex grid is built from several hexagons put aside and has the shape of a bigger hexagon.
+ * If the count contains 2 dimensions, the lower value will be used to define the radial range.
  * The number of ranges will define the size of the grid.
  * The number of hexagons will be `1 + 3 * range * (range + 1)`.
  *
- * @param Number n - The number of ranges to compute.
- * @returns Vector[] - Will return an array of 2D coordinates
+ * @param Vector|Number count - The number of cells in the hex grid.
+ * @returns Vector[] - Will return an array of 2D coordinates.
  */
-function radialHexGrid(n) =
+function radialHexGrid(count) =
     let(
-        n = abs(float(n))
+        n = radialHexRange(count)
     )
     [
         for(x = [-n : n])
@@ -53,16 +54,32 @@ function radialHexGrid(n) =
 ;
 
 /**
+ * Computes the number of ranges in a radial hex grid based on the number of cells.
+ *
+ * @param Vector|Number count - The number of cells.
+ * @returns Number - The number of ranges.
+ */
+function radialHexRange(count) = floor((abs(divisor(min(count))) - 1) / 2);
+
+/**
+ * Computes the number of cells in a radial hex grid based on the number of ranges.
+ *
+ * @param Number range - The number of ranges.
+ * @returns Vector - The number of cells.
+ */
+function radialHexCount(range) = vector2D(float(range) * 2 + 1);
+
+/**
  * Computes the physical coordinates of a cell in a radial hex grid based on its logical coordinates.
  *
- * @param Vector|Number hex - The logical coordinates in the hex grid
- * @param Vector|Number [size] - The size of a cell in the hex grid
+ * @param Vector|Number hex - The logical coordinates in the hex grid.
+ * @param Vector|Number [size] - The size of a cell in the hex grid.
  * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
- * @param Number [x] - The logical X-coordinate in the hex grid
- * @param Number [y] - The logical Y-coordinate in the hex grid
- * @param Number [l] - The length of a cell in the hex grid
- * @param Number [w] - The width of a cell in the hex grid
- * @returns Vector - Physical coordinates
+ * @param Number [x] - The logical X-coordinate in the hex grid.
+ * @param Number [y] - The logical Y-coordinate in the hex grid.
+ * @param Number [l] - The length of a cell in the hex grid.
+ * @param Number [w] - The width of a cell in the hex grid.
+ * @returns Vector - Physical coordinates.
  */
 function radialHexCoord(hex, size, pointy, x, y, l, w) =
     let(
@@ -83,15 +100,15 @@ function radialHexCoord(hex, size, pointy, x, y, l, w) =
 /**
  * Computes the physical coordinates of a cell in a linear hex grid based on its logical coordinates.
  *
- * @param Vector|Number hex - The logical coordinates in the hex grid
- * @param Vector|Number [size] - The size of a cell in the hex grid
+ * @param Vector|Number hex - The logical coordinates in the hex grid.
+ * @param Vector|Number [size] - The size of a cell in the hex grid.
  * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
  * @param Boolean [even] - Tells if the first hexagons should be below the line (default: false).
- * @param Number [x] - The logical X-coordinate in the hex grid
- * @param Number [y] - The logical Y-coordinate in the hex grid
- * @param Number [l] - The length of a cell in the hex grid
- * @param Number [w] - The width of a cell in the hex grid
- * @returns Vector - Physical coordinates
+ * @param Number [x] - The logical X-coordinate in the hex grid.
+ * @param Number [y] - The logical Y-coordinate in the hex grid.
+ * @param Number [l] - The length of a cell in the hex grid.
+ * @param Number [w] - The width of a cell in the hex grid.
+ * @returns Vector - Physical coordinates.
  */
 function linearHexCoord(hex, size, even, pointy, x, y, l, w) =
     let(
@@ -113,15 +130,15 @@ function linearHexCoord(hex, size, even, pointy, x, y, l, w) =
 /**
  * Computes the size of a hex grid based on the size of one cell and the number of cells.
  *
- * @param Vector|Number [size] - The size of a cell in the hex grid
- * @param Vector|Number [count] - The number of cells in the hex grid
+ * @param Vector|Number [size] - The size of a cell in the hex grid.
+ * @param Vector|Number [count] - The number of cells in the hex grid.
  * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
  * @param Boolean [linear] - Tells if grid is linear instead of radial (default: false).
- * @param Number [l] - The length of a cell in the hex grid
- * @param Number [w] - The width of a cell in the hex grid
- * @param Number [cx] - The number of cells per lines
- * @param Number [cy] - The number of cells per columns
- * @returns Vector - The size of the overall hex grid
+ * @param Number [l] - The length of a cell in the hex grid.
+ * @param Number [w] - The width of a cell in the hex grid.
+ * @param Number [cx] - The number of cells per lines.
+ * @param Number [cy] - The number of cells per columns.
+ * @returns Vector - The size of the overall hex grid.
  */
 function sizeHexGrid(size, count, pointy, linear, l, w, cx, cy) =
     let(
@@ -143,15 +160,15 @@ function sizeHexGrid(size, count, pointy, linear, l, w, cx, cy) =
 /**
  * Computes the size of a cell in a hex grid based on the size of the grid and the number of cells.
  *
- * @param Vector|Number [size] - The size of the hex grid
- * @param Vector|Number [count] - The number of cells in the hex grid
+ * @param Vector|Number [size] - The size of the hex grid.
+ * @param Vector|Number [count] - The number of cells in the hex grid.
  * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
  * @param Boolean [linear] - Tells if grid is linear instead of radial (default: false).
- * @param Number [l] - The length of the hex grid
- * @param Number [w] - The width of the hex grid
- * @param Number [cx] - The number of cells per lines
- * @param Number [cy] - The number of cells per columns
- * @returns Vector - The size of the overall hex grid
+ * @param Number [l] - The length of the hex grid.
+ * @param Number [w] - The width of the hex grid.
+ * @param Number [cx] - The number of cells per lines.
+ * @param Number [cy] - The number of cells per columns.
+ * @returns Vector - The size of the overall hex grid.
  */
 function sizeHexCell(size, count, pointy, linear, l, w, cx, cy) =
     let(
@@ -173,48 +190,46 @@ function sizeHexCell(size, count, pointy, linear, l, w, cx, cy) =
 /**
  * Computes the number of a cells in a hex grid that fits the provided size.
  *
- * @param Vector|Number [size] - The size of the hex grid
- * @param Vector|Number [cell] - The size of a cell in the hex grid
+ * @param Vector|Number [size] - The size of the hex grid.
+ * @param Vector|Number [cell] - The size of a cell in the hex grid.
  * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
  * @param Boolean [linear] - Tells if grid is linear instead of radial (default: false).
- * @param Number [l] - The length of the hex grid
- * @param Number [w] - The width of the hex grid
- * @param Number [cl] - The length of a cell
- * @param Number [cw] - The width of a cell
- * @returns Vector|Number - The number of cells in the linear hex grid or
- *                          the number of ranges in the radial hex grid.
+ * @param Number [l] - The length of the hex grid.
+ * @param Number [w] - The width of the hex grid.
+ * @param Number [cl] - The length of a cell.
+ * @param Number [cw] - The width of a cell.
+ * @returns Vector - The number of cells in the hex grid.
  */
 function countHexCell(size, cell, pointy, linear, l, w, cl, cw) =
     let(
         size = divisor2D(apply2D(size, l, w)),
         cell = divisor2D(apply2D(cell, cl, cw)),
-        linear = linear ? .5 : 0,
-        count = pointy
-       ?[
-            floor(size[0] * 2 / cell[0] / SQRT3 - linear),
-            floor((size[1] * 4 / cell[1] - 1) / 3)
-        ]
-       :[
-            floor((size[0] * 4 / cell[0] - 1) / 3),
-            floor(size[1] * 2 / cell[1] / SQRT3 - linear)
-        ]
+        linear = linear ? .5 : 0
     )
-    linear ? count : floor((min(count) - 1) / 2)
+    pointy
+   ?[
+        floor(size[0] * 2 / cell[0] / SQRT3 - linear),
+        floor((size[1] * 4 / cell[1] - 1) / 3)
+    ]
+   :[
+        floor((size[0] * 4 / cell[0] - 1) / 3),
+        floor(size[1] * 2 / cell[1] / SQRT3 - linear)
+    ]
 ;
 
 /**
  * Computes the offset of a hex grid in order to center it.
  *
- * @param Vector|Number [size] - The size of a cell in the hex grid
- * @param Vector|Number [count] - The number of cells in the hex grid
+ * @param Vector|Number [size] - The size of a cell in the hex grid.
+ * @param Vector|Number [count] - The number of cells in the hex grid.
  * @param Boolean [pointy] - Tells if the hexagons in the grid are pointy topped (default: false, Flat topped).
  * @param Boolean [linear] - Tells if grid is linear instead of radial (default: false).
  * @param Boolean [even] - Tells if the first hexagons of a the linear grid should be below the line (default: false).
- * @param Number [l] - The length of a cell in the hex grid
- * @param Number [w] - The width of a cell in the hex grid
- * @param Number [cx] - The number of cells per lines
- * @param Number [cy] - The number of cells per columns
- * @returns Vector - The size of the overall hex grid
+ * @param Number [l] - The length of a cell in the hex grid.
+ * @param Number [w] - The width of a cell in the hex grid.
+ * @param Number [cx] - The number of cells per lines.
+ * @param Number [cy] - The number of cells per columns.
+ * @returns Vector - The size of the overall hex grid.
  */
 function offsetHexGrid(size, count, pointy, linear, even, l, w, cx, cy) =
     !linear

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -181,17 +181,18 @@ module regularPolygonBox(size, n, l, w, h, s, center) {
  * Creates an hexagon at the origin.
  *
  * @param Number|Vector [size] - The size of the hexagon.
- * @param Number [adjust] - An adjust length added on the horizontal side
+ * @param Boolean [pointy] - Tells if the hexagon must be pointy topped (default: false, Flat topped).
+ * @param Number [adjust] - An adjust length added on the horizontal side.
  * @param Number [l] - The overall length.
  * @param Number [w] - The overall width.
  * @param Number [h] - The overall height.
  * @param Number [s] - The length of a side.
  * @param Boolean [center] - Whether or not center the box on the vertical axis.
  */
-module hexagonBox(size, adjust, l, w, h, s, center) {
+module hexagonBox(size, pointy, adjust, l, w, h, s, center) {
     size = sizeRegularPolygonBox(size=size, n=6, l=l, w=w, h=h, s=s);
     linear_extrude(height=size[2], center=center, convexity=10) {
-        hexagon(size, adjust);
+        hexagon(size=size, pointy=pointy, adjust=adjust);
     }
 }
 

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -215,3 +215,28 @@ module starBox(size, core, edges, l, w, h, cl, cw, center) {
         star(size[0], size[1], size[2]);
     }
 }
+
+/**
+ * Creates a mesh with honeycomb cells using a hex grid pattern.
+ *
+ * @param Number|Vector [size] - The outer size of the mesh.
+ * @param Number|Vector [count] - The number of cells on each lines and each columns.
+ * @param Number|Vector [gap] - The space between two cells.
+ * @param Boolean [pointy] - Tells if the hexagons in the mesh are pointy topped (default: false, Flat topped).
+ * @param Boolean [linear] - Tells if the hex grid is linear instead of radial (default: false).
+ * @param Boolean [even] - Tells if the first hexagons of a the linear grid should be below the line (default: false).
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [h] - The overall height.
+ * @param Number [cx] - The number of cells per lines.
+ * @param Number [cy] - The number of cells per columns.
+ * @param Number [gx] - The space between two cells on each lines.
+ * @param Number [gy] - The space between two cells on each columns.
+ * @param Boolean [center] - Whether or not center the box on the vertical axis.
+ */
+module meshBox(size, count, gap, pointy, linear, even, l, w, h, cx, cy, gx, gy, center) {
+    size = apply3D(size, l, w, h);
+    linear_extrude(height=size[2], center=center, convexity=10) {
+        mesh(size=size, count=count, gap=gap, pointy=pointy, linear=linear, even=even, cx=cx, cy=cy, gx=gx, gy=gy);
+    }
+}

--- a/test/core/hex.scad
+++ b/test/core/hex.scad
@@ -1,0 +1,460 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2017 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+use <../../full.scad>
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Unit tests: Operations on hex grids.
+ *
+ * @package test/core/hex
+ * @author jsconan
+ */
+module testCoreHex() {
+    testPackage("core/hex.scad", 7) {
+        // test core/hex/radialHexGrid()
+        testModule("radialHexGrid()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(radialHexGrid(), [[0, 0]], "Without parameter the function should produce a default grid of 1 cell");
+            }
+            testUnit("wrong type", 5) {
+                assertEqual(radialHexGrid("10"), [[0, 0]], "A string should produce a default grid of 1 cell");
+                assertEqual(radialHexGrid(true), [[0, 0]], "A boolean should produce a default grid of 1 cell");
+                assertEqual(radialHexGrid([]), [[0, 0]], "An empty array should produce a default grid of 1 cell");
+                assertEqual(radialHexGrid(["1"]), [[0, 0]], "An array should produce a default grid of 1 cell");
+                assertEqual(radialHexGrid([1]), [[0, 0]], "A vector should produce a default grid of 1 cell");
+            }
+            testUnit("number", 4) {
+                assertEqual(radialHexGrid(0), [[0, 0]], "A grid of range 0 is a grid with one cell");
+                assertEqual(radialHexGrid(1), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid of range 1 is a grid with 7 cells");
+                assertEqual(radialHexGrid(2), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "A grid of range 2 is a grid with 19 cells");
+                assertEqual(radialHexGrid(-1), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "Negative range should be converter to positive");
+            }
+        }
+        // test core/hex/radialHexCoord()
+        testModule("radialHexCoord()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(radialHexCoord(), [0, 0], "Without parameter the function should produce coordinates at the origin");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(radialHexCoord("10"), [0, 0], "A string should produce coordinates at the origin");
+                assertEqual(radialHexCoord(true), [0, 0], "A boolean should produce coordinates at the origin");
+                assertEqual(radialHexCoord([]), [0, 0], "An empty array should produce coordinates at the origin");
+                assertEqual(radialHexCoord(["1"]), [0, 0], "An array should produce coordinates at the origin");
+            }
+            testUnit("number", 4) {
+                assertEqual(radialHexCoord(hex=0), [0, 0], "Should return the coordinates of the origin");
+                assertEqual(radialHexCoord(hex=0, size=10), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                testUnitContext("flat topped", 3) {
+                    assertEqual(radialHexCoord(hex=1, size=10, pointy=false), [15, 15 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
+                    assertEqual(radialHexCoord(hex=-1, size=10, pointy=false), [-15, -15 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
+                    assertApproxEqual(radialHexCoord(hex=1, size=10, y=2, w=12, pointy=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                }
+                testUnitContext("pointy topped", 3) {
+                    assertEqual(radialHexCoord(hex=1, size=10, pointy=true), [15 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
+                    assertEqual(radialHexCoord(hex=-1, size=10, pointy=true), [-15 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
+                    assertEqual(radialHexCoord(hex=1, size=10, y=2, w=12, pointy=true), [20 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                }
+            }
+            testUnit("vector", 4) {
+                assertEqual(radialHexCoord(hex=[0, 0]), [0, 0], "Should return the coordinates of the origin");
+                assertEqual(radialHexCoord(hex=[0, 0], size=[10, 10]), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                testUnitContext("flat topped", 4) {
+                    assertEqual(radialHexCoord(hex=[1, 1], size=[10, 10], pointy=false), [15, 15 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
+                    assertApproxEqual(radialHexCoord(hex=[1, 2], size=[10, 12], pointy=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    assertApproxEqual(radialHexCoord(hex=[-1, -2], size=[10, 12], pointy=false), [-15, -30 * sqrt(3)], "Should return the coordinates of the cell at -1,-2");
+                    assertApproxEqual(radialHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                }
+                testUnitContext("pointy topped", 4) {
+                    assertEqual(radialHexCoord(hex=[1, 1], size=[10, 10], pointy=true), [15 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
+                    assertEqual(radialHexCoord(hex=[1, 2], size=[10, 12], pointy=true), [20 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    assertEqual(radialHexCoord(hex=[-1, -2], size=[10, 12], pointy=true), [-20 * sqrt(3), -36], "Should return the coordinates of the cell at -1,-2");
+                    assertEqual(radialHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=true), [20 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                }
+            }
+        }
+        // test core/hex/linearHexCoord()
+        testModule("linearHexCoord()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(linearHexCoord(), [0, 0], "Without parameter the function should produce coordinates at the origin");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(linearHexCoord("10"), [0, 0], "A string should produce coordinates at the origin");
+                assertEqual(linearHexCoord(true), [0, 0], "A boolean should produce coordinates at the origin");
+                assertEqual(linearHexCoord([]), [0, 0], "An empty array should produce coordinates at the origin");
+                assertEqual(linearHexCoord(["1"]), [0, 0], "An array should produce coordinates at the origin");
+            }
+            testUnit("number", 3) {
+                assertEqual(linearHexCoord(hex=0), [0, 0], "Should return the coordinates of the origin");
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("odd", 4) {
+                        assertEqual(linearHexCoord(hex=0, size=10, pointy=false, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                        assertEqual(linearHexCoord(hex=1, size=10, pointy=false, even=false), [15, 15 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
+                        assertEqual(linearHexCoord(hex=-1, size=10, pointy=false, even=false), [-15, -15 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
+                        assertApproxEqual(linearHexCoord(hex=1, size=10, y=2, w=12, pointy=false, even=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    }
+                    testUnitContext("even", 4) {
+                        assertEqual(linearHexCoord(hex=0, size=10, pointy=false, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the vertical axis");
+                        assertEqual(linearHexCoord(hex=1, size=10, pointy=false, even=true), [15, 5 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
+                        assertEqual(linearHexCoord(hex=-1, size=10, pointy=false, even=true), [-15, -5 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
+                        assertApproxEqual(linearHexCoord(hex=1, size=10, y=2, w=12, pointy=false, even=true), [15, 18 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("odd", 4) {
+                        assertEqual(linearHexCoord(hex=0, size=10, pointy=true, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                        assertEqual(linearHexCoord(hex=1, size=10, pointy=true, even=false), [15 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
+                        assertEqual(linearHexCoord(hex=-1, size=10, pointy=true, even=false), [-15 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
+                        assertEqual(linearHexCoord(hex=1, size=10, y=2, w=12, pointy=true, even=false), [10 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    }
+                    testUnitContext("even", 4) {
+                        assertEqual(linearHexCoord(hex=0, size=10, pointy=true, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the horizontal axis");
+                        assertEqual(linearHexCoord(hex=1, size=10, pointy=true, even=true), [5 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
+                        assertEqual(linearHexCoord(hex=-1, size=10, pointy=true, even=true), [-5 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
+                        assertEqual(linearHexCoord(hex=1, size=10, y=2, w=12, pointy=true, even=true), [10 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    }
+                }
+            }
+            testUnit("vector", 3) {
+                assertEqual(linearHexCoord(hex=[0, 0]), [0, 0], "Should return the coordinates of the origin");
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("odd", 4) {
+                        assertEqual(linearHexCoord(hex=[0, 0], size=[10, 10], pointy=false, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], pointy=false, even=false), [15, 15 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
+                        assertEqual(linearHexCoord(hex=[-1, -1], size=[10, 10], pointy=false, even=false), [-15, -15 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
+                        assertApproxEqual(linearHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=false, even=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    }
+                    testUnitContext("even", 4) {
+                        assertEqual(linearHexCoord(hex=[0, 0], size=[10, 10], pointy=false, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the vertical axis");
+                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], pointy=false, even=true), [15, 5 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
+                        assertEqual(linearHexCoord(hex=[-1, -1], size=[10, 10], pointy=false, even=true), [-15, -5 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
+                        assertApproxEqual(linearHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=false, even=true), [15, 18 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("odd", 4) {
+                        assertEqual(linearHexCoord(hex=[0, 0], size=[10, 10], pointy=true, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], pointy=true, even=false), [15 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
+                        assertEqual(linearHexCoord(hex=[-1, -1], size=[10, 10], pointy=true, even=false), [-15 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
+                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=true, even=false), [10 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    }
+                    testUnitContext("even", 4) {
+                        assertEqual(linearHexCoord(hex=[0, 0], size=[10, 10], pointy=true, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the horizontal axis");
+                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], pointy=true, even=true), [5 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
+                        assertEqual(linearHexCoord(hex=[-1, -1], size=[10, 10], pointy=true, even=true), [-5 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
+                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=true, even=true), [10 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    }
+                }
+            }
+        }
+        // test core/hex/sizeHexGrid()
+        testModule("sizeHexGrid()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(sizeHexGrid(), [0, 0], "Without parameter the function should produce a void size");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(sizeHexGrid("10"), [0, 0], "A string should produce a void size");
+                assertEqual(sizeHexGrid(true), [0, 0], "A boolean should produce a void size");
+                assertEqual(sizeHexGrid([]), [0, 0], "An empty array should produce a void size");
+                assertEqual(sizeHexGrid(["1"]), [0, 0], "An array should produce a void size");
+            }
+            testUnit("number", 2) {
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertEqual(sizeHexGrid(2), [2, sqrt(3)], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexGrid(2, 3), [5, sqrt(3) * 3], "Should produce a size corresponding to a grid of 3 cells");
+                        assertEqual(sizeHexGrid(2, 3, l=1, w=2, cx=3, cy=4), [2.5, sqrt(3) * 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertEqual(sizeHexGrid(2, linear=true), [2, sqrt(3) * 1.5], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexGrid(2, 3, linear=true), [5, sqrt(3) * 3.5], "Should produce a size corresponding to a grid of 3 cells");
+                        assertEqual(sizeHexGrid(2, 3, linear=true, l=1, w=2, cx=3, cy=4), [2.5, sqrt(3) * 4.5], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertEqual(sizeHexGrid(2, pointy=true), [sqrt(3), 2], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexGrid(2, 3, pointy=true), [sqrt(3) * 3, 5], "Should produce a size corresponding to a grid of 3 cells");
+                        assertEqual(sizeHexGrid(2, 3, pointy=true, l=1, w=2, cx=3, cy=4), [sqrt(3) / 2 * 3, 2 + 9 / 2], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertEqual(sizeHexGrid(2, linear=true, pointy=true), [sqrt(3) * 1.5, 2], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexGrid(2, 3, linear=true, pointy=true), [sqrt(3) * 3.5, 5], "Should produce a size corresponding to a grid of 3 cells");
+                        assertEqual(sizeHexGrid(2, 3, linear=true, pointy=true, l=1, w=2, cx=3, cy=4), [sqrt(3) / 2 * 3.5, 2 + 9 / 2], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                    }
+                }
+            }
+            testUnit("vector", 2) {
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertEqual(sizeHexGrid([2, 2]), [2, sqrt(3)], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexGrid([2, 2], [3, 3]), [5, sqrt(3) * 3], "Should produce a size corresponding to a grid of 3 cells");
+                        assertEqual(sizeHexGrid([2, 2], [3, 3], l=1, w=2, cx=3, cy=4), [2.5, sqrt(3) * 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertEqual(sizeHexGrid([2, 2], linear=true), [2, sqrt(3) * 1.5], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexGrid([2, 2], [3, 3], linear=true), [5, sqrt(3) * 3.5], "Should produce a size corresponding to a grid of 3 cells");
+                        assertEqual(sizeHexGrid([2, 2], [3, 3], linear=true, l=1, w=2, cx=3, cy=4), [2.5, sqrt(3) * 4.5], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertEqual(sizeHexGrid([2, 2], pointy=true), [sqrt(3), 2], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexGrid([2, 2], [3, 3], pointy=true), [sqrt(3) * 3, 5], "Should produce a size corresponding to a grid of 3 cells");
+                        assertEqual(sizeHexGrid([2, 2], [3, 3], pointy=true, l=1, w=2, cx=3, cy=4), [sqrt(3) / 2 * 3, 2 + 9 / 2], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertEqual(sizeHexGrid([2, 2], linear=true, pointy=true), [sqrt(3) * 1.5, 2], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexGrid([2, 2], [3, 3], linear=true, pointy=true), [sqrt(3) * 3.5, 5], "Should produce a size corresponding to a grid of 3 cells");
+                        assertEqual(sizeHexGrid([2, 2], [3, 3], linear=true, pointy=true, l=1, w=2, cx=3, cy=4), [sqrt(3) / 2 * 3.5, 2 + 9 / 2], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                    }
+                }
+            }
+        }
+        // test core/hex/sizeHexCell()
+        testModule("sizeHexCell()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(sizeHexCell(), [0, 0], "Without parameter the function should produce a void size");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(sizeHexCell("10"), [0, 0], "A string should produce a void size");
+                assertEqual(sizeHexCell(true), [0, 0], "A boolean should produce a void size");
+                assertEqual(sizeHexCell([]), [0, 0], "An empty array should produce a void size");
+                assertEqual(sizeHexCell(["1"]), [0, 0], "An array should produce a void size");
+            }
+            testUnit("number", 2) {
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertApproxEqual(sizeHexCell(10), [10, 10 / cos(30)], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexCell(10, 3), [4, 10 * 2 / 3 / sqrt(3)], "Should produce the size of a cell in a grid of 3");
+                        assertEqual(sizeHexCell(10, 3, l=10, w=20, cx=3, cy=4), [4, 20 * 2 / 4 / sqrt(3)], "Should produce the size of a cell in a grid of 3x4");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertApproxEqual(sizeHexCell(10, linear=true), [10, 20 / 1.5 / sqrt(3)], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexCell(10, 3, linear=true), [4, 20 / 3.5 / sqrt(3)], "Should produce the size of a cell in a grid of 3");
+                        assertEqual(sizeHexCell(10, 3, linear=true, l=10, w=20, cx=3, cy=4), [4, 40 / 4.5 / sqrt(3)], "Should produce the size of a cell in a grid of 3x4");
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertApproxEqual(sizeHexCell(10, pointy=true), [10 / cos(30), 10], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexCell(10, 3, pointy=true), [10 * 2 / 3 / sqrt(3), 4], "Should produce the size of a cell in a grid of 3");
+                        assertEqual(sizeHexCell(10, 3, pointy=true, l=10, w=20, cx=3, cy=4), [10 * 2 / 3 / sqrt(3), 80 / 13], "Should produce the size of a cell in a grid of 3x4");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertApproxEqual(sizeHexCell(10, linear=true, pointy=true), [20 / 1.5 / sqrt(3), 10], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexCell(10, 3, linear=true, pointy=true), [20 / 3.5 / sqrt(3), 4], "Should produce the size of a cell in a grid of 3");
+                        assertEqual(sizeHexCell(10, 3, linear=true, pointy=true, l=10, w=20, cx=3, cy=4), [20 / 3.5 / sqrt(3), 80 / 13], "Should produce the size of a cell in a grid of 3x4");
+                    }
+                }
+            }
+            testUnit("vector", 2) {
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertApproxEqual(sizeHexCell([10, 10]), [10, 10 / cos(30)], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexCell([10, 10], [3, 3]), [4, 10 * 2 / sqrt(3) / 3], "Should produce the size of a cell in a grid of 3");
+                        assertEqual(sizeHexCell([10, 10], [3, 3], l=10, w=20, cx=3, cy=4), [4, 20 * 2 / sqrt(3) / 4], "Should produce the size of a cell in a grid of 3x4");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertApproxEqual(sizeHexCell([10, 10], linear=true), [10, 20 / 1.5 / sqrt(3)], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexCell([10, 10], [3, 3], linear=true), [4, 20 / 3.5 / sqrt(3)], "Should produce the size of a cell in a grid of 3");
+                        assertEqual(sizeHexCell([10, 10], [3, 3], linear=true, l=10, w=20, cx=3, cy=4), [4, 40 / 4.5 / sqrt(3)], "Should produce the size of a cell in a grid of 3x4");
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertApproxEqual(sizeHexCell([10, 10], pointy=true), [10 / cos(30), 10], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexCell([10, 10], [3, 3], pointy=true), [10 * 2 / 3 / sqrt(3), 4], "Should produce the size of a cell in a grid of 3");
+                        assertEqual(sizeHexCell([10, 10], [3, 3], pointy=true, l=10, w=20, cx=3, cy=4), [10 * 2 / 3 / sqrt(3), 80 / 13], "Should produce the size of a cell in a grid of 3x4");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertApproxEqual(sizeHexCell([10, 10], linear=true, pointy=true), [20 / 1.5 / sqrt(3), 10], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                        assertEqual(sizeHexCell([10, 10], [3, 3], linear=true, pointy=true), [20 / 3.5 / sqrt(3), 4], "Should produce the size of a cell in a grid of 3");
+                        assertEqual(sizeHexCell([10, 10], [3, 3], linear=true, pointy=true, l=10, w=20, cx=3, cy=4), [20 / 3.5 / sqrt(3), 80 / 13], "Should produce the size of a cell in a grid of 3x4");
+                    }
+                }
+            }
+        }
+        // test core/hex/countHexCell()
+        testModule("countHexCell()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(countHexCell(), 0, "Without parameter the function should produce a grid of range 0");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(countHexCell("10"), 0, "A string should produce a grid of range 0");
+                assertEqual(countHexCell(true), 0, "A boolean should produce a grid of range 0");
+                assertEqual(countHexCell([]), 0, "An empty array should produce a grid of range 0");
+                assertEqual(countHexCell(["1"]), 0, "An array should produce a grid of range 0");
+            }
+            testUnit("number", 2) {
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertApproxEqual(countHexCell(10), 5, "Should produce a grid of range 5");
+                        assertEqual(countHexCell(10, 3), 1, "Should produce a grid of range 1");
+                        assertEqual(countHexCell(10, 3, l=10, w=20, cl=3, cw=4), 1, "Should produce a grid of range 1");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertApproxEqual(countHexCell(10, linear=true), [13, 11], "Should tell the grid is 13x11");
+                        assertEqual(countHexCell(10, 3, linear=true), [4, 3], "Should tell the grid is 4x3");
+                        assertEqual(countHexCell(10, 3, linear=true, l=10, w=20, cl=3, cw=4), [4, 5], "Should tell the grid is 4x7");
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertApproxEqual(countHexCell(10, pointy=true), 5, "Should produce a grid of range 5");
+                        assertEqual(countHexCell(10, 3, pointy=true), 1, "Should produce a grid of range 1");
+                        assertEqual(countHexCell(10, 3, pointy=true, l=10, w=20, cl=3, cw=4), 1, "Should produce a grid of range 1");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertApproxEqual(countHexCell(10, linear=true, pointy=true), [11, 13], "Should tell the grid is 11x13");
+                        assertEqual(countHexCell(10, 3, linear=true, pointy=true), [3, 4], "Should tell the grid is 3x4");
+                        assertEqual(countHexCell(10, 3, linear=true, pointy=true, l=10, w=20, cl=3, cw=4), [3, 6], "Should tell the grid is 3x8");
+                    }
+                }
+            }
+            testUnit("vector", 2) {
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertApproxEqual(countHexCell([10, 10]), 5, "Should produce a grid of range 5");
+                        assertEqual(countHexCell([10, 10], [3, 3]), 1, "Should produce a grid of range 1");
+                        assertEqual(countHexCell([10, 10], [3, 3], l=10, w=20, cl=3, cw=4), 1, "Should produce a grid of range 1");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertApproxEqual(countHexCell([10, 10], linear=true), [13, 11], "Should tell the grid is 13x11");
+                        assertEqual(countHexCell([10, 10], [3, 3], linear=true), [4, 3], "Should tell the grid is 4x3");
+                        assertEqual(countHexCell([10, 10], [3, 3], linear=true, l=10, w=20, cl=3, cw=4), [4, 5], "Should tell the grid is 4x7");
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertApproxEqual(countHexCell([10, 10], pointy=true), 5, "Should produce a grid of range 5");
+                        assertEqual(countHexCell([10, 10], [3, 3], pointy=true), 1, "Should produce a grid of range 1");
+                        assertEqual(countHexCell([10, 10], [3, 3], pointy=true, l=10, w=20, cl=3, cw=4), 1, "Should produce a grid of range 1");
+                    }
+                    testUnitContext("linear", 3) {
+                        assertApproxEqual(countHexCell([10, 10], linear=true, pointy=true), [11, 13], "Should tell the grid is 11x13");
+                        assertEqual(countHexCell([10, 10], [3, 3], linear=true, pointy=true), [3, 4], "Should tell the grid is 3x4");
+                        assertEqual(countHexCell([10, 10], [3, 3], linear=true, pointy=true, l=10, w=20, cl=3, cw=4), [3, 6], "Should tell the grid is 3x8");
+                    }
+                }
+            }
+        }
+        // test core/hex/offsetHexGrid()
+        testModule("offsetHexGrid()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(offsetHexGrid(), [0, 0], "Without parameter the function should produce a void offset");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(offsetHexGrid("10"), [0, 0], "A string should produce a void offset");
+                assertEqual(offsetHexGrid(true), [0, 0], "A boolean should produce a void offset");
+                assertEqual(offsetHexGrid([]), [0, 0], "An empty array should produce a void offset");
+                assertEqual(offsetHexGrid(["1"]), [0, 0], "An array should produce a void offset");
+            }
+            testUnit("number", 2) {
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertEqual(offsetHexGrid(2), [0, 0], "The offset to place a radial hex grid is always at the origin");
+                        assertEqual(offsetHexGrid(2, 3), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                        assertEqual(offsetHexGrid(2, 3, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                    }
+                    testUnitContext("linear", 2) {
+                        testUnitContext("odd", 3) {
+                            assertApproxEqual(offsetHexGrid(2, linear=true, even=false), [0, -sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=false), [-1.5, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=false, l=1, w=2, cx=3, cy=4), [-3 / 4, -7 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                        testUnitContext("even", 3) {
+                            assertApproxEqual(offsetHexGrid(2, linear=true, even=true), [0, sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=true), [-1.5, -3 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=true, l=1, w=2, cx=3, cy=4), [-3 / 4, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertEqual(offsetHexGrid(2, pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin");
+                        assertEqual(offsetHexGrid(2, 3, pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                        assertEqual(offsetHexGrid(2, 3, pointy=true, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                    }
+                    testUnitContext("linear", 2) {
+                        testUnitContext("odd", 3) {
+                            assertApproxEqual(offsetHexGrid(2, linear=true, pointy=true, even=false), [-1 * sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=false), [-5 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=false, l=1, w=2, cx=3, cy=4), [-2.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                        testUnitContext("even", 3) {
+                            assertApproxEqual(offsetHexGrid(2, linear=true, pointy=true, even=true), [sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=true), [-3 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=true, l=1, w=2, cx=3, cy=4), [-1.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                    }
+                }
+            }
+            testUnit("vector", 2) {
+                testUnitContext("flat topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertEqual(offsetHexGrid([2, 2]), [0, 0], "The offset to place a radial hex grid is always at the origin");
+                        assertEqual(offsetHexGrid([2, 2], [3, 3]), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                        assertEqual(offsetHexGrid([2, 2], [3, 3], l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                    }
+                    testUnitContext("linear", 2) {
+                        testUnitContext("odd", 3) {
+                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, even=false), [0, -sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=false), [-1.5, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=false, l=1, w=2, cx=3, cy=4), [-3 / 4, -7 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                        testUnitContext("even", 3) {
+                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, even=true), [0, sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=true), [-1.5, -3 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=true, l=1, w=2, cx=3, cy=4), [-3 / 4, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                    }
+                }
+                testUnitContext("pointy topped", 2) {
+                    testUnitContext("radial", 3) {
+                        assertEqual(offsetHexGrid([2, 2], pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin");
+                        assertEqual(offsetHexGrid([2, 2], [3, 3], pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                        assertEqual(offsetHexGrid([2, 2], [3, 3], pointy=true, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                    }
+                    testUnitContext("linear", 2) {
+                        testUnitContext("odd", 3) {
+                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, pointy=true, even=false), [-1 * sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=false), [-5 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=false, l=1, w=2, cx=3, cy=4), [-2.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                        testUnitContext("even", 3) {
+                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, pointy=true, even=true), [sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=true), [-3 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=true, l=1, w=2, cx=3, cy=4), [-1.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+testCoreHex();

--- a/test/core/hex.scad
+++ b/test/core/hex.scad
@@ -34,24 +34,78 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreHex() {
-    testPackage("core/hex.scad", 7) {
+    testPackage("core/hex.scad", 9) {
         // test core/hex/radialHexGrid()
-        testModule("radialHexGrid()", 3) {
+        testModule("radialHexGrid()", 4) {
             testUnit("no parameter", 1) {
                 assertEqual(radialHexGrid(), [[0, 0]], "Without parameter the function should produce a default grid of 1 cell");
             }
-            testUnit("wrong type", 5) {
+            testUnit("wrong type", 4) {
                 assertEqual(radialHexGrid("10"), [[0, 0]], "A string should produce a default grid of 1 cell");
                 assertEqual(radialHexGrid(true), [[0, 0]], "A boolean should produce a default grid of 1 cell");
                 assertEqual(radialHexGrid([]), [[0, 0]], "An empty array should produce a default grid of 1 cell");
                 assertEqual(radialHexGrid(["1"]), [[0, 0]], "An array should produce a default grid of 1 cell");
-                assertEqual(radialHexGrid([1]), [[0, 0]], "A vector should produce a default grid of 1 cell");
             }
-            testUnit("number", 4) {
+            testUnit("number", 5) {
                 assertEqual(radialHexGrid(0), [[0, 0]], "A grid of range 0 is a grid with one cell");
-                assertEqual(radialHexGrid(1), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid of range 1 is a grid with 7 cells");
-                assertEqual(radialHexGrid(2), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "A grid of range 2 is a grid with 19 cells");
-                assertEqual(radialHexGrid(-1), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "Negative range should be converter to positive");
+                assertEqual(radialHexGrid(3), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with 3 cells on a line will have 7 cells");
+                assertEqual(radialHexGrid(4), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with 4 cells on a line will have 7 cells");
+                assertEqual(radialHexGrid(5), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "A grid with 5 cells on a line will have 7 cells");
+                assertEqual(radialHexGrid(-3), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "Negative range should be converted to positive");
+            }
+            testUnit("vector", 5) {
+                assertEqual(radialHexGrid([0, 0]), [[0, 0]], "A grid of range 0 is a grid with one cell");
+                assertEqual(radialHexGrid([3, 4]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with [3, 4] cells on a line will have 7 cells");
+                assertEqual(radialHexGrid([4, 5]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with [4, 5] cells on a line will have 7 cells");
+                assertEqual(radialHexGrid([5, 6]), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "A grid with [5, 6] cells on a line will have 7 cells");
+                assertEqual(radialHexGrid([-3, -4]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "Negative range should be converted to positive");
+            }
+        }
+        // test core/hex/radialHexRange()
+        testModule("radialHexRange()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(radialHexRange(), 0, "Without parameter the function should tell the grid has range 0");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(radialHexRange("10"), 0, "With a string the function should tell the grid is has range 0");
+                assertEqual(radialHexRange(true), 0, "With a boolean the function should tell the grid is has range 0");
+                assertEqual(radialHexRange([]), 0, "With an empty array the function should tell the grid is has range 0");
+                assertEqual(radialHexRange(["1"]), 0, "With an array the function should tell the grid is has range 0");
+            }
+            testUnit("number", 5) {
+                assertEqual(radialHexRange(0), 0, "An empty size should produce a range 0");
+                assertEqual(radialHexRange(1), 0, "A size of 1 should produce a range 0");
+                assertEqual(radialHexRange(2), 0, "A size of 2 should produce a range 0");
+                assertEqual(radialHexRange(3), 1, "A size of 3 should produce a range 1");
+                assertEqual(radialHexRange(10), 4, "A size of 10 should produce a range 4");
+            }
+            testUnit("vector", 6) {
+                assertEqual(radialHexRange([0, 0]), 0, "An empty size should produce a range 0");
+                assertEqual(radialHexRange([1, 1]), 0, "A size of 1 should produce a range 0");
+                assertEqual(radialHexRange([2, 2]), 0, "A size of 2 should produce a range 0");
+                assertEqual(radialHexRange([3, 3]), 1, "A size of 3 should produce a range 1");
+                assertEqual(radialHexRange([10, 10]), 4, "A size of 10 should produce a range 4");
+                assertEqual(radialHexRange([15, 20]), 7, "Should take the lower size to compute the range");
+            }
+        }
+        // test core/hex/radialHexCount()
+        testModule("radialHexCount()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(radialHexCount(), [1, 1], "Without parameter the function should assume it is a range 0 and the size should be 1");
+            }
+            testUnit("wrong type", 5) {
+                assertEqual(radialHexCount("10"), [1, 1], "With a string the function should assume it is a range 0 and the size should be 1");
+                assertEqual(radialHexCount(true), [1, 1], "With a boolean the function should assume it is a range 0 and the size should be 1");
+                assertEqual(radialHexCount([]), [1, 1], "With an empty array the function should assume it is a range 0 and the size should be 1");
+                assertEqual(radialHexCount(["1"]), [1, 1], "With an array the function should assume it is a range 0 and the size should be 1");
+                assertEqual(radialHexCount([10]), [1, 1], "With a vector the function should assume it is a range 0 and the size should be 1");
+            }
+            testUnit("number", 5) {
+                assertEqual(radialHexCount(0), [1, 1], "A range 0 should produce a size of 1");
+                assertEqual(radialHexCount(1), [3, 3], "A range 1 should produce a size of 3");
+                assertEqual(radialHexCount(2), [5, 5], "A range 2 should produce a size of 5");
+                assertEqual(radialHexCount(3), [7, 7], "A range 3 should produce a size of 7");
+                assertEqual(radialHexCount(10), [21, 21], "A range 10 should produce a size of 21");
             }
         }
         // test core/hex/radialHexCoord()
@@ -301,63 +355,63 @@ module testCoreHex() {
         // test core/hex/countHexCell()
         testModule("countHexCell()", 4) {
             testUnit("no parameter", 1) {
-                assertEqual(countHexCell(), 0, "Without parameter the function should produce a grid of range 0");
+                assertEqual(countHexCell(), [1, 1], "Without parameter the function should tell the grid is 1x1");
             }
             testUnit("wrong type", 4) {
-                assertEqual(countHexCell("10"), 0, "A string should produce a grid of range 0");
-                assertEqual(countHexCell(true), 0, "A boolean should produce a grid of range 0");
-                assertEqual(countHexCell([]), 0, "An empty array should produce a grid of range 0");
-                assertEqual(countHexCell(["1"]), 0, "An array should produce a grid of range 0");
+                assertEqual(countHexCell("10"), [1, 1], "With a string the function should tell the grid is 1x1");
+                assertEqual(countHexCell(true), [1, 1], "With a boolean the function should tell the grid is 1x1");
+                assertEqual(countHexCell([]), [1, 1], "With an empty array the function should tell the grid is 1x1");
+                assertEqual(countHexCell(["1"]), [1, 1], "With an array the function should tell the grid is 1x1");
             }
             testUnit("number", 2) {
                 testUnitContext("flat topped", 2) {
                     testUnitContext("radial", 3) {
-                        assertApproxEqual(countHexCell(10), 5, "Should produce a grid of range 5");
-                        assertEqual(countHexCell(10, 3), 1, "Should produce a grid of range 1");
-                        assertEqual(countHexCell(10, 3, l=10, w=20, cl=3, cw=4), 1, "Should produce a grid of range 1");
+                        assertApproxEqual(countHexCell(10), [13, 11], "Should tell the grid is 13x11");
+                        assertEqual(countHexCell(10, 3), [4, 3], "Should tell the grid is 4x3");
+                        assertEqual(countHexCell(10, 3, l=10, w=20, cl=3, cw=4), [4, 5], "Should tell the grid is 4x5");
                     }
                     testUnitContext("linear", 3) {
                         assertApproxEqual(countHexCell(10, linear=true), [13, 11], "Should tell the grid is 13x11");
                         assertEqual(countHexCell(10, 3, linear=true), [4, 3], "Should tell the grid is 4x3");
-                        assertEqual(countHexCell(10, 3, linear=true, l=10, w=20, cl=3, cw=4), [4, 5], "Should tell the grid is 4x7");
+                        assertEqual(countHexCell(10, 3, linear=true, l=10, w=20, cl=3, cw=4), [4, 5], "Should tell the grid is 4x5");
                     }
                 }
                 testUnitContext("pointy topped", 2) {
                     testUnitContext("radial", 3) {
-                        assertApproxEqual(countHexCell(10, pointy=true), 5, "Should produce a grid of range 5");
-                        assertEqual(countHexCell(10, 3, pointy=true), 1, "Should produce a grid of range 1");
-                        assertEqual(countHexCell(10, 3, pointy=true, l=10, w=20, cl=3, cw=4), 1, "Should produce a grid of range 1");
+                        assertApproxEqual(countHexCell(10, pointy=true), [11, 13], "Should tell the grid is 11x13");
+                        assertEqual(countHexCell(10, 3, pointy=true), [3, 4], "Should tell the grid is 3x4");
+                        assertEqual(countHexCell(10, 3, pointy=true, l=10, w=20, cl=3, cw=4), [3, 6], "Should tell the grid is 3x6");
                     }
                     testUnitContext("linear", 3) {
                         assertApproxEqual(countHexCell(10, linear=true, pointy=true), [11, 13], "Should tell the grid is 11x13");
                         assertEqual(countHexCell(10, 3, linear=true, pointy=true), [3, 4], "Should tell the grid is 3x4");
-                        assertEqual(countHexCell(10, 3, linear=true, pointy=true, l=10, w=20, cl=3, cw=4), [3, 6], "Should tell the grid is 3x8");
+                        assertEqual(countHexCell(10, 3, linear=true, pointy=true, l=10, w=20, cl=3, cw=4), [3, 6], "Should tell the grid is 3x6");
                     }
                 }
             }
             testUnit("vector", 2) {
                 testUnitContext("flat topped", 2) {
                     testUnitContext("radial", 3) {
-                        assertApproxEqual(countHexCell([10, 10]), 5, "Should produce a grid of range 5");
-                        assertEqual(countHexCell([10, 10], [3, 3]), 1, "Should produce a grid of range 1");
-                        assertEqual(countHexCell([10, 10], [3, 3], l=10, w=20, cl=3, cw=4), 1, "Should produce a grid of range 1");
+                        assertApproxEqual(countHexCell([10, 10]), [13, 11], "Should tell the grid is 13x11");
+                        assertEqual(countHexCell([10, 10], [3, 3]), [4, 3], "Should tell the grid is 4x3");
+                        assertEqual(countHexCell([10, 10], [3, 3], l=10, w=20, cl=3, cw=4), [4, 5], "Should tell the grid is 4x5");
                     }
                     testUnitContext("linear", 3) {
                         assertApproxEqual(countHexCell([10, 10], linear=true), [13, 11], "Should tell the grid is 13x11");
                         assertEqual(countHexCell([10, 10], [3, 3], linear=true), [4, 3], "Should tell the grid is 4x3");
-                        assertEqual(countHexCell([10, 10], [3, 3], linear=true, l=10, w=20, cl=3, cw=4), [4, 5], "Should tell the grid is 4x7");
+                        assertEqual(countHexCell([10, 10], [3, 3], linear=true, l=10, w=20, cl=3, cw=4), [4, 5], "Should tell the grid is 4x5");
                     }
                 }
                 testUnitContext("pointy topped", 2) {
                     testUnitContext("radial", 3) {
-                        assertApproxEqual(countHexCell([10, 10], pointy=true), 5, "Should produce a grid of range 5");
-                        assertEqual(countHexCell([10, 10], [3, 3], pointy=true), 1, "Should produce a grid of range 1");
-                        assertEqual(countHexCell([10, 10], [3, 3], pointy=true, l=10, w=20, cl=3, cw=4), 1, "Should produce a grid of range 1");
+                        assertApproxEqual(countHexCell([10, 10], pointy=true), [11, 13], "Should tell the grid is 11x13");
+                        assertEqual(countHexCell([10, 10], [3, 3], pointy=true), [3, 4], "Should tell the grid is 3x4");
+                        assertEqual(countHexCell([10, 10], [3, 3], pointy=true, l=10, w=20, cl=3, cw=4), [3, 6], "Should tell the grid is 3x6");
                     }
                     testUnitContext("linear", 3) {
                         assertApproxEqual(countHexCell([10, 10], linear=true, pointy=true), [11, 13], "Should tell the grid is 11x13");
                         assertEqual(countHexCell([10, 10], [3, 3], linear=true, pointy=true), [3, 4], "Should tell the grid is 3x4");
-                        assertEqual(countHexCell([10, 10], [3, 3], linear=true, pointy=true, l=10, w=20, cl=3, cw=4), [3, 6], "Should tell the grid is 3x8");
+                        assertEqual(countHexCell([10, 10], [3, 3], linear=true, pointy=true, l=10, w=20, cl=3, cw=4), [3, 6], "Should tell the grid is 3x6");
                     }
                 }
             }

--- a/test/core/hex.scad
+++ b/test/core/hex.scad
@@ -34,33 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreHex() {
-    testPackage("core/hex.scad", 9) {
-        // test core/hex/radialHexGrid()
-        testModule("radialHexGrid()", 4) {
-            testUnit("no parameter", 1) {
-                assertEqual(radialHexGrid(), [[0, 0]], "Without parameter the function should produce a default grid of 1 cell");
-            }
-            testUnit("wrong type", 4) {
-                assertEqual(radialHexGrid("10"), [[0, 0]], "A string should produce a default grid of 1 cell");
-                assertEqual(radialHexGrid(true), [[0, 0]], "A boolean should produce a default grid of 1 cell");
-                assertEqual(radialHexGrid([]), [[0, 0]], "An empty array should produce a default grid of 1 cell");
-                assertEqual(radialHexGrid(["1"]), [[0, 0]], "An array should produce a default grid of 1 cell");
-            }
-            testUnit("number", 5) {
-                assertEqual(radialHexGrid(0), [[0, 0]], "A grid of range 0 is a grid with one cell");
-                assertEqual(radialHexGrid(3), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with 3 cells on a line will have 7 cells");
-                assertEqual(radialHexGrid(4), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with 4 cells on a line will have 7 cells");
-                assertEqual(radialHexGrid(5), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "A grid with 5 cells on a line will have 7 cells");
-                assertEqual(radialHexGrid(-3), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "Negative range should be converted to positive");
-            }
-            testUnit("vector", 5) {
-                assertEqual(radialHexGrid([0, 0]), [[0, 0]], "A grid of range 0 is a grid with one cell");
-                assertEqual(radialHexGrid([3, 4]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with [3, 4] cells on a line will have 7 cells");
-                assertEqual(radialHexGrid([4, 5]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with [4, 5] cells on a line will have 7 cells");
-                assertEqual(radialHexGrid([5, 6]), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "A grid with [5, 6] cells on a line will have 7 cells");
-                assertEqual(radialHexGrid([-3, -4]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "Negative range should be converted to positive");
-            }
-        }
+    testPackage("core/hex.scad", 8) {
         // test core/hex/radialHexRange()
         testModule("radialHexRange()", 4) {
             testUnit("no parameter", 1) {
@@ -108,118 +82,142 @@ module testCoreHex() {
                 assertEqual(radialHexCount(10), [21, 21], "A range 10 should produce a size of 21");
             }
         }
-        // test core/hex/radialHexCoord()
-        testModule("radialHexCoord()", 4) {
+        // test core/hex/buildHexGrid()
+        testModule("buildHexGrid()", 4) {
             testUnit("no parameter", 1) {
-                assertEqual(radialHexCoord(), [0, 0], "Without parameter the function should produce coordinates at the origin");
+                assertEqual(buildHexGrid(), [[0, 0]], "Without parameter the function should produce a default grid of 1 cell");
             }
             testUnit("wrong type", 4) {
-                assertEqual(radialHexCoord("10"), [0, 0], "A string should produce coordinates at the origin");
-                assertEqual(radialHexCoord(true), [0, 0], "A boolean should produce coordinates at the origin");
-                assertEqual(radialHexCoord([]), [0, 0], "An empty array should produce coordinates at the origin");
-                assertEqual(radialHexCoord(["1"]), [0, 0], "An array should produce coordinates at the origin");
+                assertEqual(buildHexGrid("10"), [[0, 0]], "A string should produce a default grid of 1 cell");
+                assertEqual(buildHexGrid(true), [[0, 0]], "A boolean should produce a default grid of 1 cell");
+                assertEqual(buildHexGrid([]), [[0, 0]], "An empty array should produce a default grid of 1 cell");
+                assertEqual(buildHexGrid(["1"]), [[0, 0]], "An array should produce a default grid of 1 cell");
             }
-            testUnit("number", 4) {
-                assertEqual(radialHexCoord(hex=0), [0, 0], "Should return the coordinates of the origin");
-                assertEqual(radialHexCoord(hex=0, size=10), [0, 0], "Should return the coordinates of the origin, no matter the size");
-                testUnitContext("flat topped", 3) {
-                    assertEqual(radialHexCoord(hex=1, size=10, pointy=false), [15, 15 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
-                    assertEqual(radialHexCoord(hex=-1, size=10, pointy=false), [-15, -15 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
-                    assertApproxEqual(radialHexCoord(hex=1, size=10, y=2, w=12, pointy=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+            testUnit("number", 2) {
+                testUnitContext("radial", 6) {
+                    assertEqual(buildHexGrid(0), [[0, 0]], "A grid of range 0 is a grid with one cell");
+                    assertEqual(buildHexGrid(3), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with 3 cells on a line will have 7 cells");
+                    assertEqual(buildHexGrid(4), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with 4 cells on a line will have 7 cells");
+                    assertEqual(buildHexGrid(5), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "A grid with 5 cells on a line will have 7 cells");
+                    assertEqual(buildHexGrid(-3), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "Negative range should be converted to positive");
+                    assertEqual(buildHexGrid(2, cx=5, cy=6), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "Should overwrite the default size to 5 cells");
                 }
-                testUnitContext("pointy topped", 3) {
-                    assertEqual(radialHexCoord(hex=1, size=10, pointy=true), [15 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
-                    assertEqual(radialHexCoord(hex=-1, size=10, pointy=true), [-15 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
-                    assertEqual(radialHexCoord(hex=1, size=10, y=2, w=12, pointy=true), [20 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                testUnitContext("linear", 6) {
+                    assertEqual(buildHexGrid(0, linear=true), [[0, 0]], "A grid of count 0 is a grid of 1x1 cells");
+                    assertEqual(buildHexGrid(1, linear=true), [[0, 0]], "A grid of count 1 is a grid of 1x1 cells");
+                    assertEqual(buildHexGrid(2, linear=true), [[0, 0], [0, 1], [1, 0], [1, 1]], "A grid of count 2 is a grid of 2x2 cells");
+                    assertEqual(buildHexGrid(3, linear=true), [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]], "A grid of count 2 is a grid of 2x2 cells");
+                    assertEqual(buildHexGrid(-3, linear=true), [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]], "Negative count should be converted to positive");
+                    assertEqual(buildHexGrid(1, cx=3, cy=3, linear=true), [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]], "Should overwrite the default size to 3x3 cells");
                 }
             }
-            testUnit("vector", 4) {
-                assertEqual(radialHexCoord(hex=[0, 0]), [0, 0], "Should return the coordinates of the origin");
-                assertEqual(radialHexCoord(hex=[0, 0], size=[10, 10]), [0, 0], "Should return the coordinates of the origin, no matter the size");
-                testUnitContext("flat topped", 4) {
-                    assertEqual(radialHexCoord(hex=[1, 1], size=[10, 10], pointy=false), [15, 15 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
-                    assertApproxEqual(radialHexCoord(hex=[1, 2], size=[10, 12], pointy=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
-                    assertApproxEqual(radialHexCoord(hex=[-1, -2], size=[10, 12], pointy=false), [-15, -30 * sqrt(3)], "Should return the coordinates of the cell at -1,-2");
-                    assertApproxEqual(radialHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+            testUnit("vector", 2) {
+                testUnitContext("radial", 6) {
+                    assertEqual(buildHexGrid([0, 0]), [[0, 0]], "A grid of range 0 is a grid with one cell");
+                    assertEqual(buildHexGrid([3, 4]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with [3, 4] cells on a line will have 7 cells");
+                    assertEqual(buildHexGrid([4, 5]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "A grid with [4, 5] cells on a line will have 7 cells");
+                    assertEqual(buildHexGrid([5, 6]), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "A grid with [5, 6] cells on a line will have 7 cells");
+                    assertEqual(buildHexGrid([-3, -4]), [[-1, 1], [-1, 0], [0, 1], [0, 0], [0, -1], [1, 0], [1, -1]], "Negative range should be converted to positive");
+                    assertEqual(buildHexGrid([1, 2], cx=5, cy=6), [[-2, 2], [-2, 1], [-2, 0], [-1, 2], [-1, 1], [-1, 0], [-1, -1], [0, 2], [0, 1], [0, 0], [0, -1], [0, -2], [1, 1], [1, 0], [1, -1], [1, -2], [2, 0], [2, -1], [2, -2]], "Should overwrite the default size to 5 cells");
                 }
-                testUnitContext("pointy topped", 4) {
-                    assertEqual(radialHexCoord(hex=[1, 1], size=[10, 10], pointy=true), [15 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
-                    assertEqual(radialHexCoord(hex=[1, 2], size=[10, 12], pointy=true), [20 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
-                    assertEqual(radialHexCoord(hex=[-1, -2], size=[10, 12], pointy=true), [-20 * sqrt(3), -36], "Should return the coordinates of the cell at -1,-2");
-                    assertEqual(radialHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=true), [20 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                testUnitContext("linear", 6) {
+                    assertEqual(buildHexGrid([0, 0], linear=true), [[0, 0]], "A grid of count 0x0 is a grid of 1x1 cells");
+                    assertEqual(buildHexGrid([1, 1], linear=true), [[0, 0]], "A grid of count 1x1 is a grid of 1x1 cells");
+                    assertEqual(buildHexGrid([2, 3], linear=true), [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2]], "A grid of count 2x3 is a grid of 2x3 cells");
+                    assertEqual(buildHexGrid([3, 2], linear=true), [[0, 0], [0, 1], [1, 0], [1, 1], [2, 0], [2, 1]], "A grid of count 3x2 is a grid of 3x2 cells");
+                    assertEqual(buildHexGrid([-3, -3], linear=true), [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]], "Negative count should be converted to positive");
+                    assertEqual(buildHexGrid([1, 2], cx=3, cy=3, linear=true), [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]], "Should overwrite the default size to 3x3 cells");
                 }
             }
         }
-        // test core/hex/linearHexCoord()
-        testModule("linearHexCoord()", 4) {
+        // test core/hex/offsetHexGrid()
+        testModule("offsetHexGrid()", 4) {
             testUnit("no parameter", 1) {
-                assertEqual(linearHexCoord(), [0, 0], "Without parameter the function should produce coordinates at the origin");
+                assertEqual(offsetHexGrid(), [0, 0], "Without parameter the function should produce a void offset");
             }
             testUnit("wrong type", 4) {
-                assertEqual(linearHexCoord("10"), [0, 0], "A string should produce coordinates at the origin");
-                assertEqual(linearHexCoord(true), [0, 0], "A boolean should produce coordinates at the origin");
-                assertEqual(linearHexCoord([]), [0, 0], "An empty array should produce coordinates at the origin");
-                assertEqual(linearHexCoord(["1"]), [0, 0], "An array should produce coordinates at the origin");
+                assertEqual(offsetHexGrid("10"), [0, 0], "A string should produce a void offset");
+                assertEqual(offsetHexGrid(true), [0, 0], "A boolean should produce a void offset");
+                assertEqual(offsetHexGrid([]), [0, 0], "An empty array should produce a void offset");
+                assertEqual(offsetHexGrid(["1"]), [0, 0], "An array should produce a void offset");
             }
-            testUnit("number", 3) {
-                assertEqual(linearHexCoord(hex=0), [0, 0], "Should return the coordinates of the origin");
+            testUnit("number", 2) {
                 testUnitContext("flat topped", 2) {
-                    testUnitContext("odd", 4) {
-                        assertEqual(linearHexCoord(hex=0, size=10, pointy=false, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
-                        assertEqual(linearHexCoord(hex=1, size=10, pointy=false, even=false), [15, 15 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
-                        assertEqual(linearHexCoord(hex=-1, size=10, pointy=false, even=false), [-15, -15 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
-                        assertApproxEqual(linearHexCoord(hex=1, size=10, y=2, w=12, pointy=false, even=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    testUnitContext("radial", 3) {
+                        assertEqual(offsetHexGrid(2), [0, 0], "The offset to place a radial hex grid is always at the origin");
+                        assertEqual(offsetHexGrid(2, 3), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                        assertEqual(offsetHexGrid(2, 3, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
                     }
-                    testUnitContext("even", 4) {
-                        assertEqual(linearHexCoord(hex=0, size=10, pointy=false, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the vertical axis");
-                        assertEqual(linearHexCoord(hex=1, size=10, pointy=false, even=true), [15, 5 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
-                        assertEqual(linearHexCoord(hex=-1, size=10, pointy=false, even=true), [-15, -5 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
-                        assertApproxEqual(linearHexCoord(hex=1, size=10, y=2, w=12, pointy=false, even=true), [15, 18 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    testUnitContext("linear", 2) {
+                        testUnitContext("odd", 3) {
+                            assertApproxEqual(offsetHexGrid(2, linear=true, even=false), [0, -sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=false), [-1.5, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=false, l=1, w=2, cx=3, cy=4), [-3 / 4, -7 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                        testUnitContext("even", 3) {
+                            assertApproxEqual(offsetHexGrid(2, linear=true, even=true), [0, sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=true), [-1.5, -3 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=true, l=1, w=2, cx=3, cy=4), [-3 / 4, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
                     }
                 }
                 testUnitContext("pointy topped", 2) {
-                    testUnitContext("odd", 4) {
-                        assertEqual(linearHexCoord(hex=0, size=10, pointy=true, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
-                        assertEqual(linearHexCoord(hex=1, size=10, pointy=true, even=false), [15 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
-                        assertEqual(linearHexCoord(hex=-1, size=10, pointy=true, even=false), [-15 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
-                        assertEqual(linearHexCoord(hex=1, size=10, y=2, w=12, pointy=true, even=false), [10 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    testUnitContext("radial", 3) {
+                        assertEqual(offsetHexGrid(2, pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin");
+                        assertEqual(offsetHexGrid(2, 3, pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                        assertEqual(offsetHexGrid(2, 3, pointy=true, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
                     }
-                    testUnitContext("even", 4) {
-                        assertEqual(linearHexCoord(hex=0, size=10, pointy=true, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the horizontal axis");
-                        assertEqual(linearHexCoord(hex=1, size=10, pointy=true, even=true), [5 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
-                        assertEqual(linearHexCoord(hex=-1, size=10, pointy=true, even=true), [-5 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
-                        assertEqual(linearHexCoord(hex=1, size=10, y=2, w=12, pointy=true, even=true), [10 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    testUnitContext("linear", 2) {
+                        testUnitContext("odd", 3) {
+                            assertApproxEqual(offsetHexGrid(2, linear=true, pointy=true, even=false), [-1 * sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=false), [-5 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=false, l=1, w=2, cx=3, cy=4), [-2.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                        testUnitContext("even", 3) {
+                            assertApproxEqual(offsetHexGrid(2, linear=true, pointy=true, even=true), [sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=true), [-3 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=true, l=1, w=2, cx=3, cy=4), [-1.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
                     }
                 }
             }
-            testUnit("vector", 3) {
-                assertEqual(linearHexCoord(hex=[0, 0]), [0, 0], "Should return the coordinates of the origin");
+            testUnit("vector", 2) {
                 testUnitContext("flat topped", 2) {
-                    testUnitContext("odd", 4) {
-                        assertEqual(linearHexCoord(hex=[0, 0], size=[10, 10], pointy=false, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
-                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], pointy=false, even=false), [15, 15 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
-                        assertEqual(linearHexCoord(hex=[-1, -1], size=[10, 10], pointy=false, even=false), [-15, -15 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
-                        assertApproxEqual(linearHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=false, even=false), [15, 30 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    testUnitContext("radial", 3) {
+                        assertEqual(offsetHexGrid([2, 2]), [0, 0], "The offset to place a radial hex grid is always at the origin");
+                        assertEqual(offsetHexGrid([2, 2], [3, 3]), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                        assertEqual(offsetHexGrid([2, 2], [3, 3], l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
                     }
-                    testUnitContext("even", 4) {
-                        assertEqual(linearHexCoord(hex=[0, 0], size=[10, 10], pointy=false, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the vertical axis");
-                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], pointy=false, even=true), [15, 5 * sqrt(3)], "Should return the coordinates of the cell at 1,1");
-                        assertEqual(linearHexCoord(hex=[-1, -1], size=[10, 10], pointy=false, even=true), [-15, -5 * sqrt(3)], "Should return the coordinates of the cell at -1,-1");
-                        assertApproxEqual(linearHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=false, even=true), [15, 18 * sqrt(3)], "Should return the coordinates of the cell at 1,2");
+                    testUnitContext("linear", 2) {
+                        testUnitContext("odd", 3) {
+                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, even=false), [0, -sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=false), [-1.5, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=false, l=1, w=2, cx=3, cy=4), [-3 / 4, -7 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                        testUnitContext("even", 3) {
+                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, even=true), [0, sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=true), [-1.5, -3 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=true, l=1, w=2, cx=3, cy=4), [-3 / 4, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
                     }
                 }
                 testUnitContext("pointy topped", 2) {
-                    testUnitContext("odd", 4) {
-                        assertEqual(linearHexCoord(hex=[0, 0], size=[10, 10], pointy=true, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
-                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], pointy=true, even=false), [15 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
-                        assertEqual(linearHexCoord(hex=[-1, -1], size=[10, 10], pointy=true, even=false), [-15 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
-                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=true, even=false), [10 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    testUnitContext("radial", 3) {
+                        assertEqual(offsetHexGrid([2, 2], pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin");
+                        assertEqual(offsetHexGrid([2, 2], [3, 3], pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                        assertEqual(offsetHexGrid([2, 2], [3, 3], pointy=true, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
                     }
-                    testUnitContext("even", 4) {
-                        assertEqual(linearHexCoord(hex=[0, 0], size=[10, 10], pointy=true, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the horizontal axis");
-                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], pointy=true, even=true), [5 * sqrt(3), 15], "Should return the coordinates of the cell at 1,1");
-                        assertEqual(linearHexCoord(hex=[-1, -1], size=[10, 10], pointy=true, even=true), [-5 * sqrt(3), -15], "Should return the coordinates of the cell at -1,-1");
-                        assertEqual(linearHexCoord(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=true, even=true), [10 * sqrt(3), 36], "Should return the coordinates of the cell at 1,2");
+                    testUnitContext("linear", 2) {
+                        testUnitContext("odd", 3) {
+                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, pointy=true, even=false), [-1 * sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=false), [-5 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=false, l=1, w=2, cx=3, cy=4), [-2.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
+                        testUnitContext("even", 3) {
+                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, pointy=true, even=true), [sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=true), [-3 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
+                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=true, l=1, w=2, cx=3, cy=4), [-1.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        }
                     }
                 }
             }
@@ -416,93 +414,109 @@ module testCoreHex() {
                 }
             }
         }
-        // test core/hex/offsetHexGrid()
-        testModule("offsetHexGrid()", 4) {
+        // test core/hex/coordHexCell()
+        testModule("coordHexCell()", 4) {
             testUnit("no parameter", 1) {
-                assertEqual(offsetHexGrid(), [0, 0], "Without parameter the function should produce a void offset");
+                assertEqual(coordHexCell(), [0, 0], "Without parameter the function should produce coordinates at the origin");
             }
             testUnit("wrong type", 4) {
-                assertEqual(offsetHexGrid("10"), [0, 0], "A string should produce a void offset");
-                assertEqual(offsetHexGrid(true), [0, 0], "A boolean should produce a void offset");
-                assertEqual(offsetHexGrid([]), [0, 0], "An empty array should produce a void offset");
-                assertEqual(offsetHexGrid(["1"]), [0, 0], "An array should produce a void offset");
+                assertEqual(coordHexCell("10"), [0, 0], "A string should produce coordinates at the origin");
+                assertEqual(coordHexCell(true), [0, 0], "A boolean should produce coordinates at the origin");
+                assertEqual(coordHexCell([]), [0, 0], "An empty array should produce coordinates at the origin");
+                assertEqual(coordHexCell(["1"]), [0, 0], "An array should produce coordinates at the origin");
             }
             testUnit("number", 2) {
-                testUnitContext("flat topped", 2) {
-                    testUnitContext("radial", 3) {
-                        assertEqual(offsetHexGrid(2), [0, 0], "The offset to place a radial hex grid is always at the origin");
-                        assertEqual(offsetHexGrid(2, 3), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
-                        assertEqual(offsetHexGrid(2, 3, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                testUnitContext("radial", 4) {
+                    assertEqual(coordHexCell(hex=0), [0, 0], "Should return the coordinates of the origin");
+                    assertEqual(coordHexCell(hex=0, size=10), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                    testUnitContext("flat topped", 3) {
+                        assertEqual(coordHexCell(hex=1, size=10, pointy=false), [15, 15 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,1");
+                        assertEqual(coordHexCell(hex=-1, size=10, pointy=false), [-15, -15 * sqrt(3)] / 2, "Should return the coordinates of the cell at -1,-1");
+                        assertApproxEqual(coordHexCell(hex=1, size=10, y=2, w=12, pointy=false), [15, 30 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,2");
                     }
-                    testUnitContext("linear", 2) {
-                        testUnitContext("odd", 3) {
-                            assertApproxEqual(offsetHexGrid(2, linear=true, even=false), [0, -sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
-                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=false), [-1.5, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
-                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=false, l=1, w=2, cx=3, cy=4), [-3 / 4, -7 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
-                        }
-                        testUnitContext("even", 3) {
-                            assertApproxEqual(offsetHexGrid(2, linear=true, even=true), [0, sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
-                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=true), [-1.5, -3 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
-                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, even=true, l=1, w=2, cx=3, cy=4), [-3 / 4, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
-                        }
+                    testUnitContext("pointy topped", 3) {
+                        assertEqual(coordHexCell(hex=1, size=10, pointy=true), [15 * sqrt(3), 15] / 2, "Should return the coordinates of the cell at 1,1");
+                        assertEqual(coordHexCell(hex=-1, size=10, pointy=true), [-15 * sqrt(3), -15] / 2, "Should return the coordinates of the cell at -1,-1");
+                        assertEqual(coordHexCell(hex=1, size=10, y=2, w=12, pointy=true), [10 * sqrt(3), 18], "Should return the coordinates of the cell at 1,2");
                     }
                 }
-                testUnitContext("pointy topped", 2) {
-                    testUnitContext("radial", 3) {
-                        assertEqual(offsetHexGrid(2, pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin");
-                        assertEqual(offsetHexGrid(2, 3, pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
-                        assertEqual(offsetHexGrid(2, 3, pointy=true, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
-                    }
-                    testUnitContext("linear", 2) {
-                        testUnitContext("odd", 3) {
-                            assertApproxEqual(offsetHexGrid(2, linear=true, pointy=true, even=false), [-1 * sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
-                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=false), [-5 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
-                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=false, l=1, w=2, cx=3, cy=4), [-2.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                testUnitContext("linear", 3) {
+                    assertEqual(coordHexCell(hex=0, linear=true), [0, 0], "Should return the coordinates of the origin");
+                    testUnitContext("flat topped", 2) {
+                        testUnitContext("odd", 4) {
+                            assertEqual(coordHexCell(hex=0, size=10, linear=true, pointy=false, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                            assertEqual(coordHexCell(hex=1, size=10, linear=true, pointy=false, even=false), [15, 15 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,1");
+                            assertEqual(coordHexCell(hex=-1, size=10, linear=true, pointy=false, even=false), [-15, -15 * sqrt(3)] / 2, "Should return the coordinates of the cell at -1,-1");
+                            assertApproxEqual(coordHexCell(hex=1, size=10, y=2, w=12, linear=true, pointy=false, even=false), [15, 30 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,2");
                         }
-                        testUnitContext("even", 3) {
-                            assertApproxEqual(offsetHexGrid(2, linear=true, pointy=true, even=true), [sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
-                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=true), [-3 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
-                            assertApproxEqual(offsetHexGrid(2, 3, linear=true, pointy=true, even=true, l=1, w=2, cx=3, cy=4), [-1.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        testUnitContext("even", 4) {
+                            assertEqual(coordHexCell(hex=0, size=10, linear=true, pointy=false, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the vertical axis");
+                            assertEqual(coordHexCell(hex=1, size=10, linear=true, pointy=false, even=true), [15, 5 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,1");
+                            assertEqual(coordHexCell(hex=-1, size=10, linear=true, pointy=false, even=true), [-15, -5 * sqrt(3)] / 2, "Should return the coordinates of the cell at -1,-1");
+                            assertApproxEqual(coordHexCell(hex=1, size=10, y=2, w=12, linear=true, pointy=false, even=true), [15, 18 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,2");
+                        }
+                    }
+                    testUnitContext("pointy topped", 2) {
+                        testUnitContext("odd", 4) {
+                            assertEqual(coordHexCell(hex=0, size=10, linear=true, pointy=true, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                            assertEqual(coordHexCell(hex=1, size=10, linear=true, pointy=true, even=false), [15 * sqrt(3), 15] / 2, "Should return the coordinates of the cell at 1,1");
+                            assertEqual(coordHexCell(hex=-1, size=10, linear=true, pointy=true, even=false), [-15 * sqrt(3), -15] / 2, "Should return the coordinates of the cell at -1,-1");
+                            assertEqual(coordHexCell(hex=1, size=10, y=2, w=12, linear=true, pointy=true, even=false), [5 * sqrt(3), 18], "Should return the coordinates of the cell at 1,2");
+                        }
+                        testUnitContext("even", 4) {
+                            assertEqual(coordHexCell(hex=0, size=10, linear=true, pointy=true, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the horizontal axis");
+                            assertEqual(coordHexCell(hex=1, size=10, linear=true, pointy=true, even=true), [5 * sqrt(3), 15] / 2, "Should return the coordinates of the cell at 1,1");
+                            assertEqual(coordHexCell(hex=-1, size=10, linear=true, pointy=true, even=true), [-5 * sqrt(3), -15] / 2, "Should return the coordinates of the cell at -1,-1");
+                            assertEqual(coordHexCell(hex=1, size=10, y=2, w=12, linear=true, pointy=true, even=true), [5 * sqrt(3), 18], "Should return the coordinates of the cell at 1,2");
                         }
                     }
                 }
             }
             testUnit("vector", 2) {
-                testUnitContext("flat topped", 2) {
-                    testUnitContext("radial", 3) {
-                        assertEqual(offsetHexGrid([2, 2]), [0, 0], "The offset to place a radial hex grid is always at the origin");
-                        assertEqual(offsetHexGrid([2, 2], [3, 3]), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
-                        assertEqual(offsetHexGrid([2, 2], [3, 3], l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
+                testUnitContext("radial", 4) {
+                    assertEqual(coordHexCell(hex=[0, 0]), [0, 0], "Should return the coordinates of the origin");
+                    assertEqual(coordHexCell(hex=[0, 0], size=[10, 10]), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                    testUnitContext("flat topped", 4) {
+                        assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], pointy=false), [15, 15 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,1");
+                        assertApproxEqual(coordHexCell(hex=[1, 2], size=[10, 12], pointy=false), [15, 30 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,2");
+                        assertApproxEqual(coordHexCell(hex=[-1, -2], size=[10, 12], pointy=false), [-15, -30 * sqrt(3)] / 2, "Should return the coordinates of the cell at -1,-2");
+                        assertApproxEqual(coordHexCell(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=false), [15, 30 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,2");
                     }
-                    testUnitContext("linear", 2) {
-                        testUnitContext("odd", 3) {
-                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, even=false), [0, -sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
-                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=false), [-1.5, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
-                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=false, l=1, w=2, cx=3, cy=4), [-3 / 4, -7 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
-                        }
-                        testUnitContext("even", 3) {
-                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, even=true), [0, sqrt(3) / 4], "When only the size is provided the function should assume a count of 1 and should produce a size");
-                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=true), [-1.5, -3 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3 cells");
-                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, even=true, l=1, w=2, cx=3, cy=4), [-3 / 4, -5 * sqrt(3) / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
-                        }
+                    testUnitContext("pointy topped", 4) {
+                        assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], pointy=true), [15 * sqrt(3), 15] / 2, "Should return the coordinates of the cell at 1,1");
+                        assertEqual(coordHexCell(hex=[1, 2], size=[10, 12], pointy=true), [10 * sqrt(3), 18], "Should return the coordinates of the cell at 1,2");
+                        assertEqual(coordHexCell(hex=[-1, -2], size=[10, 12], pointy=true), [-10 * sqrt(3), -18], "Should return the coordinates of the cell at -1,-2");
+                        assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], y=2, w=12, pointy=true), [10 * sqrt(3), 18], "Should return the coordinates of the cell at 1,2");
                     }
                 }
-                testUnitContext("pointy topped", 2) {
-                    testUnitContext("radial", 3) {
-                        assertEqual(offsetHexGrid([2, 2], pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin");
-                        assertEqual(offsetHexGrid([2, 2], [3, 3], pointy=true), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
-                        assertEqual(offsetHexGrid([2, 2], [3, 3], pointy=true, l=1, w=2, cx=3, cy=4), [0, 0], "The offset to place a radial hex grid is always at the origin, no matter the size");
-                    }
-                    testUnitContext("linear", 2) {
-                        testUnitContext("odd", 3) {
-                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, pointy=true, even=false), [-1 * sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
-                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=false), [-5 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
-                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=false, l=1, w=2, cx=3, cy=4), [-2.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                testUnitContext("linear", 3) {
+                    assertEqual(coordHexCell(hex=[0, 0], linear=true), [0, 0], "Should return the coordinates of the origin");
+                    testUnitContext("flat topped", 2) {
+                        testUnitContext("odd", 4) {
+                            assertEqual(coordHexCell(hex=[0, 0], size=[10, 10], linear=true, pointy=false, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                            assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], linear=true, pointy=false, even=false), [15, 15 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,1");
+                            assertEqual(coordHexCell(hex=[-1, -1], size=[10, 10], linear=true, pointy=false, even=false), [-15, -15 * sqrt(3)] / 2, "Should return the coordinates of the cell at -1,-1");
+                            assertApproxEqual(coordHexCell(hex=[1, 1], size=[10, 10], y=2, w=12, linear=true, pointy=false, even=false), [15, 30 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,2");
                         }
-                        testUnitContext("even", 3) {
-                            assertApproxEqual(offsetHexGrid([2, 2], linear=true, pointy=true, even=true), [sqrt(3) / 4, 0], "When only the size is provided the function should assume a count of 1 and should produce a size");
-                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=true), [-3 * sqrt(3) / 4, -1.5], "Should produce a size corresponding to a grid of 3 cells");
-                            assertApproxEqual(offsetHexGrid([2, 2], [3, 3], linear=true, pointy=true, even=true, l=1, w=2, cx=3, cy=4), [-1.5 * sqrt(3) / 4, -9 / 4], "Should produce a size corresponding to a grid of 3x4 cells(1, 2)");
+                        testUnitContext("even", 4) {
+                            assertEqual(coordHexCell(hex=[0, 0], size=[10, 10], linear=true, pointy=false, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the vertical axis");
+                            assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], linear=true, pointy=false, even=true), [15, 5 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,1");
+                            assertEqual(coordHexCell(hex=[-1, -1], size=[10, 10], linear=true, pointy=false, even=true), [-15, -5 * sqrt(3)] / 2, "Should return the coordinates of the cell at -1,-1");
+                            assertApproxEqual(coordHexCell(hex=[1, 1], size=[10, 10], y=2, w=12, linear=true, pointy=false, even=true), [15, 18 * sqrt(3)] / 2, "Should return the coordinates of the cell at 1,2");
+                        }
+                    }
+                    testUnitContext("pointy topped", 2) {
+                        testUnitContext("odd", 4) {
+                            assertEqual(coordHexCell(hex=[0, 0], size=[10, 10], linear=true, pointy=true, even=false), [0, 0], "Should return the coordinates of the origin, no matter the size");
+                            assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], linear=true, pointy=true, even=false), [15 * sqrt(3), 15] / 2, "Should return the coordinates of the cell at 1,1");
+                            assertEqual(coordHexCell(hex=[-1, -1], size=[10, 10], linear=true, pointy=true, even=false), [-15 * sqrt(3), -15] / 2, "Should return the coordinates of the cell at -1,-1");
+                            assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], y=2, w=12, linear=true, pointy=true, even=false), [5 * sqrt(3), 18], "Should return the coordinates of the cell at 1,2");
+                        }
+                        testUnitContext("even", 4) {
+                            assertEqual(coordHexCell(hex=[0, 0], size=[10, 10], linear=true, pointy=true, even=true), [0, 0], "Should return the coordinates of the origin, with an offset on the horizontal axis");
+                            assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], linear=true, pointy=true, even=true), [5 * sqrt(3), 15] / 2, "Should return the coordinates of the cell at 1,1");
+                            assertEqual(coordHexCell(hex=[-1, -1], size=[10, 10], linear=true, pointy=true, even=true), [-5 * sqrt(3), -15] / 2, "Should return the coordinates of the cell at -1,-1");
+                            assertEqual(coordHexCell(hex=[1, 1], size=[10, 10], y=2, w=12, linear=true, pointy=true, even=true), [5 * sqrt(3), 18], "Should return the coordinates of the cell at 1,2");
                         }
                     }
                 }

--- a/test/shape/2D/polygon.scad
+++ b/test/shape/2D/polygon.scad
@@ -181,26 +181,41 @@ module testShape2dPolygon() {
             }
         }
         // test shape/2D/polygon/drawHexagon()
-        testModule("drawHexagon()", 2) {
+        testModule("drawHexagon()", 3) {
             testUnit("default values", 3) {
-                assertEqual(drawHexagon(), [ for(i = [0 : 5]) _rotP(i * 360/6, 0.5, 0.5) ], "Should return a list of points to draw an hexagon with a size of 1");
-                assertEqual(drawHexagon("12", "12", "12"), [ for(i = [0 : 5]) _rotP(i * 360/6, 0.5, 0.5) ], "Should return a list of points to draw an hexagon with a size of 1 if wrong parameter has been provided (string)");
-                assertEqual(drawHexagon(true, true, true), [ for(i = [0 : 5]) _rotP(i * 360/6, 0.5, 0.5) ], "Should return a list of points to draw an hexagon with a size of 1 if wrong parameter has been provided (boolean)");
+                assertEqual(drawHexagon(), [ for(i = [0 : 5]) _rotP(i * 360/6, 0.5, 0.5) ], "Should return a list of points to draw a flat topped hexagon with a size of 1");
+                assertEqual(drawHexagon("12", "12", "12"), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 0.5, 0.5) ], "Should return a list of points to draw a pointy topped hexagon with a size of 1 if wrong parameter has been provided (string)");
+                assertEqual(drawHexagon(true, true, true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 0.5, 0.5) ], "Should return a list of points to draw a pointy topped hexagon with a size of 1 if wrong parameter has been provided (boolean)");
             }
-            testUnit("draw shape", 12) {
-                assertEqual(drawHexagon(3), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 1.5) ], "Should return a list of points to draw an hexagon. Single number size should be translated into vector");
-                assertEqual(drawHexagon([3, 4]), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 2) ], "Should return a list of points to draw an hexagon using the provided size vector");
-                assertEqual(drawHexagon([3, 4], l=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1, 2) ], "Should return a list of points to draw an hexagon using the provided size vector and the particular length");
-                assertEqual(drawHexagon([3, 4], w=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 1) ], "Should return a list of points to draw an hexagon using the provided size vector and the particular width");
-                assertEqual(drawHexagon(l=3, w=4), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 2) ], "Should return a list of points to draw an hexagon using the provided size length and width");
-                assertEqual(drawHexagon(s=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 2/(2 * sin(180/6)), 2/(2 * sin(180/6))) ], "Should return a list of points to draw an hexagon using the provided facet size");
+            testUnit("draw shape, flat topped", 12) {
+                assertEqual(drawHexagon(3), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 1.5) ], "Should return a list of points to draw a flat topped hexagon. Single number size should be translated into vector");
+                assertEqual(drawHexagon([3, 4]), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 2) ], "Should return a list of points to draw a flat topped hexagon using the provided size vector");
+                assertEqual(drawHexagon([3, 4], l=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1, 2) ], "Should return a list of points to draw a flat topped hexagon using the provided size vector and the particular length");
+                assertEqual(drawHexagon([3, 4], w=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 1) ], "Should return a list of points to draw a flat topped hexagon using the provided size vector and the particular width");
+                assertEqual(drawHexagon(l=3, w=4), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 2) ], "Should return a list of points to draw a flat topped hexagon using the provided size length and width");
+                assertEqual(drawHexagon(s=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 2/(2 * sin(180/6)), 2/(2 * sin(180/6))) ], "Should return a list of points to draw a flat topped hexagon using the provided facet size");
 
-                assertEqual(drawHexagon(3, adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 1.5) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw an hexagon. Single number size should be translated into vector");
-                assertEqual(drawHexagon([3, 4], adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 2) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw an hexagon using the provided size vector");
-                assertEqual(drawHexagon([3, 4], l=2, adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1, 2) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw an hexagon using the provided size vector and the particular length");
-                assertEqual(drawHexagon([3, 4], w=2, adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 1) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw an hexagon using the provided size vector and the particular width");
-                assertEqual(drawHexagon(l=3, w=4, adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 2) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw an hexagon using the provided size length and width");
-                assertEqual(drawHexagon(s=2, , adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 2/(2 * sin(180/6)), 2/(2 * sin(180/6))) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw an hexagon using the provided facet size");
+                assertEqual(drawHexagon(3, adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 1.5) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw a flat topped hexagon. Single number size should be translated into vector");
+                assertEqual(drawHexagon([3, 4], adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 2) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw a flat topped hexagon using the provided size vector");
+                assertEqual(drawHexagon([3, 4], l=2, adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1, 2) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw a flat topped hexagon using the provided size vector and the particular length");
+                assertEqual(drawHexagon([3, 4], w=2, adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 1) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw a flat topped hexagon using the provided size vector and the particular width");
+                assertEqual(drawHexagon(l=3, w=4, adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 1.5, 2) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw a flat topped hexagon using the provided size length and width");
+                assertEqual(drawHexagon(s=2, , adjust=2), [ for(i = [0 : 5]) _rotP(i * 360/6, 2/(2 * sin(180/6)), 2/(2 * sin(180/6))) + [i >= 2 && i<= 4 ? -1 : 1, 0] ], "Should return a list of points to draw a flat topped hexagon using the provided facet size");
+            }
+            testUnit("draw shape, pointy topped", 12) {
+                assertEqual(drawHexagon(3, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1.5, 1.5) ], "Should return a list of points to draw a pointy topped hexagon. Single number size should be translated into vector");
+                assertEqual(drawHexagon([3, 4], pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1.5, 2) ], "Should return a list of points to draw a pointy topped hexagon using the provided size vector");
+                assertEqual(drawHexagon([3, 4], l=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1, 2) ], "Should return a list of points to draw a pointy topped hexagon using the provided size vector and the particular length");
+                assertEqual(drawHexagon([3, 4], w=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1.5, 1) ], "Should return a list of points to draw a pointy topped hexagon using the provided size vector and the particular width");
+                assertEqual(drawHexagon(l=3, w=4, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1.5, 2) ], "Should return a list of points to draw a pointy topped hexagon using the provided size length and width");
+                assertEqual(drawHexagon(s=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 2/(2 * sin(180/6)), 2/(2 * sin(180/6))) ], "Should return a list of points to draw a pointy topped hexagon using the provided facet size");
+
+                assertEqual(drawHexagon(3, adjust=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1.5, 1.5) + [0, i >= 3 ? -1 : 1] ], "Should return a list of points to draw a pointy topped hexagon. Single number size should be translated into vector");
+                assertEqual(drawHexagon([3, 4], adjust=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1.5, 2) + [0, i >= 3 ? -1 : 1] ], "Should return a list of points to draw a pointy topped hexagon using the provided size vector");
+                assertEqual(drawHexagon([3, 4], l=2, adjust=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1, 2) + [0, i >= 3 ? -1 : 1] ], "Should return a list of points to draw a pointy topped hexagon using the provided size vector and the particular length");
+                assertEqual(drawHexagon([3, 4], w=2, adjust=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1.5, 1) + [0, i >= 3 ? -1 : 1] ], "Should return a list of points to draw a pointy topped hexagon using the provided size vector and the particular width");
+                assertEqual(drawHexagon(l=3, w=4, adjust=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 1.5, 2) + [0, i >= 3 ? -1 : 1] ], "Should return a list of points to draw a pointy topped hexagon using the provided size length and width");
+                assertEqual(drawHexagon(s=2, , adjust=2, pointy=true), [ for(i = [0 : 5]) _rotP(i * 360/6 + 30, 2/(2 * sin(180/6)), 2/(2 * sin(180/6))) + [0, i >= 3 ? -1 : 1] ], "Should return a list of points to draw a pointy topped hexagon using the provided facet size");
             }
         }
         // test shape/2D/polygon/drawStar()

--- a/test/suite.scad
+++ b/test/suite.scad
@@ -37,6 +37,7 @@ use <core/type.scad>
 use <core/logic.scad>
 use <core/list.scad>
 use <core/maths.scad>
+use <core/hex.scad>
 use <core/line.scad>
 use <core/vector.scad>
 use <core/vector-2d.scad>
@@ -64,6 +65,7 @@ testCoreType();
 testCoreLogic();
 testCoreList();
 testCoreMaths();
+testCoreHex();
 testCoreLine();
 testCoreVector();
 testCoreVector2D();


### PR DESCRIPTION
Add helpers to manage hex grids:
- `radialHexRange(count)`: Computes the number of ranges in a radial hex grid based on the number of cells.
- `radialHexCount(range)`: Computes the number of cells in a radial hex grid based on the number of ranges.
- `buildHexGrid(count, linear, cx, cy)`: Computes the logical coordinates of cells placed on a hex grid. Will return an array of 2D coordinates.
- `offsetHexGrid(size, count, pointy, linear, even, l, w, cx, cy)`: Computes the offset of a hex grid in order to center it.
- `sizeHexGrid(size, count, pointy, linear, l, w, cx, cy)`: Computes the size of a hex grid based on the size of one cell and the number of cells.
- `sizeHexCell(size, count, pointy, linear, l, w, cx, cy)`: Computes the size of a cell in a hex grid based on the size of the grid and the number of cells.
- `countHexCell(size, cell, pointy, linear, l, w, cl, cw)`: Computes the number of cells in a hex grid that fits the provided size.
- `coordHexCell(hex, size, pointy, linear, even, x, y, l, w)`: Computes the physical coordinates of a cell in a hex grid based on its logical coordinates.

Add 2D and 3D shapes that create a mesh with honeycomb cells using a hex grid pattern:
- `mesh(size, count, gap, pointy, linear, even, l, w, cx, cy, gx, gy)`
- `meshBox(size, count, gap, pointy, linear, even, l, w, h, cx, cy, gx, gy, center)`

Update the signature of the hexagon shape in order to support orientation: flat topped or pointy topped: `hexagon(size, pointy, adjust, l, w, s)`