### PR TITLE
Feature/bezier curve

### DIFF
--- a/core.scad
+++ b/core.scad
@@ -40,6 +40,7 @@ include <core/list.scad>
 include <core/maths.scad>
 include <core/hex.scad>
 include <core/line.scad>
+include <core/bezier.scad>
 include <core/vector.scad>
 include <core/vector-2d.scad>
 include <core/vector-3d.scad>

--- a/core/bezier.scad
+++ b/core/bezier.scad
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2017 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Bezier and other parametric curves.
+ *
+ * @package core/bezier
+ * @author jsconan
+ */
+
+/**
+ * Computes the coordinates of a point along a quadratic bezier curve.
+ *
+ * @param Number t - The parametric value, which may vary from 0 to 1.
+ * @param Vector p0 - The coordinates of the 1st control point.
+ * @param Vector p1 - The coordinates of the 2nd control point.
+ * @param Vector p2 - The coordinates of the 3rd control point.
+ * @returns Vector - Returns the coordinates of the point.
+ */
+function quadraticBezierPoint(t, p0, p1, p2) =
+    let(
+        t = float(t),
+        tm1 = 1 - float(t),
+        tm12 = tm1 * tm1,
+        t2 = t * t
+    )
+    [
+        float(p0[0]) * tm12 + float(p1[0]) * 2 * t * tm1 + float(p2[0]) * t2,
+        float(p0[1]) * tm12 + float(p1[1]) * 2 * t * tm1 + float(p2[1]) * t2
+    ]
+;
+
+/**
+ * Computes the coordinates of a point along a cubic bezier curve.
+ *
+ * @param Number t - The parametric value, which may vary from 0 to 1.
+ * @param Vector p0 - The coordinates of the 1st control point.
+ * @param Vector p1 - The coordinates of the 2nd control point.
+ * @param Vector p2 - The coordinates of the 3rd control point.
+ * @param Vector p3 - The coordinates of the 4th control point.
+ * @returns Vector - Returns the coordinates of the point.
+ */
+function cubicBezierPoint(t, p0, p1, p2, p3) =
+    let(
+        t = float(t),
+        tm1 = 1 - float(t),
+        tm12 = tm1 * tm1,
+        tm13 = tm12 * tm1,
+        t2 = t * t,
+        t3 = t2 * t
+    )
+    [
+        float(p0[0]) * tm13 + float(p1[0]) * 3 * t * tm12 + float(p2[0]) * 3 * t2 * tm1 + float(p3[0]) * t3,
+        float(p0[1]) * tm13 + float(p1[1]) * 3 * t * tm12 + float(p2[1]) * 3 * t2 * tm1 + float(p3[1]) * t3
+    ]
+;

--- a/core/constants.scad
+++ b/core/constants.scad
@@ -63,6 +63,12 @@ DEFAULT_MODE = MODE_DEV;
 DEGREES = 360;
 
 /**
+ * Degrees of a right angle.
+ * @type Number
+ */
+RIGHT = 90;
+
+/**
  * Degrees of a straight angle.
  * @type Number
  */

--- a/core/constants.scad
+++ b/core/constants.scad
@@ -105,6 +105,12 @@ QUADRANT_4 = DEGREES;
 SQRT3 = sqrt(3);
 
 /**
+ * The distance tolerance that will apply to $fs to check if we still need to subdivide the curve.
+ * @type Number
+ */
+BEZIER_TOLERANCE = .25;
+
+/**
  * Minimum value for $fa and $fs.
  * @type Number
  */
@@ -127,6 +133,12 @@ EPSILON = 0.0000001;
  * @type Number
  */
 MAX_DECIMALS = 7;
+
+/**
+ * The maximum recursion depth
+ * @type Number
+ */
+MAX_RECURSE = 32;
 
 /**
  * A value utilized to align wall and ensure proper cuts on one side.

--- a/core/constants.scad
+++ b/core/constants.scad
@@ -63,6 +63,36 @@ DEFAULT_MODE = MODE_DEV;
 DEGREES = 360;
 
 /**
+ * Degrees of a straight angle.
+ * @type Number
+ */
+STRAIGHT = 180;
+
+/**
+ * The end angle of the first quadrant in a circle.
+ * @type Number
+ */
+QUADRANT_1 = 90;
+
+/**
+ * The end angle of the second quadrant in a circle.
+ * @type Number
+ */
+QUADRANT_2 = 180;
+
+/**
+ * The end angle of the third quadrant in a circle.
+ * @type Number
+ */
+QUADRANT_3 = 270;
+
+/**
+ * The end angle of the fourth quadrant in a circle.
+ * @type Number
+ */
+QUADRANT_4 = 360;
+
+/**
  * Useful value for computations based on hexagons.
  * @type Number
  */

