### PR TITLE
Feature/maths polygon

### DIFF
--- a/core/line.scad
+++ b/core/line.scad
@@ -132,13 +132,13 @@ function cosinusoid(l, w, h, p, o, a) =
  * start from the absolute origin ([0, 0]), unless the first command is a point.
  *
  * The following commands are recognized:
- * - P, Point: ["P", <x>, <y>] - Adds an point at the given absolute coordinates.
- * - L, Line: ["L", <x>, <y>] - Adds a line from the last point to the given relative coordinates.
+ * - P, Point: ["P", <x>, <y>] | ["P", <point>] - Adds a point at the given absolute coordinates.
+ * - L, Line: ["L", <x>, <y>] | ["L", <point>] - Adds a line from the last point to the given relative coordinates.
  * - H, Horizontal line: ["H", <length>] - Adds an horizontal line from the last point with the given length. The sign of the length determines the direction.
  * - V, Vertical line: ["V", <length>] - Adds a vertical line from the last point with the given length. The sign of the length determines the direction.
  * - I, Intersection: ["I", <P1>, <P2>, <P3>] - Adds a line from the last point, that pass through P1 and intersects with the line defined by P2 and P3.
- * - T, Tangent: ["T", <x>, <y>, <radius>] - Adds a line from the last point, that ends at the tangent point with the defined circle.
- * - A, Angle: ["A", <angle>, <length>] - Adds a leaned line from the last point with the given angle and the given length The sign of the length determines the direction.
+ * - T, Tangent: ["T", <x>, <y>, <radius>] | ["T", <point>, <radius>] - Adds a line from the last point, that ends at the tangent point with the defined circle. The sign of the radius determines the direction
+ * - A, Angle: ["A", <angle>, <length>] - Adds a leaned line from the last point with the given angle and the given length. The sign of the length determines the direction.
  * - C, Circle: ["C", <radius>, <start angle>, <end angle>] - Adds a circle arc from the last point with the given radius and with the given angle.
  * - B, Bezier curve: ["B", <P1>, <P2>, <P3>] - Adds a cubic bezier curve from the last point with the given control points (up to 3, the first beeing the last existing point).
  *
