### PR TITLE
feature/operator sample

### DIFF
--- a/operator/sample.scad
+++ b/operator/sample.scad
@@ -24,33 +24,37 @@
  */
 
 /**
- * Entry point of the camelSCAD library.
+ * Part of the camelSCAD library.
  *
- * Features set: Includes the core components and the operators.
+ * Takes a sample of the scene.
  *
+ * @package operator
  * @author jsconan
  */
 
-/* CORE */
-include <core.scad>
+/**
+ * Takes a sample of the scene and place it at the origin.
+ * @param Number|Vector [size] - The size of sample.
+ * @param Number|Vector [offset] - The position of the sample center. Will be the on the bottom face if center=false,
+                                   and on the actual center if center=true.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [h] - The overall height.
+ * @param Number [x] - The horizontal offset.
+ * @param Number [y] - The depth offset.
+ * @param Number [z] - The vertical offset.
+ * @param Boolean [center] - Whether or not center the sample on the vertical axis.
+ */
+module sample(size, offset, l, w, h, x, y, z, center) {
+    size = apply3D(size, l, w, h);
+    offset = apply3D(offset, x, y, z);
 
-/* OPERATORS */
-include <operator/distribute/grid.scad>
-include <operator/distribute/mirror.scad>
-include <operator/distribute/rotate.scad>
-include <operator/distribute/translate.scad>
-
-include <operator/extrude/negative.scad>
-
-include <operator/repeat/mirror.scad>
-include <operator/repeat/rotate.scad>
-include <operator/repeat/translate.scad>
-
-include <operator/rotate/axis.scad>
-include <operator/rotate/origin.scad>
-
-include <operator/translate/axis.scad>
-
-include <operator/operation.scad>
-include <operator/transform.scad>
-include <operator/sample.scad>
+    translate(-offset) {
+        intersection() {
+            translate(offset) {
+                box(size, center=center);
+            }
+            children();
+        }
+    }
+}


### PR DESCRIPTION
New operator module: `sample(size, offset, l, w, h, x, y, z, center)`.
Takes a sample of the scene and place it at the origin.