--- a/core/constants.scad
+++ b/core/constants.scad
@@ -78,25 +78,25 @@ STRAIGHT = 180;
  * The end angle of the first quadrant in a circle.
  * @type Number
  */
-QUADRANT_1 = 90;
+QUADRANT_1 = RIGHT;
 
 /**
  * The end angle of the second quadrant in a circle.
  * @type Number
  */
-QUADRANT_2 = 180;
+QUADRANT_2 = STRAIGHT;
 
 /**
  * The end angle of the third quadrant in a circle.
  * @type Number
  */
-QUADRANT_3 = 270;
+QUADRANT_3 = DEGREES - RIGHT;
 
 /**
  * The end angle of the fourth quadrant in a circle.
  * @type Number
  */
-QUADRANT_4 = 360;
+QUADRANT_4 = DEGREES;
 
 /**
  * Useful value for computations based on hexagons.

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -60,6 +60,18 @@ function absdeg(a) =
 ;
 
 /**
+ * Ensures an angle is defined within an absolute straight angle range (0..180).
+ *
+ * @param Number a - The angle.
+ * @returns Number
+ */
+function straight(a) =
+    let( a = absdeg(a) )
+    a > STRAIGHT ? DEGREES - a
+                 : a
+;
+
+/**
  * Computes the number of fragments needed to draw a circle with the provided radius.
  *
  * @param Number [r] - The radius of the circle.

--- a/operator/distribute/rotate.scad
+++ b/operator/distribute/rotate.scad
@@ -53,7 +53,7 @@
  * @param Number [originY] - The Y origin (will overwrite the Y coordinate in the `origin` vector).
  * @param Number [originZ] - The Z origin (will overwrite the Z coordinate in the `origin` vector).
  */