@@ -162,12 +162,12 @@ function path(p, points, i) =
    :let(
         values = (
             l <= 1 ? [point]
-            :cmd == "P" || cmd == "p" ? [apply2D(x=cur[1], y=cur[2])]
-            :cmd == "L" || cmd == "l" ? [point, point + apply2D(x=cur[1], y=cur[2])]
+            :cmd == "P" || cmd == "p" ? [isVector(cur[1]) ? vector2D(cur[1]) : apply2D(x=cur[1], y=cur[2])]
+            :cmd == "L" || cmd == "l" ? [point, point + (isVector(cur[1]) ? vector2D(cur[1]) : apply2D(x=cur[1], y=cur[2]))]
             :cmd == "H" || cmd == "h" ? [point, point + apply2D(x=cur[1])]
             :cmd == "V" || cmd == "v" ? [point, point + apply2D(y=cur[1])]
-            :cmd == "I" || cmd == "i" ? [point, intersect2D(point, vector2D(cur[1]), vector2D(cur[2]), vector2D(cur[3]))]
-            :cmd == "T" || cmd == "t" ? [point, tangent2D(point, apply2D(x=cur[1], y=cur[2]), float(cur[3]))]
+            :cmd == "I" || cmd == "i" ? [point, intersect2D(point, cur[1], cur[2], cur[3])]
+            :cmd == "T" || cmd == "t" ? let(isv = isVector(cur[1])) [point, tangent2D(point, isv ? cur[1] : apply2D(x=cur[1], y=cur[2]), isv ? cur[2] : cur[3])]
             :cmd == "A" || cmd == "a" ? [point, point + arcPoint(a=cur[1], r=cur[2])]
             :cmd == "C" || cmd == "c" ? arc(r=cur[1], a1=cur[2], a2=cur[3], o=point + arcPoint(a=float(cur[2]) + STRAIGHT, r=cur[1]))
             :cmd == "B" || cmd == "b" ? (

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -130,6 +130,25 @@ function apothem(n, r, l) =
 ;
 
 /**
+ * Computes the radius of a circle circumscribing a regular N-sides polygon.
+ * The circumradius can be computed either from the apothem or the side of the
+ * circumscribed polygon. Only one of these values is required, if both are
+ * provided, the apothem is predominant.
+ *
+ * @param Number n - The number of sides (min 3).
+ * @param Number [a] - The apothem of the regular polygon.
+ * @param Number [l] - The length of a side of the polygon.
+ * @returns Number
+ */
+function circumradius(n, a, l) =
+    let (
+        n = max(float(n), 3),
+        a = a ? float(a) : float(l) / (2 * tan(STRAIGHT / n))
+    )
+    a / cos(STRAIGHT / n)
+;
+
+/**
  * Computes the factorial of N.
  *
  * @param Number n

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -109,6 +109,27 @@ function pythagore(a, b, c) =
 ;
 
 /**
+ * Computes the apothem of a regular N-sides polygon.
+ * An apothem is a line from the center of a regular polygon at right angles
+ * to any of its sides.
+ * The apothem can be computed either from the radius of the inscribed circle
+ * or from the length of one side. Only one of these values is required, if
+ * both are provided, the radius is predominant.
+ *
+ * @param Number n - The number of sides (min 3).
+ * @param Number [r] - The radius of the inscribed circle.
+ * @param Number [a] - The length of a side.
+ * @returns Number
+ */
+function apothem(n, r, a) =
+    let (
+        n = max(float(n), 3)
+    )
+    r ? float(r) * cos(PI / n)
+      : float(a) / 2 * tan(PI / n)
+;
+
+/**
  * Computes the factorial of N.
  *
  * @param Number n

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -118,15 +118,15 @@ function pythagore(a, b, c) =
  *
  * @param Number n - The number of sides (min 3).
  * @param Number [r] - The radius of the inscribed circle.
- * @param Number [a] - The length of a side.
+ * @param Number [l] - The length of a side of the polygon.
  * @returns Number
  */
-function apothem(n, r, a) =
+function apothem(n, r, l) =
     let (
         n = max(float(n), 3)
     )
-    r ? float(r) * cos(PI / n)
-      : float(a) / 2 * tan(PI / n)
+    r ? float(r) * cos(STRAIGHT / n)
+      : float(l) / (2 * tan(STRAIGHT / n))
 ;
 
 /**

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -202,26 +202,32 @@ function center2D(a, b, r, negative) =
 ;
 
 /**
- * Checks if two line are parallels.
- * Each line is defined by two points.
+ * Computes a parallel line. The source line is defined by two points.
+ * The parallel line will be defined by two other points translated by
+ * the provided distance.
  *
- * @param Vector a - The first point on the first line.
- * @param Vector b - The second point on the first line.
- * @param Vector c - The first point on the second line.
- * @param Vector d - The second point on the second line.
- * @returns Boolean
+ * @param Vector a - The first point on the line.
+ * @param Vector b - The second point on the line.
+ * @param Number d - The distance to the parallel line. The sign determines the direction
+ * @returns Vector[]
  */
-function parallel2D(a, b, c, d) =
+function parallel2D(a, b, d) =
     let(
-        i = vector2D(b) - vector2D(a),
-        j = vector2D(d) - vector2D(c)
+        a = vector2D(a),
+        b = vector2D(b),
+        v = normal(unit2D(b - a)),
+        d = float(d)
     )
-    i[0] * j[1] - i[1] * j[0] == 0
+    [
+        a + v * d,
+        b + v * d
+    ]
 ;
 
 /**
  * Computes the point at the intersection of two lines.
  * Each line is defined by two points.
+ * If the lines cannot intersect (i.e. are parallel), returns the first point.
  *
  * @param Vector a - The first point on the first line.
  * @param Vector b - The second point on the first line.

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -196,17 +196,19 @@ module testCoreLine() {
                 assertEqual(path(true, true), [true], "Cannot build a line using booleans");
                 assertEqual(path(1, 1), [1], "Cannot build a line using numbers");
             }
-            testUnit("path only", 52) {
+            testUnit("path only", 55) {
                 // point
                 assertEqual(path([["P"]]), [[0, 0]], "Path with 1 empty point");
-                assertEqual(path([["P", 10, 20]]), [[10, 20]], "Path with 1 absolute point");
+                assertEqual(path([["P", 10, 20]]), [[10, 20]], "Path with 1 absolute point, using coordinates");
+                assertEqual(path([["P", [10, 20]]]), [[10, 20]], "Path with 1 absolute point, using point value");
                 assertEqual(path([["P", 10, 20], ["P"]]), [[10, 20]], "Path with 1 absolute point and 1 empty point");
                 assertEqual(path([["P", 10, 20], ["P", 0, 5]]), [[10, 20], [0, 5]], "Path with 2 absolute points");
                 assertEqual(path([["P", 10, 20], ["P", 0, 5], ["P", 7, 4]]), [[10, 20], [0, 5], [7, 4]], "Path with 3 absolute points");
 
                 // line
                 assertEqual(path([["L"]]), [[0, 0]], "Path with 1 empty line");
-                assertEqual(path([["L", 10, 20]]), [[0, 0], [10, 20]], "Path with 1 line");
+                assertEqual(path([["L", 10, 20]]), [[0, 0], [10, 20]], "Path with 1 line, using coordinates");
+                assertEqual(path([["L", [10, 20]]]), [[0, 0], [10, 20]], "Path with 1 line, using point value");
                 assertEqual(path([["P", 5, 6], ["L", 10, 20]]), [[5, 6], [15, 26]], "Path with 1 line from an absolute point");
                 assertEqual(path([["P", 5, 6], ["L"]]), [[5, 6]], "Path with 1 empty line from an absolute point");
 
@@ -230,7 +232,8 @@ module testCoreLine() {
 
                 // tangent line
                 assertEqual(path([["T"]]), [[0, 0]], "Path with 1 empty tangent line");
-                assertEqual(path([["T", 8, 6, 2]]), [[0, 0], arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line");
+                assertEqual(path([["T", 8, 6, 2]]), [[0, 0], arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line, using coordinates");
+                assertEqual(path([["T", [8, 6], 2]]), [[0, 0], arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line, using point value");
                 assertEqual(path([["P", 11, 5], ["T", 19, 11, 2]]), [[11, 5], [11, 5] + arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line from an absolute point");
                 assertEqual(path([["P", 5, 6], ["T"]]), [[5, 6]], "Path with 1 empty tangent line from an absolute point");
 

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -334,26 +334,30 @@ module testCoreMaths() {
                 assertEqual(apothem(["1"], ["2"]), 0, "Arrays should be converted to 0");
                 assertEqual(apothem([1], [2]), 0, "Vectors should be converted to 0");
             }
-            testUnit("number", 15) {
+            testUnit("number", 18) {
                 assertEqual(apothem(0), 0, "If the only one parameter is 0, the function should not fail, but should return 0");
-                assertEqual(apothem(0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
+                assertEqual(apothem(0, 0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
 
-                assertEqual(apothem(r=8), 8 * cos(PI / 3), "If only the radius is provided, the function should compute the apothem of a triangle");
-                assertEqual(apothem(a=8), 8 / 2 * tan(PI / 3), "If only the lenght of a side is provided, the function should compute the apothem of a triangle");
+                assertEqual(apothem(r=8), 8 * cos(60), "If only the radius is provided, the function should compute the apothem of a triangle");
+                assertEqual(apothem(l=8), 8 / (2 * tan(60)), "If only the length of a side is provided, the function should compute the apothem of a triangle");
                 assertEqual(apothem(n=8), 0, "If only the number of sides is provided, the function cannot compute the result");
 
-                assertEqual(apothem(n=4, r=8), 8 * cos(PI / 4), "Apothem of a square, using the radius");
-                assertEqual(apothem(n=5, r=8), 8 * cos(PI / 5), "Apothem of a pentagon, using the radius");
-                assertEqual(apothem(n=6, r=8), 8 * cos(PI / 6), "Apothem of an hexagon, using the radius");
-                assertEqual(apothem(n=8, r=8), 8 * cos(PI / 8), "Apothem of an octogon, using the radius");
+                assertEqual(apothem(r=8, n=4), 8 * cos(45), "Apothem of a square, using the radius");
+                assertEqual(apothem(r=8, n=5), 8 * cos(36), "Apothem of a pentagon, using the radius");
+                assertEqual(apothem(r=8, n=6), 8 * cos(30), "Apothem of an hexagon, using the radius");
+                assertEqual(apothem(r=8, n=8), 8 * cos(22.5), "Apothem of an octogon, using the radius");
 
-                assertEqual(apothem(n=4, a=8), 8 / 2 * tan(PI / 4), "Apothem of a square, using the side");
-                assertEqual(apothem(n=5, a=8), 8 / 2 * tan(PI / 5), "Apothem of a pentagon, using the side");
-                assertEqual(apothem(n=6, a=8), 8 / 2 * tan(PI / 6), "Apothem of an hexagon, using the side");
-                assertEqual(apothem(n=8, a=8), 8 / 2 * tan(PI / 8), "Apothem of an octogon, using the side");
+                assertEqual(apothem(l=8, n=4), 8 / (2 * tan(45)), "Apothem of a square, using the side");
+                assertEqual(apothem(l=8, n=5), 8 / (2 * tan(36)), "Apothem of a pentagon, using the side");
+                assertEqual(apothem(l=8, n=6), 8 / (2 * tan(30)), "Apothem of an hexagon, using the side");
+                assertEqual(apothem(l=8, n=8), 8 / (2 * tan(22.5)), "Apothem of an octogon, using the side");
 
-                assertEqual(apothem(6, 8), 8 * cos(PI / 6), "Apothem of an hexagon, using the default order of parameters");
-                assertEqual(apothem(6, 8, 10), 8 * cos(PI / 6), "Apothem of an hexagon, using the default order of parameters with all provided (radius should predomin)");
+                assertEqual(apothem(6, 8), 8 * cos(30), "Apothem of an hexagon, using the default order of parameters");
+                assertEqual(apothem(6, 8, 10), 8 * cos(30), "Apothem of an hexagon, using the default order of parameters with all provided (radius should predomin)");
+
+                assertEqual(apothem(n=4, r=sqrt(32) / 2), apothem(n=4, l=4), "Apothem of a square, comparing results using radius and side");
+                assertApproxEqual(apothem(n=4, l=4), 2, "Apothem of a square, comparing results and side");
+                assertApproxEqual(apothem(n=6, r=4), apothem(n=6, l=4), "Apothem of an hexagon, comparing results using radius and side");
             }
         }
         // test core/maths/factorial()

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 13) {
+    testPackage("core/maths.scad", 14) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -320,6 +320,40 @@ module testCoreMaths() {
                 assertEqual(pythagore(a=3, c=8), sqrt(64-9), "If B and C are provided the function should compute A");
                 assertEqual(pythagore(a=3, b=5, c=8), sqrt(64-9), "If A, B and C are provided the function should compute B");
 
+            }
+        }
+        // test core/maths/apothem()
+        testModule("apothem()") {
+            testUnit("no parameter", 1) {
+                assertEqual(apothem(), 0, "Without parameter the function should return 0");
+            }
+            testUnit("wrong type", 5) {
+                assertEqual(apothem("10", "10"), 0, "Strings should be converted to 0");
+                assertEqual(apothem(true, true), 0, "Booleans should be converted to 0");
+                assertEqual(apothem([], []), 0, "Empty arrays should be converted to 0");
+                assertEqual(apothem(["1"], ["2"]), 0, "Arrays should be converted to 0");
+                assertEqual(apothem([1], [2]), 0, "Vectors should be converted to 0");
+            }
+            testUnit("number", 15) {
+                assertEqual(apothem(0), 0, "If the only one parameter is 0, the function should not fail, but should return 0");
+                assertEqual(apothem(0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
+
+                assertEqual(apothem(r=8), 8 * cos(PI / 3), "If only the radius is provided, the function should compute the apothem of a triangle");
+                assertEqual(apothem(a=8), 8 / 2 * tan(PI / 3), "If only the lenght of a side is provided, the function should compute the apothem of a triangle");
+                assertEqual(apothem(n=8), 0, "If only the number of sides is provided, the function cannot compute the result");
+
+                assertEqual(apothem(n=4, r=8), 8 * cos(PI / 4), "Apothem of a square, using the radius");
+                assertEqual(apothem(n=5, r=8), 8 * cos(PI / 5), "Apothem of a pentagon, using the radius");
+                assertEqual(apothem(n=6, r=8), 8 * cos(PI / 6), "Apothem of an hexagon, using the radius");
+                assertEqual(apothem(n=8, r=8), 8 * cos(PI / 8), "Apothem of an octogon, using the radius");
+
+                assertEqual(apothem(n=4, a=8), 8 / 2 * tan(PI / 4), "Apothem of a square, using the side");
+                assertEqual(apothem(n=5, a=8), 8 / 2 * tan(PI / 5), "Apothem of a pentagon, using the side");
+                assertEqual(apothem(n=6, a=8), 8 / 2 * tan(PI / 6), "Apothem of an hexagon, using the side");
+                assertEqual(apothem(n=8, a=8), 8 / 2 * tan(PI / 8), "Apothem of an octogon, using the side");
+
+                assertEqual(apothem(6, 8), 8 * cos(PI / 6), "Apothem of an hexagon, using the default order of parameters");
+                assertEqual(apothem(6, 8, 10), 8 * cos(PI / 6), "Apothem of an hexagon, using the default order of parameters with all provided (radius should predomin)");
             }
         }
         // test core/maths/factorial()

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 14) {
+    testPackage("core/maths.scad", 15) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -358,6 +358,49 @@ module testCoreMaths() {
                 assertEqual(apothem(n=4, r=sqrt(32) / 2), apothem(n=4, l=4), "Apothem of a square, comparing results using radius and side");
                 assertApproxEqual(apothem(n=4, l=4), 2, "Apothem of a square, comparing results and side");
                 assertApproxEqual(apothem(n=6, r=4), apothem(n=6, l=4), "Apothem of an hexagon, comparing results using radius and side");
+            }
+        }
+        // test core/maths/circumradius()
+        testModule("circumradius()") {
+            testUnit("no parameter", 1) {
+                assertEqual(circumradius(), 0, "Without parameter the function should return 0");
+            }
+            testUnit("wrong type", 5) {
+                assertEqual(circumradius("10", "10"), 0, "Strings should be converted to 0");
+                assertEqual(circumradius(true, true), 0, "Booleans should be converted to 0");
+                assertEqual(circumradius([], []), 0, "Empty arrays should be converted to 0");
+                assertEqual(circumradius(["1"], ["2"]), 0, "Arrays should be converted to 0");
+                assertEqual(circumradius([1], [2]), 0, "Vectors should be converted to 0");
+            }
+            testUnit("number", 22) {
+                assertEqual(circumradius(0), 0, "If the only one parameter is 0, the function should not fail, but should return 0");
+                assertEqual(circumradius(0, 0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
+
+                assertEqual(circumradius(a=8), 8 / cos(60), "If only the length is provided, the function should compute the circumradius of a triangle");
+                assertEqual(circumradius(l=8), apothem(l=8)/ cos(60), "If only the length of a side is provided, the function should compute the circumradius of a triangle");
+                assertEqual(circumradius(n=8), 0, "If only the number of sides is provided, the function cannot compute the result");
+
+                assertEqual(circumradius(a=8, n=4), 8 / cos(45), "Circumradius of a square, using the the apothem");
+                assertEqual(circumradius(a=8, n=5), 8 / cos(36), "Circumradius of a pentagon, using the the apothem");
+                assertEqual(circumradius(a=8, n=6), 8 / cos(30), "Circumradius of an hexagon, using the the apothem");
+                assertEqual(circumradius(a=8, n=8), 8 / cos(22.5), "Circumradius of an octogon, using the the apothem");
+
+                assertEqual(circumradius(l=8, n=4), apothem(l=8, n=4) / cos(45), "Circumradius of a square, using the the side");
+                assertEqual(circumradius(l=8, n=5), apothem(l=8, n=5) / cos(36), "Circumradius of a pentagon, using the the side");
+                assertEqual(circumradius(l=8, n=6), apothem(l=8, n=6) / cos(30), "Circumradius of an hexagon, using the the side");
+                assertEqual(circumradius(l=8, n=8), apothem(l=8, n=8) / cos(22.5), "Circumradius of an octogon, using the the side");
+
+                assertEqual(circumradius(6, 8), 8 / cos(30), "Circumradius of an hexagon, using the default order of parameters");
+                assertEqual(circumradius(6, 8, 10), 8 / cos(30), "Circumradius of an hexagon, using the default order of parameters with all provided (apothem should predomin)");
+
+                assertEqual(circumradius(n=6, a=apothem(n=6, l=8)), circumradius(n=6, l=8), "Circumradius of an hexagon, comparing results using apothem and side");
+                assertApproxEqual(circumradius(n=4, a=2), circumradius(n=4, l=4), "Circumradius of a square, comparing results using apothem and side");
+                assertApproxEqual(circumradius(n=6, l=4), 4, "Circumradius of an hexagon, comparing results and side");
+
+                assertEqual(circumradius(n=4, a=apothem(n=4, r=8)), 8, "Circumradius of a square, using radius of the inscribed circle");
+                assertEqual(circumradius(n=5, a=apothem(n=5, r=8)), 8, "Circumradius of a pentagon, using radius of the inscribed circle");
+                assertEqual(circumradius(n=6, a=apothem(n=6, r=8)), 8, "Circumradius of an hexagon, using radius of the inscribed circle");
+                assertEqual(circumradius(n=8, a=apothem(n=8, r=8)), 8, "Circumradius of an octogon, using radius of the inscribed circle");
             }
         }
         // test core/maths/factorial()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -323,23 +323,24 @@ module testCoreVector2D() {
         // test core/vector-2d/parallel2D()
         testModule("parallel2D()", 3) {
             testUnit("no parameter", 1) {
-                assertEqual(parallel2D(), true, "Without parameter the function should return true");
+                assertEqual(parallel2D(), [[0, 0], [0, 0]], "Without parameter the function should return the origin");
             }
             testUnit("wrong type", 4) {
-                assertEqual(parallel2D("10", "10", "10", "10"), true, "Cannot tell if strings are parallels");
-                assertEqual(parallel2D(true, true, true, true), true, "Cannot tell if boolean are parallels");
-                assertEqual(parallel2D([], [], [], []), true, "Cannot tell if empty arrays are parallels");
-                assertEqual(parallel2D(["1"], ["2"], ["3"], ["4"]), true, "Cannot tell if arrays are parallels");
+                assertEqual(parallel2D("10", "10", "10"), [[0, 0], [0, 0]], "Cannot compute parallel of strings");
+                assertEqual(parallel2D(true, true, true), [[0, 0], [0, 0]], "Cannot compute parallel of boolean");
+                assertEqual(parallel2D([], [], []), [[0, 0], [0, 0]], "Cannot compute parallel of empty arrays");
+                assertEqual(parallel2D(["1"], ["2"], ["3"]), [[0, 0], [0, 0]], "Cannot compute parallel of arrays");
             }
-            testUnit("check", 8) {
-                assertEqual(parallel2D(0, 1, 2, 3), true, "Numbers should be converted to vectors");
-                assertEqual(parallel2D([0, 0], [1, 1], [2, 2], [3, 3]), true, "45° positive segments");
-                assertEqual(parallel2D([0, 0], [-1, 1], [-2, 2], [-3, 3]), true, "45° negative segments");
-                assertEqual(parallel2D([0, 0], [3, 0], [1, 2], [3, 2]), true, "horizontal segments");
-                assertEqual(parallel2D([0, 0], [0, 3], [2, 1], [2, 3]), true, "vertical segments");
-                assertEqual(parallel2D([4, 5], [6, 7], [2, 3], [0, 1]), true, "parallels segments");
-                assertEqual(parallel2D([4, 5], [8, 7], [2, 3], [5, 1]), false, "not parallels segments");
-                assertEqual(parallel2D([0, 0], [3, 0], [1, 2], [1, 4]), false, "perpendicular segments");
+            testUnit("check", 9) {
+                assertApproxEqual(parallel2D(0, 1, 2), [[-2 * cos(135), -2 * sin(135)], [1 - 2 * cos(135), 1 - 2 * sin(135)]], "Numbers should be converted to vectors");
+                assertApproxEqual(parallel2D([0, 0], [1, 1], 2), [[-2 * cos(135), -2 * sin(135)], [1 - 2 * cos(135), 1 - 2 * sin(135)]], "45° positive line with a distance of 2");
+                assertApproxEqual(parallel2D([0, 0], [1, 1], -2), [[2 * cos(135), 2 * sin(135)], [1 + 2 * cos(135), 1 + 2 * sin(135)]], "45° positive line with a distance of -2");
+                assertApproxEqual(parallel2D([0, 0], [-1, -1], 2), [[2 * cos(135), 2 * sin(135)], [-1 + 2 * cos(135), -1 + 2 * sin(135)]], "45° negative line with a distance of 2");
+                assertApproxEqual(parallel2D([0, 0], [-1, -1], -2), [[-2 * cos(135), -2 * sin(135)], [-1 - 2 * cos(135), -1 - 2 * sin(135)]], "45° negative line with a distance of -2");
+                assertEqual(parallel2D([0, 2], [3, 2], 3), [[0, -1], [3, -1]], "horizontal line with a distance of 3");
+                assertEqual(parallel2D([0, 2], [3, 2], -3), [[0, 5], [3, 5]], "horizontal line with a distance of -3");
+                assertEqual(parallel2D([4, -2], [4, 8], 3), [[7, -2], [7, 8]], "vertical line with a distance of 3");
+                assertEqual(parallel2D([4, -2], [4, 8], -3), [[1, -2], [1, 8]], "vertical line with a distance of -3");
             }
         }
         // test core/vector-2d/intersect2D()


### PR DESCRIPTION
Add core functions that compute relations between circles and regular polygons:
- `apothem()`: Computes the apothem of a regular N-sides polygon. An apothem is a line from the center of a regular polygon at right angles to any of its sides.
- `circumradius()`: Computes the radius of a circle circumscribing a regular N-sides polygon.

Change the core function `parallel2D()` to compute a parallel line instead of checking if two lines are parallels.

Improve the core function `path()` to accept either points or separated coordinates in commands `P`, `L`,  and `T`.