-module distributeRotate(angle    = 360,
+module distributeRotate(angle    = DEGREES,
                         axis     = [0, 0, 1],
                         interval = [0, 0, 0],
                         origin   = [0, 0, 0],
@@ -64,7 +64,7 @@ module distributeRotate(angle    = 360,
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
     origin = apply3D(origin, originX, originY, originZ);
     angle = deg(angle);
-    partAngle = angle / (angle % 360 ? $children - 1 : $children);
+    partAngle = angle / (angle % DEGREES ? $children - 1 : $children);
     axis = apply3D(axis, axisX, axisY, axisZ) * partAngle;
 
     for (i = [0 : $children - 1]) {

--- a/operator/repeat/rotate.scad
+++ b/operator/repeat/rotate.scad
@@ -54,7 +54,7 @@
  * @param Number [originZ] - The Z origin (will overwrite the Z coordinate in the `origin` vector).
  */
 module repeatRotate(count    = 2,
-                    angle    = 360,
+                    angle    = DEGREES,
                     axis     = [0, 0, 1],
                     interval = [0, 0, 0],
                     origin   = [0, 0, 0],
@@ -65,7 +65,7 @@ module repeatRotate(count    = 2,
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
     origin = apply3D(origin, originX, originY, originZ);
     angle = deg(angle);
-    partAngle = angle / (angle % 360 ? count - 1 : count);
+    partAngle = angle / (angle % DEGREES ? count - 1 : count);
     axis = apply3D(axis, axisX, axisY, axisZ) * partAngle;
 
     for (i = [0 : count - 1]) {
@@ -93,8 +93,8 @@ module repeatRotate(count    = 2,
  */
 module repeatRotate2D(countX    = 2,
                       countY    = 2,
-                      angleX    = 360,
-                      angleY    = 360,
+                      angleX    = DEGREES,
+                      angleY    = DEGREES,
                       axisX     = [0, 0, 1],
                       axisY     = [0, 1, 0],
                       intervalX = [0, 0, 0],
@@ -131,9 +131,9 @@ module repeatRotate2D(countX    = 2,
 module repeatRotate3D(countX    = 2,
                       countY    = 2,
                       countZ    = 2,
-                      angleX    = 360,
-                      angleY    = 360,
-                      angleZ    = 360,
+                      angleX    = DEGREES,
+                      angleY    = DEGREES,
+                      angleZ    = DEGREES,
                       axisX     = [0, 0, 1],
                       axisY     = [0, 1, 0],
                       axisZ     = [1, 0, 0],

--- a/shape/2D/ellipse.scad
+++ b/shape/2D/ellipse.scad
@@ -113,7 +113,7 @@ function drawEllipse(r, d, rx, ry, dx, dy) =
  * @param Number [dy] - The vertical diameter.
  * @returns Vector[]
  */
-function drawPie(r, a=90, d, a1, a2, rx, ry, dx, dy) =
+function drawPie(r, a=RIGHT, d, a1, a2, rx, ry, dx, dy) =
     let (
         a1 = deg(a1),
         a2 = a2 != undef ? deg(a2) : a1 + deg(a),
@@ -154,7 +154,7 @@ module ellipse(r, d, rx, ry, dx, dy) {
  * @param Number [dx] - The horizontal diameter.
  * @param Number [dy] - The vertical diameter.
  */
-module pie(r, a=90, d, a1, a2, rx, ry, dx, dy) {
+module pie(r, a=RIGHT, d, a1, a2, rx, ry, dx, dy) {
     polygon(
         points = drawPie(r=r, a=a, d=d, a1=a1, a2=a2, rx=rx, ry=ry, dx=dx, dy=dy),
         convexity = 10
@@ -174,7 +174,7 @@ module pie(r, a=90, d, a1, a2, rx, ry, dx, dy) {
  * @param Number [dx] - The horizontal diameter.
  * @param Number [dy] - The vertical diameter.
  */
-module chord(r, a=90, d, a1, a2, rx, ry, dx, dy) {
+module chord(r, a=RIGHT, d, a1, a2, rx, ry, dx, dy) {
     polygon(
         points = arc(v=sizeEllipse(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy), a=a, a1=a1, a2=a2),
         convexity = 10

--- a/shape/2D/polygon.scad
+++ b/shape/2D/polygon.scad
@@ -83,7 +83,7 @@ function sizeTrapezium(size, a, b, w) =
 function sizeRegularPolygon(size, n, l, w, s) =
     let(
         n = max(3, float(n)),
-        size = (s && !size && !l && !w) ? vector2D(2 * divisor(s) / (2 * sin(180 / n)))
+        size = (s && !size && !l && !w) ? vector2D(2 * divisor(s) / (2 * sin(STRAIGHT / n)))
                                         : apply2D(size, l, w)
     )
     [
@@ -180,7 +180,7 @@ function drawRegularPolygon(size, n, l, w, s) =
     )
     [
         for(i = [0 : n - 1])
-            arcp(radius, i * step + 90)
+            arcp(radius, i * step + RIGHT)
     ]
 ;
 
@@ -250,7 +250,7 @@ function drawStar(size, core, edges, l, w, cl, cw) =
             let(
                 e = floor(i / 2),
                 m = i % 2,
-                a = angle * e + (m ? step : 0) + 90
+                a = angle * e + (m ? step : 0) + RIGHT
             )
             [
                 cos(a) * (m ? inner[0] : outer[0]),

--- a/shape/2D/rounded.scad
+++ b/shape/2D/rounded.scad
@@ -170,9 +170,9 @@ function sizeRoundedCorner(size, r, d, p, convex) =
         B = [s, 0],
         C = S ? (convex ? [0, 0] : [ s, s ])
               : center2D(A, B, R, !convex),
-        arcAngle = S ? 90 : angle2D(C - A, C - B),
+        arcAngle = S ? RIGHT : angle2D(C - A, C - B),
         cornerAngle = absdeg(round(atan2(p[1], p[0]) - 45)),
-        startAngle = absdeg(cornerAngle + (convex ? 0 : 180) + (90 - arcAngle) / 2)
+        startAngle = absdeg(cornerAngle + (convex ? 0 : STRAIGHT) + (RIGHT - arcAngle) / 2)
     )
     [ vector2D(s), vector2D(R), rotp(C, cornerAngle), cornerAngle, startAngle, arcAngle ]
 ;
@@ -199,7 +199,7 @@ function drawArch(size, r, d, w, h, rx, ry, dx, dy) =
         center = [
             0, size[1] - radius[1]
         ],
-        points = arc(r=radius, o=center, a=180)
+        points = arc(r=radius, o=center, a=STRAIGHT)
     )
     center == [0, 0] ? points
    :complete(points, [radius[0], 0], -[radius[0], 0])
@@ -229,7 +229,7 @@ function drawStadium(size, r, d, w, h, rx, ry, dx, dy) =
         ]
     )
     center == [0, 0] ? arc(r=radius)
-   :concat(arc(r=radius, o=center, a=180), arc(r=radius, o=-center, a=-180))
+   :concat(arc(r=radius, o=center, a=STRAIGHT), arc(r=radius, o=-center, a=-STRAIGHT))
 ;
 
 /**
@@ -261,10 +261,10 @@ function drawRoundedRectangle(size, r, d, w, h, rx, ry, dx, dy) =
     radius == [0, 0] ? [ [right, top], [-right, top], [-right, -top], [right, -top] ]
    :center == [0, 0] ? arc(r=radius)
    :concat(
-       arc(r=radius, o=center, a1=0, a2=90),
-       arc(r=radius, o=[-center[0], center[1]], a1=90, a2=180),
-       arc(r=radius, o=[-center[0], -center[1]], a1=180, a2=270),
-       arc(r=radius, o=[center[0], -center[1]], a1=270, a2=360)
+       arc(r=radius, o=center, a1=0, a2=QUADRANT_1),
+       arc(r=radius, o=[-center[0], center[1]], a1=QUADRANT_1, a2=QUADRANT_2),
+       arc(r=radius, o=[-center[0], -center[1]], a1=QUADRANT_2, a2=QUADRANT_3),
+       arc(r=radius, o=[center[0], -center[1]], a1=QUADRANT_3, a2=QUADRANT_4)
    )
 ;
 

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -89,7 +89,7 @@ function sizeTrapeziumBox(size, a, b, w, h) =
 function sizeRegularPolygonBox(size, n, l, w, h, s) =
     let(
         n = max(3, float(n)),
-        size = (s && !size && !l && !w) ? vector3D(2 * divisor(s) / (2 * sin(180 / n)))
+        size = (s && !size && !l && !w) ? vector3D(2 * divisor(s) / (2 * sin(STRAIGHT / n)))
                                         : apply3D(size, l, w, h)
     )
     [

--- a/shape/3D/rounded.scad
+++ b/shape/3D/rounded.scad
@@ -309,7 +309,7 @@ function drawBullet(size, r, d, l, w, h, rx, ry, dx, dy) =
         center = [
             0, size[2] - radius[1]
         ],
-        points = arc(r=radius, o=center, a=90)
+        points = arc(r=radius, o=center, a=RIGHT)
     )
     complete(points, [radius[0], 0], [0, 0])
 ;
@@ -338,10 +338,10 @@ function drawPill(size, r, d, l, w, h, rx, ry, dx, dy) =
             0, size[2] / 2 - radius[1]
         ]
     )
-    center == [0, 0] ? arc(r=radius, a1=-90, a2=90)
+    center == [0, 0] ? arc(r=radius, a1=-RIGHT, a2=RIGHT)
    :concat(
-        arc(r=radius, o=-center, a=-90),
-        arc(r=radius, o=center, a=90)
+        arc(r=radius, o=-center, a=-RIGHT),
+        arc(r=radius, o=center, a=RIGHT)
     )
 ;
 
@@ -373,11 +373,11 @@ function drawPeg(size, r, d, l, w, h, rx, ry, dx, dy) =
         ]
     )
     radius == [0, 0] ? [ [right, top], [0, top], [0, -top], [right, -top] ]
-   :center == [0, 0] ? arc(r=radius, a1=-90, a2=90)
+   :center == [0, 0] ? arc(r=radius, a1=-RIGHT, a2=RIGHT)
    :complete(
         concat(
-            arc(r=radius, o=[center[0], -center[1]], a1=270, a2=360),
-            arc(r=radius, o=center, a1=0, a2=90)
+            arc(r=radius, o=[center[0], -center[1]], a1=QUADRANT_3, a2=QUADRANT_4),
+            arc(r=radius, o=center, a1=0, a2=QUADRANT_1)
         ),
         [0, -top],
         [0, top]
@@ -407,7 +407,7 @@ function drawPlate(size, r, d, w, h, rx, ry, dx, dy) =
         center = [
             max(size[0], size[1]) / 2 - radius[0], 0
         ],
-        points = arc(r=radius, o=center, a1=-90, a2=90)
+        points = arc(r=radius, o=center, a1=-RIGHT, a2=RIGHT)
     )
     center == [0, 0] ? points
    :complete(points, -[0, radius[1]], [0, radius[1]])

--- a/test/core/bezier.scad
+++ b/test/core/bezier.scad
@@ -24,6 +24,7 @@
  */
 
 use <../../full.scad>
+include <../../core/constants.scad>
 
 /**
  * Part of the camelSCAD library.
@@ -34,7 +35,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreBezier() {
-    testPackage("core/bezier.scad", 2) {
+    testPackage("core/bezier.scad", 4) {
         // test core/bezier/quadraticBezierPoint()
         testModule("quadraticBezierPoint()", 3) {
             testUnit("no parameter", 1) {
@@ -76,6 +77,87 @@ module testCoreBezier() {
                 assertEqual(cubicBezierPoint(0.5, p0, p1, p2, p3), [(p0[0] + p1[0] * 3 + p2[0] * 3 + p3[0]) / 8, (p0[1] + p1[1] * 3 + p2[1] * 3 + p3[1]) / 8], "At t=0.5 should return the at point on the middle of the curve");
                 assertApproxEqual(cubicBezierPoint(0.8, p0, p1, p2, p3), [(p0[0] + p1[0] * 12 + p2[0] * 48 + p3[0] * 64) / 125, (p0[1] + p1[1] * 12 + p2[1] * 48 + p3[1] * 64) / 125], "At t=0.8 should return the at point on the end of the curve");
                 assertEqual(cubicBezierPoint(1, p0, p1, p2, p3), p3, "At t=1 should return the last control point");
+            }
+        }
+        // test core/bezier/quadraticBezierCurve()
+        testModule("quadraticBezierCurve()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(quadraticBezierCurve(), [[0, 0], [0, 0]], "Cannot compute a bezier curve without parameters");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(quadraticBezierCurve("1", "1"), [[0, 0], [0, 0]], "Cannot compute a bezier curve using strings");
+                assertEqual(quadraticBezierCurve(true, true), [[0, 0], [0, 0]], "Cannot compute a bezier curve using booleans");
+                assertEqual(quadraticBezierCurve([true], [true]), [[0, 0], [0, 0]], "Cannot compute a bezier curve using arrays");
+            }
+            testUnit("control points", 3) {
+                p0 = [-5, -5];
+                p1 = [-5, 5];
+                p2 = [5, 5];
+                testUnitContext("mode dirty", 3) {
+                    $fa = facetAngle(MODE_DIRTY);
+                    $fs = facetSize(MODE_DIRTY);
+                    curve = quadraticBezierCurve(p0, p1, p2);
+                    assertEqual(len(curve), 6, "Should produce 6 points");
+                    assertEqual(curve[0], p0, "The first point should be the first control point");
+                    assertEqual(curve[5], p2, "The last point should be the last control point");
+                }
+                testUnitContext("mode dev", 3) {
+                    $fa = facetAngle(MODE_DEV);
+                    $fs = facetSize(MODE_DEV);
+                    curve = quadraticBezierCurve(p0, p1, p2);
+                    assertEqual(len(curve), 10, "Should produce 10 points");
+                    assertEqual(curve[0], p0, "The first point should be the first control point");
+                    assertEqual(curve[9], p2, "The last point should be the last control point");
+                }
+                testUnitContext("mode prod", 3) {
+                    $fa = facetAngle(MODE_PROD);
+                    $fs = facetSize(MODE_PROD);
+                    curve = quadraticBezierCurve(p0, p1, p2);
+                    assertEqual(len(curve), 18, "Should produce 18 points");
+                    assertEqual(curve[0], p0, "The first point should be the first control point");
+                    assertEqual(curve[17], p2, "The last point should be the last control point");
+                }
+            }
+        }
+        // test core/bezier/cubicBezierCurve()
+        testModule("cubicBezierCurve()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(cubicBezierCurve(), [[0, 0], [0, 0]], "Cannot compute a bezier curve without parameters");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(cubicBezierCurve("1", "1"), [[0, 0], [0, 0]], "Cannot compute a bezier curve using strings");
+                assertEqual(cubicBezierCurve(true, true), [[0, 0], [0, 0]], "Cannot compute a bezier curve using booleans");
+                assertEqual(cubicBezierCurve([true], [true]), [[0, 0], [0, 0]], "Cannot compute a bezier curve using arrays");
+            }
+            testUnit("control points", 3) {
+                p0 = [-5, -5];
+                p1 = [-5, 5];
+                p2 = [5, 5];
+                p3 = [5, -5];
+                testUnitContext("mode dirty", 3) {
+                    $fa = facetAngle(MODE_DIRTY);
+                    $fs = facetSize(MODE_DIRTY);
+                    curve = cubicBezierCurve(p0, p1, p2, p3);
+                    assertEqual(len(curve), 10, "Should produce 10 points");
+                    assertEqual(curve[0], p0, "The first point should be the first control point");
+                    assertEqual(curve[9], p3, "The last point should be the last control point");
+                }
+                testUnitContext("mode dev", 3) {
+                    $fa = facetAngle(MODE_DEV);
+                    $fs = facetSize(MODE_DEV);
+                    curve = cubicBezierCurve(p0, p1, p2, p3);
+                    assertEqual(len(curve), 18, "Should produce 18 points");
+                    assertEqual(curve[0], p0, "The first point should be the first control point");
+                    assertEqual(curve[17], p3, "The last point should be the last control point");
+                }
+                testUnitContext("mode prod", 3) {
+                    $fa = facetAngle(MODE_PROD);
+                    $fs = facetSize(MODE_PROD);
+                    curve = cubicBezierCurve(p0, p1, p2, p3);
+                    assertEqual(len(curve), 34, "Should produce 34 points");
+                    assertEqual(curve[0], p0, "The first point should be the first control point");
+                    assertEqual(curve[33], p3, "The last point should be the last control point");
+                }
             }
         }
     }

--- a/test/core/bezier.scad
+++ b/test/core/bezier.scad
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2017 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+use <../../full.scad>
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Unit tests: Bezier and other parametric curves.
+ *
+ * @package test/core/bezier
+ * @author jsconan
+ */
+module testCoreBezier() {
+    testPackage("core/bezier.scad", 2) {
+        // test core/bezier/quadraticBezierPoint()
+        testModule("quadraticBezierPoint()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(quadraticBezierPoint(), [0,0], "Cannot compute a bezier point without parameters");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(quadraticBezierPoint("1", "1"), [0, 0], "Cannot compute a bezier point using strings");
+                assertEqual(quadraticBezierPoint(true, true), [0, 0], "Cannot compute a bezier point using booleans");
+                assertEqual(quadraticBezierPoint([1], [true]), [0, 0], "Cannot compute a bezier point using vectors");
+            }
+            testUnit("control points", 5) {
+                p0 = [-5, -5];
+                p1 = [0, 5];
+                p2 = [5, 5];
+                assertEqual(quadraticBezierPoint(0, p0, p1, p2), p0, "At t=0 should return the first control point");
+                assertApproxEqual(quadraticBezierPoint(0.2, p0, p1, p2), [(p0[0] * 16 + p1[0] * 8 + p2[0]) / 25, (p0[1] * 16 + p1[1] * 8 + p2[1]) / 25], "At t=0.2 should return the at point on the beginning of the curve");
+                assertEqual(quadraticBezierPoint(0.5, p0, p1, p2), [(p0[0] + p1[0] * 2 + p2[0]) / 4, (p0[1] + p1[1] * 2 + p2[1]) / 4], "At t=0.5 should return the at point on the middle of the curve");
+                assertApproxEqual(quadraticBezierPoint(0.8, p0, p1, p2), [(p0[0] + p1[0] * 8 + p2[0] * 16) / 25, (p0[1] + p1[1] * 8 + p2[1] * 16) / 25], "At t=0.8 should return the at point on the end of the curve");
+                assertEqual(quadraticBezierPoint(1, p0, p1, p2), p2, "At t=1 should return the last control point");
+            }
+        }
+        // test core/bezier/cubicBezierPoint()
+        testModule("cubicBezierPoint()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(cubicBezierPoint(), [0,0], "Cannot compute a bezier point without parameters");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(cubicBezierPoint("1", "1"), [0, 0], "Cannot compute a bezier point using strings");
+                assertEqual(cubicBezierPoint(true, true), [0, 0], "Cannot compute a bezier point using booleans");
+                assertEqual(cubicBezierPoint([1], [true]), [0, 0], "Cannot compute a bezier point using vectors");
+            }
+            testUnit("control points", 5) {
+                p0 = [-5, -5];
+                p1 = [-5, 5];
+                p2 = [5, 5];
+                p3 = [5, -5];
+                assertEqual(cubicBezierPoint(0, p0, p1, p2, p3), p0, "At t=0 should return the first control point");
+                assertApproxEqual(cubicBezierPoint(0.2, p0, p1, p2, p3), [(p0[0] * 64 + p1[0] * 48 + p2[0] * 12 + p3[0]) / 125, (p0[1] * 64 + p1[1] * 48 + p2[1] * 12 + p3[1]) / 125], "At t=0.2 should return the at point on the beginning of the curve");
+                assertEqual(cubicBezierPoint(0.5, p0, p1, p2, p3), [(p0[0] + p1[0] * 3 + p2[0] * 3 + p3[0]) / 8, (p0[1] + p1[1] * 3 + p2[1] * 3 + p3[1]) / 8], "At t=0.5 should return the at point on the middle of the curve");
+                assertApproxEqual(cubicBezierPoint(0.8, p0, p1, p2, p3), [(p0[0] + p1[0] * 12 + p2[0] * 48 + p3[0] * 64) / 125, (p0[1] + p1[1] * 12 + p2[1] * 48 + p3[1] * 64) / 125], "At t=0.8 should return the at point on the end of the curve");
+                assertEqual(cubicBezierPoint(1, p0, p1, p2, p3), p3, "At t=1 should return the last control point");
+            }
+        }
+    }
+}
+
+testCoreBezier();

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 10) {
+    testPackage("core/maths.scad", 11) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -81,6 +81,30 @@ module testCoreMaths() {
                 assertEqual(absdeg(720), 360, "720 degrees should be converted to 360");
                 assertEqual(absdeg(-420), 300, "-420 degrees should be converted to 300");
                 assertEqual(absdeg(420), 60, "420 degrees should be converted to 60");
+            }
+        }
+        // test core/maths/straight()
+        testModule("straight()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(straight(), 0, "Without parameter the function should return 0");
+            }
+            testUnit("wrong type", 5) {
+                assertEqual(straight("10"), 0, "A string should be converted to 0");
+                assertEqual(straight(true), 0, "A boolean should be converted to 0");
+                assertEqual(straight([]), 0, "An empty array should be converted to 0");
+                assertEqual(straight(["1"]), 0, "An array should be converted to 0");
+                assertEqual(straight([1]), 0, "A vector should be converted to 0");
+            }
+            testUnit("number", 9) {
+                assertEqual(straight(0), 0, "0 degree should be converted to 0");
+                assertEqual(straight(-10), 10, "-10 degrees should be converted to 10");
+                assertEqual(straight(10), 10, "10 degrees should be converted to 10");
+                assertEqual(straight(-360), 0, "-360 degrees should be converted to 180");
+                assertEqual(straight(360), 0, "360 degrees should be converted to 0");
+                assertEqual(straight(-720), 0, "-720 degrees should be converted to 180");
+                assertEqual(straight(720), 0, "720 degrees should be converted to 0");
+                assertEqual(straight(-420), 60, "-420 degrees should be converted to 60");
+                assertEqual(straight(420), 60, "420 degrees should be converted to 60");
             }
         }
         // test core/maths/fragments()

--- a/test/suite.scad
+++ b/test/suite.scad
@@ -39,6 +39,7 @@ use <core/list.scad>
 use <core/maths.scad>
 use <core/hex.scad>
 use <core/line.scad>
+use <core/bezier.scad>
 use <core/vector.scad>
 use <core/vector-2d.scad>
 use <core/vector-3d.scad>
@@ -67,6 +68,7 @@ testCoreList();
 testCoreMaths();
 testCoreHex();
 testCoreLine();
+testCoreBezier();
 testCoreVector();
 testCoreVector2D();
 testCoreVector3D();


### PR DESCRIPTION
Add bezier curves functions:
- `quadraticBezierPoint()`: computes the coordinates of a point along a quadratic bezier curve.
- `cubicBezierPoint()`: computes the coordinates of a point along a cubic bezier curve.
- `quadraticBezierCurve()`: computes the coordinates of a quadratic bezier curve.
- `cubicBezierCurve()`: computes the coordinates of a cubic bezier curve.

Add core function `straight()` that ensures an angle is defined within an absolute straight angle range (0..180).

Add constants for circle quadrants and more.