### PR TITLE
Release 0.5.0

### DIFF
--- a/core/line.scad
+++ b/core/line.scad
@@ -134,6 +134,8 @@ function cosinusoid(l, w, h, p, o, a) =
  * - L, Line: ["L", <x>, <y>] - Adds a line from the last point to the given relative coordinates.
  * - H, Horizontal line: ["H", <length>] - Adds an horizontal line from the last point with the given length. The sign of the length determines the direction.
  * - V, Vertical line: ["V", <length>] - Adds a vertical line from the last point with the given length. The sign of the length determines the direction.
+ * - I, Intersection: ["I", <P1>, <P2>, <P3>] - Adds a line from the last point, that pass through P1 and intersects with the line defined by P2 and P3.
+ * - T, Tangent: ["T", <x>, <y>, <radius>] - Adds a line from the last point, that ends at the tangent point with the defined circle.
  * - A, Angle: ["A", <angle>, <length>] - Adds a leaned line from the last point with the given angle and the given length The sign of the length determines the direction.
  * - C, Circle: ["C", <radius>, <start angle>, <end angle>] - Adds a circle arc from the last point with the given radius and with the given angle.
  * - B, Bezier curve: ["B", <P1>, <P2>, <P3>] - Adds a cubic bezier curve from the last point with the given control points (up to 3, the first beeing the last existing point).
@@ -162,6 +164,8 @@ function path(p, points, i) =
             :cmd == "L" || cmd == "l" ? [point, point + apply2D(x=cur[1], y=cur[2])]
             :cmd == "H" || cmd == "h" ? [point, point + apply2D(x=cur[1])]
             :cmd == "V" || cmd == "v" ? [point, point + apply2D(y=cur[1])]
+            :cmd == "I" || cmd == "i" ? [point, intersect2D(point, vector2D(cur[1]), vector2D(cur[2]), vector2D(cur[3]))]
+            :cmd == "T" || cmd == "t" ? [point, tangent2D(point, apply2D(x=cur[1], y=cur[2]), float(cur[3]))]
             :cmd == "A" || cmd == "a" ? [point, point + arcPoint(a=cur[1], r=cur[2])]
             :cmd == "C" || cmd == "c" ? arc(r=cur[1], a1=cur[2], a2=cur[3], o=point + arcPoint(a=float(cur[2]) + STRAIGHT, r=cur[1]))
             :cmd == "B" || cmd == "b" ? (

--- a/core/line.scad
+++ b/core/line.scad
@@ -53,16 +53,18 @@ function arc(r, a=DEGREES, o, a1, a2) =
    :let(
         start = min(a1, a2),
         end = max(a1, a2),
-        step = astep(max(r), absdeg(end - start))
+        range = end - start,
+        step = astep(max(r), absdeg(range)),
+        inc = sign(a2 - a1) * step
     )
     complete(
         // intermediate points
-        end - start <= step ? []
-       :[ for (a = [start + step : step : end]) arcp(r, a) + o ],
+        range <= step ? []
+       :[ for (a = [a1 + inc : inc : a2]) arcp(r, a) + o ],
         // the start point
-        arcp(r, start) + o,
+        arcp(r, a1) + o,
         // the final point
-        arcp(r, end) + o
+        arcp(r, a2) + o
     )
 ;
 

--- a/core/line.scad
+++ b/core/line.scad
@@ -132,13 +132,13 @@ function cosinusoid(l, w, h, p, o, a) =
  * start from the absolute origin ([0, 0]), unless the first command is a point.
  *
  * The following commands are recognized:
- * - P, Point: ["P", <x>, <y>] - Adds an point at the given absolute coordinates.
- * - L, Line: ["L", <x>, <y>] - Adds a line from the last point to the given relative coordinates.
+ * - P, Point: ["P", <x>, <y>] | ["P", <point>] - Adds a point at the given absolute coordinates.
+ * - L, Line: ["L", <x>, <y>] | ["L", <point>] - Adds a line from the last point to the given relative coordinates.
  * - H, Horizontal line: ["H", <length>] - Adds an horizontal line from the last point with the given length. The sign of the length determines the direction.
  * - V, Vertical line: ["V", <length>] - Adds a vertical line from the last point with the given length. The sign of the length determines the direction.
  * - I, Intersection: ["I", <P1>, <P2>, <P3>] - Adds a line from the last point, that pass through P1 and intersects with the line defined by P2 and P3.
- * - T, Tangent: ["T", <x>, <y>, <radius>] - Adds a line from the last point, that ends at the tangent point with the defined circle.
- * - A, Angle: ["A", <angle>, <length>] - Adds a leaned line from the last point with the given angle and the given length The sign of the length determines the direction.
+ * - T, Tangent: ["T", <x>, <y>, <radius>] | ["T", <point>, <radius>] - Adds a line from the last point, that ends at the tangent point with the defined circle. The sign of the radius determines the direction
+ * - A, Angle: ["A", <angle>, <length>] - Adds a leaned line from the last point with the given angle and the given length. The sign of the length determines the direction.
  * - C, Circle: ["C", <radius>, <start angle>, <end angle>] - Adds a circle arc from the last point with the given radius and with the given angle.
  * - B, Bezier curve: ["B", <P1>, <P2>, <P3>] - Adds a cubic bezier curve from the last point with the given control points (up to 3, the first beeing the last existing point).
  *
@@ -162,12 +162,12 @@ function path(p, points, i) =
    :let(
         values = (
             l <= 1 ? [point]
-            :cmd == "P" || cmd == "p" ? [apply2D(x=cur[1], y=cur[2])]
-            :cmd == "L" || cmd == "l" ? [point, point + apply2D(x=cur[1], y=cur[2])]
+            :cmd == "P" || cmd == "p" ? [isVector(cur[1]) ? vector2D(cur[1]) : apply2D(x=cur[1], y=cur[2])]
+            :cmd == "L" || cmd == "l" ? [point, point + (isVector(cur[1]) ? vector2D(cur[1]) : apply2D(x=cur[1], y=cur[2]))]
             :cmd == "H" || cmd == "h" ? [point, point + apply2D(x=cur[1])]
             :cmd == "V" || cmd == "v" ? [point, point + apply2D(y=cur[1])]
-            :cmd == "I" || cmd == "i" ? [point, intersect2D(point, vector2D(cur[1]), vector2D(cur[2]), vector2D(cur[3]))]
-            :cmd == "T" || cmd == "t" ? [point, tangent2D(point, apply2D(x=cur[1], y=cur[2]), float(cur[3]))]
+            :cmd == "I" || cmd == "i" ? [point, intersect2D(point, cur[1], cur[2], cur[3])]
+            :cmd == "T" || cmd == "t" ? let(isv = isVector(cur[1])) [point, tangent2D(point, isv ? cur[1] : apply2D(x=cur[1], y=cur[2]), isv ? cur[2] : cur[3])]
             :cmd == "A" || cmd == "a" ? [point, point + arcPoint(a=cur[1], r=cur[2])]
             :cmd == "C" || cmd == "c" ? arc(r=cur[1], a1=cur[2], a2=cur[3], o=point + arcPoint(a=float(cur[2]) + STRAIGHT, r=cur[1]))
             :cmd == "B" || cmd == "b" ? (

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -130,6 +130,25 @@ function apothem(n, r, l) =
 ;
 
 /**
+ * Computes the radius of a circle circumscribing a regular N-sides polygon.
+ * The circumradius can be computed either from the apothem or the side of the
+ * circumscribed polygon. Only one of these values is required, if both are
+ * provided, the apothem is predominant.
+ *
+ * @param Number n - The number of sides (min 3).
+ * @param Number [a] - The apothem of the regular polygon.
+ * @param Number [l] - The length of a side of the polygon.
+ * @returns Number
+ */
+function circumradius(n, a, l) =
+    let (
+        n = max(float(n), 3),
+        a = a ? float(a) : float(l) / (2 * tan(STRAIGHT / n))
+    )
+    a / cos(STRAIGHT / n)
+;
+
+/**
  * Computes the factorial of N.
  *
  * @param Number n

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -109,6 +109,27 @@ function pythagore(a, b, c) =
 ;
 
 /**
+ * Computes the apothem of a regular N-sides polygon.
+ * An apothem is a line from the center of a regular polygon at right angles
+ * to any of its sides.
+ * The apothem can be computed either from the radius of the inscribed circle
+ * or from the length of one side. Only one of these values is required, if
+ * both are provided, the radius is predominant.
+ *
+ * @param Number n - The number of sides (min 3).
+ * @param Number [r] - The radius of the inscribed circle.
+ * @param Number [a] - The length of a side.
+ * @returns Number
+ */
+function apothem(n, r, a) =
+    let (
+        n = max(float(n), 3)
+    )
+    r ? float(r) * cos(PI / n)
+      : float(a) / 2 * tan(PI / n)
+;
+
+/**
  * Computes the factorial of N.
  *
  * @param Number n

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -248,3 +248,29 @@ function decimals(value) =
     )
     isZero(value) ? 0 : min(1 + decimals(value * 10), MAX_DECIMALS)
 ;
+
+/**
+ * Resolves a quadratic equation: `ax^2+bx+c=0`.
+ * Returns the result as a vector of two values:
+ * - the first value is for the result of (-b - sqrt(delta)) / (2 * a)
+ * - the second value is for the result of (-b + sqrt(delta)) / (2 * a)
+ * If the equation cannot be resolved, returns an empty vector.
+ *
+ * @param Number a - The A term of the equation
+ * @param Number b - The B term of the equation
+ * @param Number c - The C term of the equation
+ * @returns Vector[]
+ */
+function quadraticEquation(a, b, c) =
+    let(
+        a = float(a) * 2,
+        b = float(b),
+        c = float(c),
+        d = sqrt(b * b - 2 * a * c)
+    )
+    a && d >= 0 ? [
+        (-b - d) / a,
+        (-b + d) / a
+    ]
+   :[]
+;

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -118,15 +118,15 @@ function pythagore(a, b, c) =
  *
  * @param Number n - The number of sides (min 3).
  * @param Number [r] - The radius of the inscribed circle.
- * @param Number [a] - The length of a side.
+ * @param Number [l] - The length of a side of the polygon.
  * @returns Number
  */
-function apothem(n, r, a) =
+function apothem(n, r, l) =
     let (
         n = max(float(n), 3)
     )
-    r ? float(r) * cos(PI / n)
-      : float(a) / 2 * tan(PI / n)
+    r ? float(r) * cos(STRAIGHT / n)
+      : float(l) / (2 * tan(STRAIGHT / n))
 ;
 
 /**

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -202,26 +202,32 @@ function center2D(a, b, r, negative) =
 ;
 
 /**
- * Checks if two line are parallels.
- * Each line is defined by two points.
+ * Computes a parallel line. The source line is defined by two points.
+ * The parallel line will be defined by two other points translated by
+ * the provided distance.
  *
- * @param Vector a - The first point on the first line.
- * @param Vector b - The second point on the first line.
- * @param Vector c - The first point on the second line.
- * @param Vector d - The second point on the second line.
- * @returns Boolean
+ * @param Vector a - The first point on the line.
+ * @param Vector b - The second point on the line.
+ * @param Number d - The distance to the parallel line. The sign determines the direction
+ * @returns Vector[]
  */
-function parallel2D(a, b, c, d) =
+function parallel2D(a, b, d) =
     let(
-        i = vector2D(b) - vector2D(a),
-        j = vector2D(d) - vector2D(c)
+        a = vector2D(a),
+        b = vector2D(b),
+        v = normal(unit2D(b - a)),
+        d = float(d)
     )
-    i[0] * j[1] - i[1] * j[0] == 0
+    [
+        a + v * d,
+        b + v * d
+    ]
 ;
 
 /**
  * Computes the point at the intersection of two lines.
  * Each line is defined by two points.
+ * If the lines cannot intersect (i.e. are parallel), returns the first point.
  *
  * @param Vector a - The first point on the first line.
  * @param Vector b - The second point on the first line.

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -301,6 +301,21 @@ function isosceles2D(a, b, h, angle) =
 ;
 
 /**
+ * Computes the angle of a line defined by two points.
+ *
+ * @param Vector [a] - The first point on the line
+ * @param Vector [b] - The second point on the line
+ * @returns Number
+ */
+function protractor(a, b) =
+    let(
+        v = vector2D(b) - vector2D(a)
+    )
+    v[0] || v[1] ? atan2(v[1], v[0])
+                 : 0
+;
+
+/**
  * Computes the angle between two 2D vectors.
  *
  * @param Vector [a] - The first vector

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -259,6 +259,48 @@ function tangent2D(p, c, r) =
 ;
 
 /**
+ * Computes the third edge of an isosceles triangle.
+ * The edges that have the same angle must be provided.
+ * The height or the angle must be provided.
+ * If both are provided, the height overrides the angle.
+ *
+ * @param Vector a - The first edge
+ * @param Vector b - The second edge
+ * @param Number [h] - The height of the triangle
+ * @param Number [angle] - The angle of the triangle
+ * @returns Vector
+ */
+function isosceles2D(a, b, h, angle) =
+    let(
+        a = vector2D(a),
+        b = vector2D(b),
+        v = b - a,
+        d = norm2D(v) / 2,
+        w = atan2(v[1], v[0])
+    )
+    h != undef ? (
+        let(
+            h = float(h),
+            r = pythagore(h, d),
+            angle = atan2(h, d)
+        )
+        a + arcPoint(r, w + angle)
+    )
+   :(
+       let(
+           angle = straight(angle)
+       )
+       angle < RIGHT ? (
+           let(
+               r = d / cos(angle)
+           )
+           a + arcPoint(r, w + angle)
+       )
+      :a
+   )
+;
+
+/**
  * Computes the angle between two 2D vectors.
  *
  * @param Vector [a] - The first vector

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -202,6 +202,35 @@ function parallel2D(a, b, c, d) =
 ;
 
 /**
+ * Computes the point at the intersection of two lines.
+ * Each line is defined by two points.
+ *
+ * @param Vector a - The first point on the first line.
+ * @param Vector b - The second point on the first line.
+ * @param Vector c - The first point on the second line.
+ * @param Vector d - The second point on the second line.
+ * @returns Vector
+ */
+function intersect2D(a, b, c, d) =
+    let(
+        a = vector2D(a),
+        b = vector2D(b),
+        c = vector2D(c),
+        d = vector2D(d),
+        i = b - a,
+        j = d - c,
+        n = i[0] * j[1] - i[1] * j[0]
+    )
+    n ? (
+        let(
+            k = -(a[0] * j[1] - c[0] * j[1] - j[0] * a[1] + j[0] * c[1]) / n
+        )
+        a + k * i
+    )
+   :a
+;
+
+/**
  * Computes the angle between two 2D vectors.
  *
  * @param Vector [a] - The first vector

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -359,6 +359,92 @@ function circleLineIntersect2D(i, j, c, r) =
 ;
 
 /**
+ * Computes the points at the intersection of two circles.
+ * Each circle is defined by a center and a radius.
+ * If the function cannot compute the intersection, returns an empty vector.
+ *
+ * @param Vector c1 - The center of the first circle.
+ * @param Number r1 - The radius of the first circle
+ * @param Vector c2 - The center of the second circle.
+ * @param Number r2 - The radius of the second circle
+ * @returns Vector[]
+ */
+function circleIntersect2D(c1, r1, c2, r2) =
+    let(
+        c1 = vector2D(c1),
+        c2 = vector2D(c2),
+        r1 = abs(float(r1)),
+        r2 = abs(float(r2)),
+        v = c1[0] == c2[0],
+        h = c1[1] == c2[1]
+    )
+    v && h ? []
+   :v ? (
+        let(
+            a = c2[1] - c1[1],
+            l = abs(a),
+            d = r1 + r2
+        )
+        l > d ? []
+       :l == d ? (
+            let(
+                p = c1 + [0, sign(a) * r1]
+            )
+            [ p, p ]
+        )
+       :(
+            let(
+                y = (r2 * r2 - a * a - r1 * r1) / (-2 * a),
+                x = sqrt(r2 * r2 - (a - y) * (a - y))
+            )
+            [ c1 + [x, -y], c1 + [x, y] ]
+        )
+    )
+   :h ? (
+       let(
+           a = c2[0] - c1[0],
+           l = abs(a),
+           d = r1 + r2
+       )
+       l > d ? []
+      :l == d ? (
+           let(
+               p = c1 + [sign(a) * r1, 0]
+           )
+           [ p, p ]
+       )
+      :(
+           let(
+               x = (r2 * r2 - a * a - r1 * r1) / (-2 * a),
+               y = sqrt(r2 * r2 - (a - x) * (a - x))
+           )
+           [ c1 + [-x, y], c1 + [x, y] ]
+       )
+   )
+  :(
+        let(
+            x12 = c1[0] * c1[0],
+            y12 = c1[1] * c1[1],
+            r12 = r1 * r1,
+            a = (c2[0] * c2[0] + c2[1] * c2[1] - x12 - y12 + r12 - r2 * r2) / (2 * (c2[1] - c1[1])),
+            b = (c2[0] - c1[0]) / (c2[1] - c1[1]),
+            x = quadraticEquation(
+                b * b + 1,
+                (-c1[0] + (c1[1] - a) * b) * 2,
+                (2 * -c1[1] + a) * a + x12 + y12 - r12
+            )
+        )
+        len(x) ? (
+            [
+                [x[0], a - x[0] * b],
+                [x[1], a - x[1] * b]
+            ]
+        )
+       :[]
+   )
+;
+
+/**
  * Computes the third edge of an isosceles triangle.
  * The edges that have the same angle must be provided.
  * The height or the angle must be provided.

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -231,6 +231,34 @@ function intersect2D(a, b, c, d) =
 ;
 
 /**
+ * Computes the point at the intersection of a circle and a tangent line.
+ * The center is defined by a center and a radius.
+ * The line is defined by a point.
+ *
+ * @param Vector p - A point on the line that should be tangent to the circle
+ * @param Vector c - The center of the circle.
+ * @param Number r - The radius of the circle
+ * @returns Vector
+ */
+function tangent2D(p, c, r) =
+    let(
+        p = vector2D(p),
+        c = vector2D(c),
+        r = float(r),
+        v = c - p,
+        d = norm2D(v)
+    )
+    d > r ? (
+        let(
+            t = pythagore(0, r, d),
+            a = atan2(v[1], v[0]) + asin(r / d)
+        )
+        p + arcPoint(t, a)
+    )
+   :p
+;
+
+/**
  * Computes the angle between two 2D vectors.
  *
  * @param Vector [a] - The first vector

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -283,6 +283,82 @@ function tangent2D(p, c, r) =
 ;
 
 /**
+ * Computes the points at the intersection of a circle and a line.
+ * The circle is defined by a center and a radius.
+ * The line is defined by two points.
+ * If the function cannot compute the intersection, returns an empty vector.
+ *
+ * @param Vector i - The first point on the line
+ * @param Vector j - The second point on the line
+ * @param Vector c - The center of the circle.
+ * @param Number r - The radius of the circle
+ * @returns Vector[]
+ */
+function circleLineIntersect2D(i, j, c, r) =
+    let(
+        i = vector2D(i),
+        j = vector2D(j),
+        c = vector2D(c),
+        r = abs(float(r)),
+        v = i[0] == j[0],
+        h = i[1] == j[1]
+    )
+    h && v ? (
+        approx(pow(i[0] - c[0], 2) + pow(i[1] - c[1], 2), r * r) ? [i, j] : []
+    )
+   :v ? (
+        let(
+            a = abs(i[0] - c[0])
+        )
+        a <= r ? (
+            let(
+                b = pythagore(a, 0, r)
+            )
+            [
+                [i[0], c[1] - b],
+                [i[0], c[1] + b]
+            ]
+        )
+       :[]
+
+    )
+   :h ? (
+       let(
+           a = abs(i[1] - c[1])
+       )
+       a <= r ? (
+           let(
+               b = pythagore(a, 0, r)
+           )
+           [
+               [c[0] - b, i[1]],
+               [c[0] + b, i[1]]
+           ]
+       )
+      :[]
+    )
+   :(
+        let(
+            v = i - j,
+            a = v[1] / v[0],
+            b = i[1] - a * i[0],
+            x = quadraticEquation(
+                1 + a * a,
+                2 * (-c[0] + (b - c[1]) * a),
+                c[0] * c[0] + c[1] * c[1] + (c[1] * -2 + b) * b - r * r
+            )
+        )
+        len(x) ? (
+            [
+                [x[0], a * x[0] + b],
+                [x[1], a * x[1] + b]
+            ]
+        )
+       :[]
+    )
+;
+
+/**
  * Computes the third edge of an isosceles triangle.
  * The edges that have the same angle must be provided.
  * The height or the angle must be provided.

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -162,6 +162,24 @@ function middle2D(a, b) = (vector2D(a) + vector2D(b)) / 2;
 function move2D(p, v, d) = vector2D(p) + unit2D(v) * float(d);
 
 /**
+ * Computes the point at the wanted distance from the origin on the defined line.
+ * The line is defined by two points: the origin and another arbitrary point.
+ *
+ * @param Vector a - The origin of the line.
+ * @param Vector b - The second point on the line.
+ * @param Number d - The distance from the origin where to find the wanted point.
+ * @returns Vector
+ */
+function extend2D(a, b, d) =
+    let(
+        a = vector2D(a),
+        b = vector2D(b),
+        d = float(d)
+    )
+    a + unit2D(b - a) * d
+;
+
+/**
  * Computes the center of a cicle that pass through two points.
  *
  * @param Number a - The first point.

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -184,6 +184,24 @@ function center2D(a, b, r, negative) =
 ;
 
 /**
+ * Checks if two line are parallels.
+ * Each line is defined by two points.
+ *
+ * @param Vector a - The first point on the first line.
+ * @param Vector b - The second point on the first line.
+ * @param Vector c - The first point on the second line.
+ * @param Vector d - The second point on the second line.
+ * @returns Boolean
+ */
+function parallel2D(a, b, c, d) =
+    let(
+        i = vector2D(b) - vector2D(a),
+        j = vector2D(d) - vector2D(c)
+    )
+    i[0] * j[1] - i[1] * j[0] == 0
+;
+
+/**
  * Computes the angle between two 2D vectors.
  *
  * @param Vector [a] - The first vector

--- a/core/vector-3d.scad
+++ b/core/vector-3d.scad
@@ -123,6 +123,24 @@ function middle3D(a, b) = (vector3D(a) + vector3D(b)) / 2;
 function move3D(p, v, d) = vector3D(p) + unit3D(v) * float(d);
 
 /**
+ * Computes the point at the wanted distance from the origin on the defined line.
+ * The line is defined by two points: the origin and another arbitrary point.
+ *
+ * @param Vector a - The origin of the line.
+ * @param Vector b - The second point on the line.
+ * @param Number d - The distance from the origin where to find the wanted point.
+ * @returns Vector
+ */
+function extend3D(a, b, d) =
+    let(
+        a = vector3D(a),
+        b = vector3D(b),
+        d = float(d)
+    )
+    a + unit3D(b - a) * d
+;
+
+/**
  * Computes the angle between two 3D vectors.
  *
  * @param Vector [a] - The first vector

--- a/core/version.scad
+++ b/core/version.scad
@@ -36,7 +36,7 @@
  * The version of the library.
  * @type Vector
  */
-CAMEL_SCAD_VERSION = [0, 4, 0];
+CAMEL_SCAD_VERSION = [0, 5, 0];
 
 /**
  * The minimal version of OpenSCAD required by the library.

--- a/samples/render-modes.scad
+++ b/samples/render-modes.scad
@@ -28,7 +28,7 @@ DEMO_FONT_SIZE = 10;
 
 // The list of render modes to illustrate
 DEMO_MODES = [
-    [null, null], // MODE_DEFAULT
+    [undef, undef], // MODE_DEFAULT
     [[.5, 0, 0], MODE_DIRTY],
     [[0, .5, 0], MODE_DEV],
     [[0, 0, .5], MODE_PROD],

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -87,9 +87,9 @@ openscad -o "${dst}" "${src}" -D CSV=true >"${output}" 2>&1
 
 if [ "$?" != "0" ]; then
     echo -e "\033[31m"
-    cat "${output}"
+    echo "$(<${output})"
 else
-    cat "${output}" | sed -e 's/^ECHO: "\(.*\)"$/\1/g' >"${result}"
+    sed -e 's/^ECHO: "\(.*\)"$/\1/g' "${output}" >"${result}"
     awk -f "${scriptPath}/parse-test.awk" "${result}"
 fi
 

--- a/shape/2D/polygon.scad
+++ b/shape/2D/polygon.scad
@@ -57,8 +57,8 @@ function sizeRectangle(size, l, w) =
  * @param Number|Vector [chamfer] - The size of the chamfers.
  * @param Number [l] - The overall length.
  * @param Number [w] - The overall width.
- * @param Number [cl] - The vertical length of the chamfers.
- * @param Number [cw] - The horizontal width of the chamfers.
+ * @param Number [cl] - The length of the chamfers.
+ * @param Number [cw] - The width of the chamfers.
  * @returns Vector[] - Returns an array containing the size vector and the chamfer vector.
  */
 function sizeChamferedRectangle(size, chamfer, l, w, cl, cw) =
@@ -173,8 +173,8 @@ function drawRectangle(size, l, w) =
  * @param Number|Vector [chamfer] - The size of the chamfers.
  * @param Number [l] - The overall length.
  * @param Number [w] - The overall width.
- * @param Number [cl] - The vertical length of the chamfers.
- * @param Number [cw] - The horizontal width of the chamfers.
+ * @param Number [cl] - The length of the chamfers.
+ * @param Number [cw] - The width of the chamfers.
  * @returns Vector[]
  */
 function drawChamferedRectangle(size, chamfer, l, w, cl, cw) =
@@ -344,8 +344,8 @@ module rectangle(size, l, w) {
  * @param Number|Vector [chamfer] - The size of the chamfers.
  * @param Number [l] - The overall length.
  * @param Number [w] - The overall width.
- * @param Number [cl] - The vertical length of the chamfers.
- * @param Number [cw] - The horizontal width of the chamfers.
+ * @param Number [cl] - The length of the chamfers.
+ * @param Number [cw] - The width of the chamfers.
  */
 module chamferedRectangle(size, chamfer, l, w, cl, cw) {
     polygon(

--- a/shape/2D/polygon.scad
+++ b/shape/2D/polygon.scad
@@ -51,6 +51,33 @@ function sizeRectangle(size, l, w) =
 ;
 
 /**
+ * Computes the size of a chamfered rectangle shape.
+ *
+ * @param Number|Vector [size] - The size of the chamfered rectangle.
+ * @param Number|Vector [chamfer] - The size of the chamfers.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [cl] - The vertical length of the chamfers.
+ * @param Number [cw] - The horizontal width of the chamfers.
+ * @returns Vector[] - Returns an array containing the size vector and the chamfer vector.
+ */
+function sizeChamferedRectangle(size, chamfer, l, w, cl, cw) =
+    let(
+        s = apply2D(size, l, w),
+        c = apply2D(chamfer, cl, cw),
+        size = [
+            divisor(s[0] ? s[0] : c[0] * 2),
+            divisor(s[1] ? s[1] : c[1] * 2)
+        ],
+        chamfer = [
+            min(size[0] / 2, c[0]),
+            min(size[1] / 2, c[1])
+        ]
+    )
+    [ size, chamfer[0] && chamfer[1] ? chamfer : [0, 0] ]
+;
+
+/**
  * Computes the size of a trapezium shape.
  *
  * @param Number|Vector [size] - The size of the trapezium.
@@ -132,6 +159,43 @@ function drawRectangle(size, l, w) =
         half = size / 2
     )
     [
+        [ half[0],  half[1]],
+        [-half[0],  half[1]],
+        [-half[0], -half[1]],
+        [ half[0], -half[1]]
+    ]
+;
+
+/**
+ * Computes the points that draw the sketch of a chamfered rectangle shape.
+ *
+ * @param Number|Vector [size] - The size of the chamfered rectangle.
+ * @param Number|Vector [chamfer] - The size of the chamfers.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [cl] - The vertical length of the chamfers.
+ * @param Number [cw] - The horizontal width of the chamfers.
+ * @returns Vector[]
+ */
+function drawChamferedRectangle(size, chamfer, l, w, cl, cw) =
+    let(
+        specs = sizeChamferedRectangle(size=size, chamfer=chamfer, l=l, w=w, cl=cl, cw=cw),
+        size = specs[0],
+        chamfer = specs[1],
+        half = size / 2
+    )
+    chamfer[0]
+   ?[
+        [ half[0],  half[1] - chamfer[1]],
+        [ half[0] - chamfer[0],  half[1]],
+        [-half[0] + chamfer[0],  half[1]],
+        [-half[0],  half[1] - chamfer[1]],
+        [-half[0], -half[1] + chamfer[1]],
+        [-half[0] + chamfer[0], -half[1]],
+        [ half[0] - chamfer[0], -half[1]],
+        [ half[0], -half[1] + chamfer[1]]
+    ]
+   :[
         [ half[0],  half[1]],
         [-half[0],  half[1]],
         [-half[0], -half[1]],
@@ -269,6 +333,23 @@ function drawStar(size, core, edges, l, w, cl, cw) =
 module rectangle(size, l, w) {
     polygon(
         points = drawRectangle(size=size, l=l, w=w),
+        convexity = 10
+    );
+}
+
+/**
+ * Creates a chamfered rectangle at the origin.
+ *
+ * @param Number|Vector [size] - The size of the chamfered rectangle.
+ * @param Number|Vector [chamfer] - The size of the chamfers.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [cl] - The vertical length of the chamfers.
+ * @param Number [cw] - The horizontal width of the chamfers.
+ */
+module chamferedRectangle(size, chamfer, l, w, cl, cw) {
+    polygon(
+        points = drawChamferedRectangle(size=size, chamfer=chamfer, l=l, w=w, cl=cl, cw=cw),
         convexity = 10
     );
 }

--- a/shape/2D/rounded.scad
+++ b/shape/2D/rounded.scad
@@ -229,7 +229,7 @@ function drawStadium(size, r, d, w, h, rx, ry, dx, dy) =
         ]
     )
     center == [0, 0] ? arc(r=radius)
-   :concat(arc(r=radius, o=center, a=STRAIGHT), arc(r=radius, o=-center, a=-STRAIGHT))
+   :concat(arc(r=radius, o=center, a=STRAIGHT), arc(r=radius, o=-center, a=STRAIGHT, a1=STRAIGHT))
 ;
 
 /**

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -53,6 +53,35 @@ function sizeBox(size, l, w, h) =
 ;
 
 /**
+ * Computes the size of a chamfered box.
+ *
+ * @param Number|Vector [size] - The size of the chamfered box.
+ * @param Number|Vector [chamfer] - The size of the chamfers.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [h] - The overall height.
+ * @param Number [cl] - The vertical length of the chamfers.
+ * @param Number [cw] - The horizontal width of the chamfers.
+ * @returns Vector[] - Returns an array containing the size vector and the chamfer vector.
+ */
+function sizeChamferedBox(size, chamfer, l, w, h, cl, cw) =
+    let(
+        s = apply3D(size, l, w, h),
+        c = apply2D(chamfer, cl, cw),
+        size = [
+            divisor(s[0] ? s[0] : c[0] * 2),
+            divisor(s[1] ? s[1] : c[1] * 2),
+            divisor(s[2])
+        ],
+        chamfer = [
+            min(size[0] / 2, c[0]),
+            min(size[1] / 2, c[1])
+        ]
+    )
+    [ size, chamfer[0] && chamfer[1] ? chamfer : [0, 0] ]
+;
+
+/**
  * Computes the size of a trapezium shape.
  *
  * @param Number|Vector [size] - The size of the trapezium.
@@ -139,6 +168,25 @@ module box(size, l, w, h, center) {
     size = sizeBox(size=size, l=l, w=w, h=h);
     linear_extrude(height=size[2], center=center, convexity=10) {
         rectangle(size);
+    }
+}
+
+/**
+ * Creates a chamfered box at the origin.
+ *
+ * @param Number|Vector [size] - The size of the chamfered box.
+ * @param Number|Vector [chamfer] - The size of the chamfers.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [h] - The overall height.
+ * @param Number [cl] - The vertical length of the chamfers.
+ * @param Number [cw] - The horizontal width of the chamfers.
+ * @param Boolean [center] - Whether or not center the box on the vertical axis.
+ */
+module chamferedBox(size, chamfer, l, w, h, cl, cw, center) {
+    size = sizeBox(size=size, chamfer=chamfer, l=l, w=w, h=h, cl=cl, cw=cw);
+    linear_extrude(height=size[2], center=center, convexity=10) {
+        chamferedRectangle(size, chamfer);
     }
 }
 

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -60,8 +60,8 @@ function sizeBox(size, l, w, h) =
  * @param Number [l] - The overall length.
  * @param Number [w] - The overall width.
  * @param Number [h] - The overall height.
- * @param Number [cl] - The vertical length of the chamfers.
- * @param Number [cw] - The horizontal width of the chamfers.
+ * @param Number [cl] - The length of the chamfers.
+ * @param Number [cw] - The width of the chamfers.
  * @returns Vector[] - Returns an array containing the size vector and the chamfer vector.
  */
 function sizeChamferedBox(size, chamfer, l, w, h, cl, cw) =
@@ -179,8 +179,8 @@ module box(size, l, w, h, center) {
  * @param Number [l] - The overall length.
  * @param Number [w] - The overall width.
  * @param Number [h] - The overall height.
- * @param Number [cl] - The vertical length of the chamfers.
- * @param Number [cw] - The horizontal width of the chamfers.
+ * @param Number [cl] - The length of the chamfers.
+ * @param Number [cw] - The width of the chamfers.
  * @param Boolean [center] - Whether or not center the box on the vertical axis.
  */
 module chamferedBox(size, chamfer, l, w, h, cl, cw, center) {

--- a/shape/3D/rounded.scad
+++ b/shape/3D/rounded.scad
@@ -340,7 +340,7 @@ function drawPill(size, r, d, l, w, h, rx, ry, dx, dy) =
     )
     center == [0, 0] ? arc(r=radius, a1=-RIGHT, a2=RIGHT)
    :concat(
-        arc(r=radius, o=-center, a=-RIGHT),
+        arc(r=radius, o=-center, a=RIGHT, a1=-RIGHT),
         arc(r=radius, o=center, a=RIGHT)
     )
 ;

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -36,7 +36,7 @@ use <../../full.scad>
 module testCoreLine() {
     testPackage("core/line.scad", 4) {
         // test core/line/arc()
-        testModule("arc()", 7) {
+        testModule("arc()", 9) {
             testUnit("no parameter", 1) {
                 assertEqual(arc(), [], "Cannot build an arc without parameters, should return an empty array");
             }
@@ -53,37 +53,79 @@ module testCoreLine() {
                 assertEqual(arc(1, 0), [], "Cannot build a 0° circle arc, should return an empty array");
                 assertEqual(arc([1, 1], 0), [], "Cannot build a 0° ellipse arc, should return an empty array");
             }
-            testUnit("circle", 4) {
+            testUnit("circle", 5) {
                 assertEqual(arc(1, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 1) ], "Should return a list of points to draw a circle with a radius of 1 and 3 facets (triangle)");
                 assertEqual(arc(1, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 1) ], "Should return a list of points to draw a circle with a radius of 1 and 4 facets (square)");
                 assertEqual(arc(1, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 1) ], "Should return a list of points to draw a circle with a radius of 1 and 6 facets (hexagon)");
                 assertEqual(arc(5, $fa=12, $fs=2), [ for (a = [astep(5, $fa=12, $fs=2) : astep(5, $fa=12, $fs=2) : 360]) _rotP(a, 5, 5) ], "Should return a list of points to draw a circle with a radius of 1 and 16 facets");
+                assertEqual(arc(10, $fn=36), [ for (a = [10 : 10 : 360]) _rotP(a, 10, 10) ], "Should return a list of points to draw a circle with a radius of 10 and 36 facets");
             }
-            testUnit("ellipse", 4) {
+            testUnit("ellipse", 5) {
                 assertEqual(arc([1, 2], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(arc([1, 2], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(arc([1, 2], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 6 facets (hexagon)");
                 assertEqual(arc([5, 6], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
+                assertEqual(arc([10, 20], $fn=36), [ for (a = [10 : 10 : 360]) _rotP(a, 10, 20) ], "Should return a list of points to draw an ellipse with a radius of [10, 20] and 36 facets");
             }
-            testUnit("circle arc", 8) {
+            testUnit("circle arc from origin", 12) {
                 assertEqual(arc(1, a=30, $fn=3), [ for (a = [0 : 30 : 30]) _rotP(a, 1, 1) ], "Should return a list of points to draw a 30° arc with a radius of 1 and 3 facets (triangle)");
                 assertEqual(arc(1, a=140, $fn=3), concat([ for (a = [0 : 120 : 140]) _rotP(a, 1, 1) ], [_rotP(140, 1, 1)]), "Should return a list of points to draw a 140° arc with a radius of 1 and 3 facets (triangle)");
                 assertEqual(arc(1, a=140, $fn=4), concat([ for (a = [0 : 90 : 140]) _rotP(a, 1, 1) ], [_rotP(140, 1, 1)]), "Should return a list of points to draw a 140° arc with a radius of 1 and 4 facets (square)");
                 assertEqual(arc(1, a=200, $fn=4), concat([ for (a = [0 : 90 : 200]) _rotP(a, 1, 1) ], [_rotP(200, 1, 1)]), "Should return a list of points to draw a 200° arc with a radius of 1 and 4 facets (square)");
                 assertEqual(arc(1, a=140, $fn=6), concat([ for (a = [0 : 60 : 140]) _rotP(a, 1, 1) ], [_rotP(140, 1, 1)]), "Should return a list of points to draw a 140° arc with a radius of 1 and 6 facets (hexagon)");
                 assertEqual(arc(1, a=200, $fn=6), concat([ for (a = [0 : 60 : 200]) _rotP(a, 1, 1) ], [_rotP(200, 1, 1)]), "Should return a list of points to draw a 200° arc with a radius of 1 and 6 facets (hexagon)");
-                assertEqual(arc(5, a=80, $fa=12, $fs=2), concat([ for (a = [0 : astep(5, $fa=12, $fs=2) : 80]) _rotP(a, 5, 5) ], [_rotP(80, 5, 5)]), "Should return a list of points to draw a 30° arc with a radius of 1 and 16 facets");
-                assertEqual(arc(5, a=160, $fa=12, $fs=2), concat([ for (a = [0 : astep(5, $fa=12, $fs=2) : 160]) _rotP(a, 5, 5) ], [_rotP(160, 5, 5)]), "Should return a list of points to draw a 30° arc with a radius of 1 and 16 facets");
+                assertEqual(arc(5, a=80, $fa=12, $fs=2), concat([ for (a = [0 : astep(5, $fa=12, $fs=2) : 80]) _rotP(a, 5, 5) ], [_rotP(80, 5, 5)]), "Should return a list of points to draw a 80° arc with a radius of 1 and 16 facets");
+                assertEqual(arc(5, a=160, $fa=12, $fs=2), concat([ for (a = [0 : astep(5, $fa=12, $fs=2) : 160]) _rotP(a, 5, 5) ], [_rotP(160, 5, 5)]), "Should return a list of points to draw a 160° arc with a radius of 1 and 16 facets");
+                assertEqual(arc(10, a=300, $fn=36), [ for (a = [0 : 10 : 300]) _rotP(a, 10, 10) ], "Should return a list of points to draw a 300° arc with a radius of 10 and 36 facets");
+                assertEqual(arc(10, a=360, $fn=36), [ for (a = [10 : 10 : 360]) _rotP(a, 10, 10) ], "Should return a list of points to draw a 360° arc with a radius of 10 and 36 facets");
+                assertEqual(arc(10, a=660, $fn=36), [ for (a = [0 : 10 : 300]) _rotP(a, 10, 10) ], "Should return a list of points to draw a 660° arc with a radius of 10 and 36 facets");
+                assertEqual(arc(10, a=720, $fn=36), [ for (a = [10 : 10 : 360]) _rotP(a, 10, 10) ], "Should return a list of points to draw a 720° arc with a radius of 10 and 36 facets");
             }
-            testUnit("ellipse arc", 8) {
+            testUnit("ellipse arc from origin", 12) {
                 assertEqual(arc([1, 2], a=30, $fn=3), [ for (a = [0 : 30 : 30]) _rotP(a, 1, 2) ], "Should return a list of points to draw a 30° arc with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(arc([1, 2], a=140, $fn=3), concat([ for (a = [0 : 120 : 140]) _rotP(a, 1, 2) ], [_rotP(140, 1, 2)]), "Should return a list of points to draw a 140° arc with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(arc([1, 2], a=140, $fn=4), concat([ for (a = [0 : 90 : 140]) _rotP(a, 1, 2) ], [_rotP(140, 1, 2)]), "Should return a list of points to draw a 140° arc with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(arc([1, 2], a=200, $fn=4), concat([ for (a = [0 : 90 : 200]) _rotP(a, 1, 2) ], [_rotP(200, 1, 2)]), "Should return a list of points to draw a 200° arc with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(arc([1, 2], a=140, $fn=6), concat([ for (a = [0 : 60 : 140]) _rotP(a, 1, 2) ], [_rotP(140, 1, 2)]), "Should return a list of points to draw a 140° arc with a radius of [1, 2] and 6 facets (hexagon)");
                 assertEqual(arc([1, 2], a=200, $fn=6), concat([ for (a = [0 : 60 : 200]) _rotP(a, 1, 2) ], [_rotP(200, 1, 2)]), "Should return a list of points to draw a 200° arc with a radius of [1, 2] and 6 facets (hexagon)");
-                assertEqual(arc([5, 6], a=80, $fa=12, $fs=2), concat([ for (a = [0 : astep(6, $fa=12, $fs=2) : 80]) _rotP(a, 5, 6) ], [_rotP(80, 5, 6)]), "Should return a list of points to draw a 30° arc with a radius of [5, 6] and 16 facets");
-                assertEqual(arc([5, 6], a=160, $fa=12, $fs=2), concat([ for (a = [0 : astep(6, $fa=12, $fs=2) : 160]) _rotP(a, 5, 6) ], [_rotP(160, 5, 6)]), "Should return a list of points to draw a 30° arc with a radius of [5, 6] and 16 facets");
+                assertEqual(arc([5, 6], a=80, $fa=12, $fs=2), concat([ for (a = [0 : astep(6, $fa=12, $fs=2) : 80]) _rotP(a, 5, 6) ], [_rotP(80, 5, 6)]), "Should return a list of points to draw a 80° arc with a radius of [5, 6] and 16 facets");
+                assertEqual(arc([5, 6], a=160, $fa=12, $fs=2), concat([ for (a = [0 : astep(6, $fa=12, $fs=2) : 160]) _rotP(a, 5, 6) ], [_rotP(160, 5, 6)]), "Should return a list of points to draw a 160° arc with a radius of [5, 6] and 16 facets");
+                assertEqual(arc([10, 20], a=300, $fn=36), [ for (a = [0 : 10 : 300]) _rotP(a, 10, 20) ], "Should return a list of points to draw a 300° arc with a radius of [10, 20] and 36 facets");
+                assertEqual(arc([10, 20], a=360, $fn=36), [ for (a = [10 : 10 : 360]) _rotP(a, 10, 20) ], "Should return a list of points to draw a 360° arc with a radius of [10, 20] and 36 facets");
+                assertEqual(arc([10, 20], a=660, $fn=36), [ for (a = [0 : 10 : 300]) _rotP(a, 10, 20) ], "Should return a list of points to draw a 660° arc with a radius of [10, 20] and 36 facets");
+                assertEqual(arc([10, 20], a=720, $fn=36), [ for (a = [10 : 10 : 360]) _rotP(a, 10, 20) ], "Should return a list of points to draw a 720° arc with a radius of [10, 20] and 36 facets");
+            }
+            testUnit("circle arc arbitrary angle", 14) {
+                assertEqual(arc(1, a1=30, a2=60, $fn=36), [ for (a = [30 : 10 : 60]) _rotP(a, 1, 1) ], "Should return a list of points to draw an arc from 30° to 60° with a radius of 1");
+                assertEqual(arc(1, a1=60, a2=30, $fn=36), [ for (a = [60 : -10 : 30]) _rotP(a, 1, 1) ], "Should return a list of points to draw an arc from 60° to 30° with a radius of 1");
+                assertEqual(arc(1, a1=45, a=30, $fn=36), [ for (a = [45 : 10 : 75]) _rotP(a, 1, 1) ], "Should return a list of points to draw a 30° arc from 45° with a radius of 1");
+                assertEqual(arc(1, a1=45, a=-30, $fn=36), [ for (a = [45 : -10 : 15]) _rotP(a, 1, 1) ], "Should return a list of points to draw a -30° arc from 45° with a radius of 1");
+                assertEqual(arc(1, a1=-45, a=30, $fn=36), [ for (a = [-45 : 10 : -15]) _rotP(a, 1, 1) ], "Should return a list of points to draw a 30° arc from -45° with a radius of 1");
+                assertEqual(arc(1, a1=-45, a=-30, $fn=36), [ for (a = [-45 : -10 : -75]) _rotP(a, 1, 1) ], "Should return a list of points to draw a -30° arc from -45° with a radius of 1");
+                assertEqual(arc(1, a1=405, a=390, $fn=36), [ for (a = [45 : 10 : 75]) _rotP(a, 1, 1) ], "Should return a list of points to draw a 390° arc from 405° with a radius of 1");
+                assertEqual(arc(1, a1=405, a=-390, $fn=36), [ for (a = [45 : -10 : 15]) _rotP(a, 1, 1) ], "Should return a list of points to draw a -390° arc from 405° with a radius of 1");
+                assertEqual(arc(1, a1=-30, a2=-60, $fn=36), [ for (a = [-30 : -10 : -60]) _rotP(a, 1, 1) ], "Should return a list of points to draw an arc from -30° to -60° with a radius of 1");
+                assertEqual(arc(1, a1=-60, a2=-30, $fn=36), [ for (a = [-60 : 10 : -30]) _rotP(a, 1, 1) ], "Should return a list of points to draw an arc from -60° to -30° with a radius of 1");
+                assertEqual(arc(1, a1=-30, a2=30, $fn=36), [ for (a = [-30 : 10 : 30]) _rotP(a, 1, 1) ], "Should return a list of points to draw an arc from -30° to 30° with a radius of 1");
+                assertEqual(arc(1, a1=30, a2=-30, $fn=36), [ for (a = [30 : -10 : -30]) _rotP(a, 1, 1) ], "Should return a list of points to draw an arc from 30° to -30° with a radius of 1");
+                assertEqual(arc(1, a1=-390, a2=390, $fn=36), [ for (a = [-30 : 10 : 30]) _rotP(a, 1, 1) ], "Should return a list of points to draw an arc from -390° to 390° with a radius of 1");
+                assertEqual(arc(1, a1=390, a2=-390, $fn=36), [ for (a = [30 : -10 : -30]) _rotP(a, 1, 1) ], "Should return a list of points to draw an arc from 390° to -390° with a radius of 1");
+            }
+            testUnit("ellipse arc arbitrary angle", 14) {
+                assertEqual(arc([1, 2], a1=30, a2=60, $fn=36), [ for (a = [30 : 10 : 60]) _rotP(a, 1, 2) ], "Should return a list of points to draw an arc from 30° to 60° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=60, a2=30, $fn=36), [ for (a = [60 : -10 : 30]) _rotP(a, 1, 2) ], "Should return a list of points to draw an arc from 60° to 30° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=45, a=30, $fn=36), [ for (a = [45 : 10 : 75]) _rotP(a, 1, 2) ], "Should return a list of points to draw a 30° arc from 45° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=45, a=-30, $fn=36), [ for (a = [45 : -10 : 15]) _rotP(a, 1, 2) ], "Should return a list of points to draw a -30° arc from 45° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=-45, a=30, $fn=36), [ for (a = [-45 : 10 : -15]) _rotP(a, 1, 2) ], "Should return a list of points to draw a 30° arc from -45° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=-45, a=-30, $fn=36), [ for (a = [-45 : -10 : -75]) _rotP(a, 1, 2) ], "Should return a list of points to draw a -30° arc from -45° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=405, a=390, $fn=36), [ for (a = [45 : 10 : 75]) _rotP(a, 1, 2) ], "Should return a list of points to draw a 390° arc from 405° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=405, a=-390, $fn=36), [ for (a = [45 : -10 : 15]) _rotP(a, 1, 2) ], "Should return a list of points to draw a -390° arc from 405° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=-30, a2=-60, $fn=36), [ for (a = [-30 : -10 : -60]) _rotP(a, 1, 2) ], "Should return a list of points to draw an arc from -30° to -60° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=-60, a2=-30, $fn=36), [ for (a = [-60 : 10 : -30]) _rotP(a, 1, 2) ], "Should return a list of points to draw an arc from -60° to -30° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=-30, a2=30, $fn=36), [ for (a = [-30 : 10 : 30]) _rotP(a, 1, 2) ], "Should return a list of points to draw an arc from -30° to 30° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=30, a2=-30, $fn=36), [ for (a = [30 : -10 : -30]) _rotP(a, 1, 2) ], "Should return a list of points to draw an arc from 30° to -30° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=-390, a2=390, $fn=36), [ for (a = [-30 : 10 : 30]) _rotP(a, 1, 2) ], "Should return a list of points to draw an arc from -390° to 390° with a radius of [1, 2]");
+                assertEqual(arc([1, 2], a1=390, a2=-390, $fn=36), [ for (a = [30 : -10 : -30]) _rotP(a, 1, 2) ], "Should return a list of points to draw an arc from 390° to -390° with a radius of [1, 2]");
             }
         }
         // test core/line/sinusoid()
@@ -154,7 +196,7 @@ module testCoreLine() {
                 assertEqual(path(true, true), [true], "Cannot build a line using booleans");
                 assertEqual(path(1, 1), [1], "Cannot build a line using numbers");
             }
-            testUnit("path only", 49) {
+            testUnit("path only", 52) {
                 // point
                 assertEqual(path([["P"]]), [[0, 0]], "Path with 1 empty point");
                 assertEqual(path([["P", 10, 20]]), [[10, 20]], "Path with 1 absolute point");
@@ -200,8 +242,11 @@ module testCoreLine() {
 
                 // circle
                 assertEqual(path([["C"]]), [[0, 0]], "Path with 1 empty circle arc");
+                assertEqual(path([["C", 20]]), [ for (a = [astep(360) : astep(360) : 360]) _rotP(180, 20, 20) + _rotP(a, 20, 20) ], "Path with 1 full circle");
                 assertEqual(path([["C", 20, 40, 80]]), concat([ for (a = [40 : astep(20) : 80]) _rotP(220, 20, 20) + _rotP(a, 20, 20) ], [_rotP(220, 20, 20) + _rotP(80, 20, 20)]), "Path with 1 circle arc");
+                assertEqual(path([["C", 20, 80, 40]]), concat([ for (a = [80 : -astep(20) : 40]) _rotP(260, 20, 20) + _rotP(a, 20, 20) ], [_rotP(260, 20, 20) + _rotP(40, 20, 20)]), "Path with 1 negative circle arc");
                 assertEqual(path([["P", 5, 6], ["C", 20, 40, 80]]), concat([ for (a = [40 : astep(20) : 80]) [5, 6] + _rotP(220, 20, 20) + _rotP(a, 20, 20) ], [[5, 6] + _rotP(220, 20, 20) + _rotP(80, 20, 20)]), "Path with 1 circle arc from an absolute point");
+                assertEqual(path([["P", 5, 6], ["C", 20, 80, 40]]), concat([ for (a = [80 : -astep(20) : 40]) [5, 6] + _rotP(260, 20, 20) + _rotP(a, 20, 20) ], [[5, 6] + _rotP(260, 20, 20) + _rotP(40, 20, 20)]), "Path with 1 negative circle arc from an absolute point");
                 assertEqual(path([["P", 5, 6], ["C"]]), [[5, 6]], "Path with 1 empty circle arc from an absolute point");
 
                 // bezier point

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -196,17 +196,19 @@ module testCoreLine() {
                 assertEqual(path(true, true), [true], "Cannot build a line using booleans");
                 assertEqual(path(1, 1), [1], "Cannot build a line using numbers");
             }
-            testUnit("path only", 52) {
+            testUnit("path only", 55) {
                 // point
                 assertEqual(path([["P"]]), [[0, 0]], "Path with 1 empty point");
-                assertEqual(path([["P", 10, 20]]), [[10, 20]], "Path with 1 absolute point");
+                assertEqual(path([["P", 10, 20]]), [[10, 20]], "Path with 1 absolute point, using coordinates");
+                assertEqual(path([["P", [10, 20]]]), [[10, 20]], "Path with 1 absolute point, using point value");
                 assertEqual(path([["P", 10, 20], ["P"]]), [[10, 20]], "Path with 1 absolute point and 1 empty point");
                 assertEqual(path([["P", 10, 20], ["P", 0, 5]]), [[10, 20], [0, 5]], "Path with 2 absolute points");
                 assertEqual(path([["P", 10, 20], ["P", 0, 5], ["P", 7, 4]]), [[10, 20], [0, 5], [7, 4]], "Path with 3 absolute points");
 
                 // line
                 assertEqual(path([["L"]]), [[0, 0]], "Path with 1 empty line");
-                assertEqual(path([["L", 10, 20]]), [[0, 0], [10, 20]], "Path with 1 line");
+                assertEqual(path([["L", 10, 20]]), [[0, 0], [10, 20]], "Path with 1 line, using coordinates");
+                assertEqual(path([["L", [10, 20]]]), [[0, 0], [10, 20]], "Path with 1 line, using point value");
                 assertEqual(path([["P", 5, 6], ["L", 10, 20]]), [[5, 6], [15, 26]], "Path with 1 line from an absolute point");
                 assertEqual(path([["P", 5, 6], ["L"]]), [[5, 6]], "Path with 1 empty line from an absolute point");
 
@@ -230,7 +232,8 @@ module testCoreLine() {
 
                 // tangent line
                 assertEqual(path([["T"]]), [[0, 0]], "Path with 1 empty tangent line");
-                assertEqual(path([["T", 8, 6, 2]]), [[0, 0], arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line");
+                assertEqual(path([["T", 8, 6, 2]]), [[0, 0], arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line, using coordinates");
+                assertEqual(path([["T", [8, 6], 2]]), [[0, 0], arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line, using point value");
                 assertEqual(path([["P", 11, 5], ["T", 19, 11, 2]]), [[11, 5], [11, 5] + arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line from an absolute point");
                 assertEqual(path([["P", 5, 6], ["T"]]), [[5, 6]], "Path with 1 empty tangent line from an absolute point");
 

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -154,7 +154,7 @@ module testCoreLine() {
                 assertEqual(path(true, true), [true], "Cannot build a line using booleans");
                 assertEqual(path(1, 1), [1], "Cannot build a line using numbers");
             }
-            testUnit("path only", 41) {
+            testUnit("path only", 49) {
                 // point
                 assertEqual(path([["P"]]), [[0, 0]], "Path with 1 empty point");
                 assertEqual(path([["P", 10, 20]]), [[10, 20]], "Path with 1 absolute point");
@@ -179,6 +179,18 @@ module testCoreLine() {
                 assertEqual(path([["V", 10]]), [[0, 0], [0, 10]], "Path with 1 vertical line");
                 assertEqual(path([["P", 5, 6], ["V", 10]]), [[5, 6], [5, 16]], "Path with 1 vertical line from an absolute point");
                 assertEqual(path([["P", 5, 6], ["V"]]), [[5, 6]], "Path with 1 empty vertical line from an absolute point");
+
+                // intersection line
+                assertEqual(path([["I"]]), [[0, 0]], "Path with 1 empty intersection line");
+                assertEqual(path([["I", [3, 3], [1, 3], [6, -2]]]), [[0, 0], [2, 2]], "Path with 1 intersection line");
+                assertEqual(path([["P", 5, 6], ["I", [8, 9], [6, 9], [11, 4]]]), [[5, 6], [7, 8]], "Path with 1 intersection line from an absolute point");
+                assertEqual(path([["P", 5, 6], ["I"]]), [[5, 6]], "Path with 1 empty intersection line from an absolute point");
+
+                // tangent line
+                assertEqual(path([["T"]]), [[0, 0]], "Path with 1 empty tangent line");
+                assertEqual(path([["T", 8, 6, 2]]), [[0, 0], arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line");
+                assertEqual(path([["P", 11, 5], ["T", 19, 11, 2]]), [[11, 5], [11, 5] + arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10))], "Path with 1 tangent line from an absolute point");
+                assertEqual(path([["P", 5, 6], ["T"]]), [[5, 6]], "Path with 1 empty tangent line from an absolute point");
 
                 // leaned line
                 assertEqual(path([["A"]]), [[0, 0]], "Path with 1 empty leaned line");

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -334,26 +334,30 @@ module testCoreMaths() {
                 assertEqual(apothem(["1"], ["2"]), 0, "Arrays should be converted to 0");
                 assertEqual(apothem([1], [2]), 0, "Vectors should be converted to 0");
             }
-            testUnit("number", 15) {
+            testUnit("number", 18) {
                 assertEqual(apothem(0), 0, "If the only one parameter is 0, the function should not fail, but should return 0");
-                assertEqual(apothem(0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
+                assertEqual(apothem(0, 0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
 
-                assertEqual(apothem(r=8), 8 * cos(PI / 3), "If only the radius is provided, the function should compute the apothem of a triangle");
-                assertEqual(apothem(a=8), 8 / 2 * tan(PI / 3), "If only the lenght of a side is provided, the function should compute the apothem of a triangle");
+                assertEqual(apothem(r=8), 8 * cos(60), "If only the radius is provided, the function should compute the apothem of a triangle");
+                assertEqual(apothem(l=8), 8 / (2 * tan(60)), "If only the length of a side is provided, the function should compute the apothem of a triangle");
                 assertEqual(apothem(n=8), 0, "If only the number of sides is provided, the function cannot compute the result");
 
-                assertEqual(apothem(n=4, r=8), 8 * cos(PI / 4), "Apothem of a square, using the radius");
-                assertEqual(apothem(n=5, r=8), 8 * cos(PI / 5), "Apothem of a pentagon, using the radius");
-                assertEqual(apothem(n=6, r=8), 8 * cos(PI / 6), "Apothem of an hexagon, using the radius");
-                assertEqual(apothem(n=8, r=8), 8 * cos(PI / 8), "Apothem of an octogon, using the radius");
+                assertEqual(apothem(r=8, n=4), 8 * cos(45), "Apothem of a square, using the radius");
+                assertEqual(apothem(r=8, n=5), 8 * cos(36), "Apothem of a pentagon, using the radius");
+                assertEqual(apothem(r=8, n=6), 8 * cos(30), "Apothem of an hexagon, using the radius");
+                assertEqual(apothem(r=8, n=8), 8 * cos(22.5), "Apothem of an octogon, using the radius");
 
-                assertEqual(apothem(n=4, a=8), 8 / 2 * tan(PI / 4), "Apothem of a square, using the side");
-                assertEqual(apothem(n=5, a=8), 8 / 2 * tan(PI / 5), "Apothem of a pentagon, using the side");
-                assertEqual(apothem(n=6, a=8), 8 / 2 * tan(PI / 6), "Apothem of an hexagon, using the side");
-                assertEqual(apothem(n=8, a=8), 8 / 2 * tan(PI / 8), "Apothem of an octogon, using the side");
+                assertEqual(apothem(l=8, n=4), 8 / (2 * tan(45)), "Apothem of a square, using the side");
+                assertEqual(apothem(l=8, n=5), 8 / (2 * tan(36)), "Apothem of a pentagon, using the side");
+                assertEqual(apothem(l=8, n=6), 8 / (2 * tan(30)), "Apothem of an hexagon, using the side");
+                assertEqual(apothem(l=8, n=8), 8 / (2 * tan(22.5)), "Apothem of an octogon, using the side");
 
-                assertEqual(apothem(6, 8), 8 * cos(PI / 6), "Apothem of an hexagon, using the default order of parameters");
-                assertEqual(apothem(6, 8, 10), 8 * cos(PI / 6), "Apothem of an hexagon, using the default order of parameters with all provided (radius should predomin)");
+                assertEqual(apothem(6, 8), 8 * cos(30), "Apothem of an hexagon, using the default order of parameters");
+                assertEqual(apothem(6, 8, 10), 8 * cos(30), "Apothem of an hexagon, using the default order of parameters with all provided (radius should predomin)");
+
+                assertEqual(apothem(n=4, r=sqrt(32) / 2), apothem(n=4, l=4), "Apothem of a square, comparing results using radius and side");
+                assertApproxEqual(apothem(n=4, l=4), 2, "Apothem of a square, comparing results and side");
+                assertApproxEqual(apothem(n=6, r=4), apothem(n=6, l=4), "Apothem of an hexagon, comparing results using radius and side");
             }
         }
         // test core/maths/factorial()

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 15) {
+    testPackage("core/maths.scad", 16) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -655,6 +655,23 @@ module testCoreMaths() {
                 assertEqual(decimals(-1.123456), 6, "Should count 6 decimals in this negative number");
                 assertEqual(decimals(1.12345678), 7, "Should count 7 decimals in this positive number");
                 assertEqual(decimals(-1.12345678), 7, "Should count 7 decimals in this negative number");
+            }
+        }
+        // test core/maths/quadraticEquation()
+        testModule("quadraticEquation()", 2) {
+            testUnit("default value", 4) {
+                assertEqual(quadraticEquation(), [], "Cannot resolve quadratic equation of undefined");
+                assertEqual(quadraticEquation("1", "2", "3"), [], "Cannot resolve quadratic equation of strings");
+                assertEqual(quadraticEquation(true, true, true), [], "Cannot resolve quadratic equation of booleans");
+                assertEqual(quadraticEquation([1], [2], [3]), [], "Cannot resolve quadratic equation of vectors");
+            }
+            testUnit("resolve", 6) {
+                assertEqual(quadraticEquation(2, -22, 53), [(22 - sqrt(60)) / 4, (22 + sqrt(60)) / 4], "Should resolve the quadratic equation 2x^2 - 22x + 53 = 0");
+                assertEqual(quadraticEquation(2, 4, -4), [-1 - sqrt(3), -1 + sqrt(3)], "Should resolve the quadratic equation 2x^2 + 4x - 4 = 0");
+                assertEqual(quadraticEquation(10, -124, 1603), [], "Should not resolve the quadratic equation 10x^2 + -124x - 1603 = 0");
+                assertEqual(quadraticEquation(0, 1, 2), [], "Should not resolve the quadratic equation 0x^2 + 1x - 2 = 0");
+                assertEqual(quadraticEquation(1, 0, 2), [], "Should not resolve the quadratic equation 1x^2 + 0x - 2 = 0");
+                assertEqual(quadraticEquation(1, 2, 0), [-2, 0], "Should resolve the quadratic equation 1x^2 + 2x - 0 = 0");
             }
         }
     }

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 13) {
+    testPackage("core/maths.scad", 14) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -320,6 +320,40 @@ module testCoreMaths() {
                 assertEqual(pythagore(a=3, c=8), sqrt(64-9), "If B and C are provided the function should compute A");
                 assertEqual(pythagore(a=3, b=5, c=8), sqrt(64-9), "If A, B and C are provided the function should compute B");
 
+            }
+        }
+        // test core/maths/apothem()
+        testModule("apothem()") {
+            testUnit("no parameter", 1) {
+                assertEqual(apothem(), 0, "Without parameter the function should return 0");
+            }
+            testUnit("wrong type", 5) {
+                assertEqual(apothem("10", "10"), 0, "Strings should be converted to 0");
+                assertEqual(apothem(true, true), 0, "Booleans should be converted to 0");
+                assertEqual(apothem([], []), 0, "Empty arrays should be converted to 0");
+                assertEqual(apothem(["1"], ["2"]), 0, "Arrays should be converted to 0");
+                assertEqual(apothem([1], [2]), 0, "Vectors should be converted to 0");
+            }
+            testUnit("number", 15) {
+                assertEqual(apothem(0), 0, "If the only one parameter is 0, the function should not fail, but should return 0");
+                assertEqual(apothem(0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
+
+                assertEqual(apothem(r=8), 8 * cos(PI / 3), "If only the radius is provided, the function should compute the apothem of a triangle");
+                assertEqual(apothem(a=8), 8 / 2 * tan(PI / 3), "If only the lenght of a side is provided, the function should compute the apothem of a triangle");
+                assertEqual(apothem(n=8), 0, "If only the number of sides is provided, the function cannot compute the result");
+
+                assertEqual(apothem(n=4, r=8), 8 * cos(PI / 4), "Apothem of a square, using the radius");
+                assertEqual(apothem(n=5, r=8), 8 * cos(PI / 5), "Apothem of a pentagon, using the radius");
+                assertEqual(apothem(n=6, r=8), 8 * cos(PI / 6), "Apothem of an hexagon, using the radius");
+                assertEqual(apothem(n=8, r=8), 8 * cos(PI / 8), "Apothem of an octogon, using the radius");
+
+                assertEqual(apothem(n=4, a=8), 8 / 2 * tan(PI / 4), "Apothem of a square, using the side");
+                assertEqual(apothem(n=5, a=8), 8 / 2 * tan(PI / 5), "Apothem of a pentagon, using the side");
+                assertEqual(apothem(n=6, a=8), 8 / 2 * tan(PI / 6), "Apothem of an hexagon, using the side");
+                assertEqual(apothem(n=8, a=8), 8 / 2 * tan(PI / 8), "Apothem of an octogon, using the side");
+
+                assertEqual(apothem(6, 8), 8 * cos(PI / 6), "Apothem of an hexagon, using the default order of parameters");
+                assertEqual(apothem(6, 8, 10), 8 * cos(PI / 6), "Apothem of an hexagon, using the default order of parameters with all provided (radius should predomin)");
             }
         }
         // test core/maths/factorial()

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 14) {
+    testPackage("core/maths.scad", 15) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -358,6 +358,49 @@ module testCoreMaths() {
                 assertEqual(apothem(n=4, r=sqrt(32) / 2), apothem(n=4, l=4), "Apothem of a square, comparing results using radius and side");
                 assertApproxEqual(apothem(n=4, l=4), 2, "Apothem of a square, comparing results and side");
                 assertApproxEqual(apothem(n=6, r=4), apothem(n=6, l=4), "Apothem of an hexagon, comparing results using radius and side");
+            }
+        }
+        // test core/maths/circumradius()
+        testModule("circumradius()") {
+            testUnit("no parameter", 1) {
+                assertEqual(circumradius(), 0, "Without parameter the function should return 0");
+            }
+            testUnit("wrong type", 5) {
+                assertEqual(circumradius("10", "10"), 0, "Strings should be converted to 0");
+                assertEqual(circumradius(true, true), 0, "Booleans should be converted to 0");
+                assertEqual(circumradius([], []), 0, "Empty arrays should be converted to 0");
+                assertEqual(circumradius(["1"], ["2"]), 0, "Arrays should be converted to 0");
+                assertEqual(circumradius([1], [2]), 0, "Vectors should be converted to 0");
+            }
+            testUnit("number", 22) {
+                assertEqual(circumradius(0), 0, "If the only one parameter is 0, the function should not fail, but should return 0");
+                assertEqual(circumradius(0, 0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
+
+                assertEqual(circumradius(a=8), 8 / cos(60), "If only the length is provided, the function should compute the circumradius of a triangle");
+                assertEqual(circumradius(l=8), apothem(l=8)/ cos(60), "If only the length of a side is provided, the function should compute the circumradius of a triangle");
+                assertEqual(circumradius(n=8), 0, "If only the number of sides is provided, the function cannot compute the result");
+
+                assertEqual(circumradius(a=8, n=4), 8 / cos(45), "Circumradius of a square, using the the apothem");
+                assertEqual(circumradius(a=8, n=5), 8 / cos(36), "Circumradius of a pentagon, using the the apothem");
+                assertEqual(circumradius(a=8, n=6), 8 / cos(30), "Circumradius of an hexagon, using the the apothem");
+                assertEqual(circumradius(a=8, n=8), 8 / cos(22.5), "Circumradius of an octogon, using the the apothem");
+
+                assertEqual(circumradius(l=8, n=4), apothem(l=8, n=4) / cos(45), "Circumradius of a square, using the the side");
+                assertEqual(circumradius(l=8, n=5), apothem(l=8, n=5) / cos(36), "Circumradius of a pentagon, using the the side");
+                assertEqual(circumradius(l=8, n=6), apothem(l=8, n=6) / cos(30), "Circumradius of an hexagon, using the the side");
+                assertEqual(circumradius(l=8, n=8), apothem(l=8, n=8) / cos(22.5), "Circumradius of an octogon, using the the side");
+
+                assertEqual(circumradius(6, 8), 8 / cos(30), "Circumradius of an hexagon, using the default order of parameters");
+                assertEqual(circumradius(6, 8, 10), 8 / cos(30), "Circumradius of an hexagon, using the default order of parameters with all provided (apothem should predomin)");
+
+                assertEqual(circumradius(n=6, a=apothem(n=6, l=8)), circumradius(n=6, l=8), "Circumradius of an hexagon, comparing results using apothem and side");
+                assertApproxEqual(circumradius(n=4, a=2), circumradius(n=4, l=4), "Circumradius of a square, comparing results using apothem and side");
+                assertApproxEqual(circumradius(n=6, l=4), 4, "Circumradius of an hexagon, comparing results and side");
+
+                assertEqual(circumradius(n=4, a=apothem(n=4, r=8)), 8, "Circumradius of a square, using radius of the inscribed circle");
+                assertEqual(circumradius(n=5, a=apothem(n=5, r=8)), 8, "Circumradius of a pentagon, using radius of the inscribed circle");
+                assertEqual(circumradius(n=6, a=apothem(n=6, r=8)), 8, "Circumradius of an hexagon, using radius of the inscribed circle");
+                assertEqual(circumradius(n=8, a=apothem(n=8, r=8)), 8, "Circumradius of an octogon, using radius of the inscribed circle");
             }
         }
         // test core/maths/factorial()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 25) {
+    testPackage("core/vector-2d.scad", 26) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -302,6 +302,26 @@ module testCoreVector2D() {
                 assertEqual(parallel2D([4, 5], [6, 7], [2, 3], [0, 1]), true, "parallels segments");
                 assertEqual(parallel2D([4, 5], [8, 7], [2, 3], [5, 1]), false, "not parallels segments");
                 assertEqual(parallel2D([0, 0], [3, 0], [1, 2], [1, 4]), false, "perpendicular segments");
+            }
+        }
+        // test core/vector-2d/intersect2D()
+        testModule("intersect2D()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(intersect2D(), [0, 0], "Without parameter the function should return the origin");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(intersect2D("10", "10", "10", "10"), [0, 0], "Cannot compute intersection of strings, should return the origin");
+                assertEqual(intersect2D(true, true, true, true), [0, 0], "Cannot compute intersection of boolean, should return the origin");
+                assertEqual(intersect2D([], [], [], []), [0, 0], "Cannot compute intersection of empty arrays, should return the origin");
+                assertEqual(intersect2D(["1"], ["2"], ["3"], ["4"]), [0, 0], "Cannot compute intersection of arrays, should return the origin");
+            }
+            testUnit("intersection", 6) {
+                assertEqual(intersect2D(1, 2, 3, 4), [1, 1], "Numbers should be converted to vectors");
+                assertEqual(intersect2D([1, 1], [2, 2], [3, 1], [4, 2]), [1, 1], "Parallel lines");
+                assertEqual(intersect2D([1, 1], [2, 2], [1, 2], [2, 1]), [1.5, 1.5], "Perpendicular lines");
+                assertEqual(intersect2D([0, -3], [1, 0], [0, 3], [1, 0]), [1, 0], "Lines crossing on X axis");
+                assertEqual(intersect2D([-3, 0], [0, 1], [3, 0], [0, 1]), [0, 1], "Lines crossing on Y axis");
+                assertEqual(intersect2D([-3, 1], [3, 8], [-2, 5], [7, 3]), [-3, 1] + (-38 / -75) * [6, 7], "Lines crossing on Y axis");
             }
         }
         // test core/vector-2d/angle2D()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 30) {
+    testPackage("core/vector-2d.scad", 31) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -399,6 +399,58 @@ module testCoreVector2D() {
                 assertApproxEqual(tangent2D([-19, -11], [-11, -5], -2), [-19, -11] + arcPoint(sqrt(96), atan2(6, 8) + asin(-2 / 10)), "Third quadrant, a cicle on the right");
                 assertApproxEqual(tangent2D([11, -5], [19, -11], -2), [11, -5] + arcPoint(sqrt(96), atan2(-6, 8) + asin(-2 / 10)), "Fourth quadrant, a cicle on the right");
                 assertApproxEqual(tangent2D([19, -11], [11, -5], -2), [19, -11] + arcPoint(sqrt(96), atan2(6, -8) + asin(-2 / 10)), "Fourth quadrant, a cicle on the left");
+            }
+        }
+        // test core/vector-2d/circleLineIntersect2D()
+        testModule("circleLineIntersect2D()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(circleLineIntersect2D(), [[0, 0], [0, 0]], "Without parameter the function cannot compute the intersection");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(circleLineIntersect2D("10", "10", "10", "10"), [[0, 0], [0, 0]], "Cannot compute intersection of strings");
+                assertEqual(circleLineIntersect2D(true, true, true, true), [[0, 0], [0, 0]], "Cannot compute intersection of booleans");
+                assertEqual(circleLineIntersect2D([], [], [], []), [[0, 0], [0, 0]], "Cannot compute intersection of empty arrays");
+                assertEqual(circleLineIntersect2D(["10"], ["10"], ["10"], ["10"]), [[0, 0], [0, 0]], "Cannot compute intersection of arrays");
+            }
+            testUnit("positive", 15) {
+                assertApproxEqual(circleLineIntersect2D(1, 2, 3, 4), [vector2D((12 - sqrt(128)) / 4), vector2D((12 + sqrt(128)) / 4)], "Numbers should be converted to vectors");
+                assertApproxEqual(circleLineIntersect2D([1, -1], [5, 3], [5, 4], 2), [vector2D((22 - sqrt(28)) / 4) - [0, 2], vector2D((22 + sqrt(28)) / 4) - [0, 2]], "45° line");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [5, 1], [3, 1], 1), [[2, 1], [4, 1]], "Horizontal centered line");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [1, 5], [1, 3], 1), [[1, 2], [1, 4]], "Vertical centered line");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [5, 1], [3, 2], 2), [[3 - sqrt(3), 1], [3 + sqrt(3), 1]], "Horizontal shifted line");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [1, 5], [2, 3], 2), [[1, 3 - sqrt(3)], [1, 3 + sqrt(3)]], "Vertical shifted line");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [5, 1], [3, 2], 1), [[3, 1], [3, 1]], "Horizontal tangent line");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [1, 5], [2, 3], 1), [[1, 3], [1, 3]], "Vertical tangent line");
+                assertApproxEqual(circleLineIntersect2D([8, 0], [2, 12], [4, 3], sqrt(5)), [[6, 4], [6, 4]], "Leaned tangent line");
+                assertApproxEqual(circleLineIntersect2D([6, 4], [6, 4], [4, 3], sqrt(5)), [[6, 4], [6, 4]], "Tangent point");
+                assertApproxEqual(circleLineIntersect2D([2, 5], [8, 3], [5, 4], 3), [
+                    vmul(vector2D((100 / 9 - sqrt(40)) / (20 / 9)), [1, -1 / 3]) + [0, 17 / 3],
+                    vmul(vector2D((100 / 9 + sqrt(40)) / (20 / 9)), [1, -1 / 3]) + [0, 17 / 3]
+                ], "Leaned line");
+                assertApproxEqual(circleLineIntersect2D([2, 5], [8, 3], [10, 15], 3), [], "Leaned line, no intersection");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [5, 1], [3, 3], 1), [], "Horizontal line, no intersection");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [1, 5], [3, 3], 1), [], "Vertical line, no intersection");
+                assertApproxEqual(circleLineIntersect2D([1, 1], [1, 1], [3, 3], 1), [], "Point, no intersection");
+            }
+            testUnit("negative", 15) {
+                assertApproxEqual(circleLineIntersect2D(-1, -2, -3, -4), [vector2D((-12 - sqrt(128)) / 4), vector2D((-12 + sqrt(128)) / 4)], "Numbers should be converted to vectors");
+                assertApproxEqual(circleLineIntersect2D([-1, 1], [-5, -3], [-5, -4], -2), [vector2D((-22 - sqrt(28)) / 4) + [0, 2], vector2D((-22 + sqrt(28)) / 4) + [0, 2]], "45° line");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-5, -1], [-3, -1], -1), [[-4, -1], [-2, -1]], "Horizontal centered line");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-1, -5], [-1, -3], -1), [[-1, -4], [-1, -2]], "Vertical centered line");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-5, -1], [-3, -2], -2), [[-3 - sqrt(3), -1], [-3 + sqrt(3), -1]], "Horizontal shifted line");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-1, -5], [-2, -3], -2), [[-1, -3 - sqrt(3)], [-1, -3 + sqrt(3)]], "Vertical shifted line");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-5, -1], [-3, -2], -1), [[-3, -1], [-3, -1]], "Horizontal tangent line");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-1, -5], [-2, -3], -1), [[-1, -3], [-1, -3]], "Vertical tangent line");
+                assertApproxEqual(circleLineIntersect2D([-8, 0], [-2, -12], [-4, -3], sqrt(5)), [[-6, -4], [-6, -4]], "Leaned tangent line");
+                assertApproxEqual(circleLineIntersect2D([-6, -4], [-6, -4], [-4, -3], sqrt(5)), [[-6, -4], [-6, -4]], "Tangent point");
+                assertApproxEqual(circleLineIntersect2D([-2, -5], [-8, -3], [-5, -4], -3), [
+                    vmul(vector2D((-100 / 9 - sqrt(40)) / (20 / 9)), [1, -1 / 3]) - [0, 17 / 3],
+                    vmul(vector2D((-100 / 9 + sqrt(40)) / (20 / 9)), [1, -1 / 3]) - [0, 17 / 3]
+                ], "Leaned line");
+                assertApproxEqual(circleLineIntersect2D([-2, -5], [-8, -3], [-10, -15], -3), [], "Leaned line, no intersection");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-5, -1], [-3, -3], -1), [], "Horizontal line, no intersection");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-1, -5], [-3, -3], -1), [], "Vertical line, no intersection");
+                assertApproxEqual(circleLineIntersect2D([-1, -1], [-1, -1], [-3, -3], -1), [], "Point, no intersection");
             }
         }
         // test core/vector-2d/isosceles2D()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 31) {
+    testPackage("core/vector-2d.scad", 32) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -451,6 +451,54 @@ module testCoreVector2D() {
                 assertApproxEqual(circleLineIntersect2D([-1, -1], [-5, -1], [-3, -3], -1), [], "Horizontal line, no intersection");
                 assertApproxEqual(circleLineIntersect2D([-1, -1], [-1, -5], [-3, -3], -1), [], "Vertical line, no intersection");
                 assertApproxEqual(circleLineIntersect2D([-1, -1], [-1, -1], [-3, -3], -1), [], "Point, no intersection");
+            }
+        }
+        // test core/vector-2d/circleIntersect2D()
+        testModule("circleIntersect2D()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(circleIntersect2D(), [], "Without parameter the function cannot compute the intersection");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(circleIntersect2D("10", "10", "10", "10"), [], "Cannot compute intersection of strings");
+                assertEqual(circleIntersect2D(true, true, true, true), [], "Cannot compute intersection of booleans");
+                assertEqual(circleIntersect2D([], [], [], []), [], "Cannot compute intersection of empty arrays");
+                assertEqual(circleIntersect2D(["10"], ["10"], ["10"], ["10"]), [], "Cannot compute intersection of arrays");
+            }
+            testUnit("positive", 13) {
+                assertApproxEqual(circleIntersect2D(1, 2, 3, 4), [[(2 - sqrt(28)) / 4, 1 - (2 - sqrt(28)) / 4], [(2 + sqrt(28)) / 4, 1 - (2 + sqrt(28)) / 4]], "Numbers should be converted to vectors");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [3, 3], 4), [[(2 - sqrt(28)) / 4, 1 - (2 - sqrt(28)) / 4], [(2 + sqrt(28)) / 4, 1 - (2 + sqrt(28)) / 4]], "Circles aligned at 45°");
+                assertApproxEqual(circleIntersect2D([3, 2], 3, [4, 5], 2), [
+                    [((25 - 3 * sqrt(15)) / 3) / (20 / 9), 11 / 2 - ((25 - 3 * sqrt(15)) / 3) / (20 / 9) / 3],
+                    [((25 + 3 * sqrt(15)) / 3) / (20 / 9), 11 / 2 - ((25 + 3 * sqrt(15)) / 3) / (20 / 9) / 3]
+                ], "Intersecting circles");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [3, 1], 2), [[0, 1 + sqrt(3)], [2, 1 + sqrt(3)]], "Circles aligned on horizontal axis");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [1, 3], 2), [[1 + sqrt(3), 0], [1 + sqrt(3), 2]], "Circles aligned on vertical axis");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [5, 1], 2), [[3, 1], [3, 1]], "Tangent circles on horizontal axis");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [1, 5], 2), [[1, 3], [1, 3]], "Tangent circles on vertical axis");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [1, 1] + [4 * cos(45), 4 * sin(45)], 2), [[1, 1] + [2 * cos(45), 2 * sin(45)], [1, 1] + [2 * cos(45), 2 * sin(45)]], "Tangent circles");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [6, 1], 2), [], "Not intersecting circles aligned on horizontal axis");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [1, 6], 2), [], "Not intersecting circles aligned on vertical axis");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [1, 1], 3), [], "Concentric circles");
+                assertApproxEqual(circleIntersect2D([1, 1], 2, [1, 1], 2), [], "Concentric and equal circles");
+                assertApproxEqual(circleIntersect2D([1, 4], 2, [8, 3], 2), [], "Not intersecting circles");
+            }
+            testUnit("negative", 13) {
+                assertApproxEqual(circleIntersect2D(-1, -2, -3, -4), [[(-2 - sqrt(28)) / 4, -1 - (-2 - sqrt(28)) / 4], [(-2 + sqrt(28)) / 4, -1 - (-2 + sqrt(28)) / 4]], "Numbers should be converted to vectors");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-3, -3], -4), [[(-2 - sqrt(28)) / 4, -1 - (-2 - sqrt(28)) / 4], [(-2 + sqrt(28)) / 4, -1 - (-2 + sqrt(28)) / 4]], "Circles aligned at 45°");
+                assertApproxEqual(circleIntersect2D([-3, -2], -3, [-4, -5], -2), [
+                    [((-25 - 3 * sqrt(15)) / 3) / (20 / 9), -11 / 2 - ((-25 - 3 * sqrt(15)) / 3) / (20 / 9) / 3],
+                    [((-25 + 3 * sqrt(15)) / 3) / (20 / 9), -11 / 2 - ((-25 + 3 * sqrt(15)) / 3) / (20 / 9) / 3]
+                ], "Intersecting circles");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-3, -1], -2), [[0, -1 + sqrt(3)], [-2, -1 + sqrt(3)]], "Circles aligned on horizontal axis");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-1, -3], -2), [[-1 + sqrt(3), 0], [-1 + sqrt(3), -2]], "Circles aligned on vertical axis");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-5, -1], -2), [[-3, -1], [-3, -1]], "Tangent circles on horizontal axis");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-1, -5], -2), [[-1, -3], [-1, -3]], "Tangent circles on vertical axis");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-1, -1] - [4 * cos(45), 4 * sin(45)], 2), [[-1, -1] - [2 * cos(45), 2 * sin(45)], [-1, -1] - [2 * cos(45), 2 * sin(45)]], "Tangent circles");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-6, -1], -2), [], "Not intersecting circles aligned on horizontal axis");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-1, -6], -2), [], "Not intersecting circles aligned on vertical axis");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-1, -1], -3), [], "Concentric circles");
+                assertApproxEqual(circleIntersect2D([-1, -1], -2, [-1, -1], -2), [], "Concentric and equal circles");
+                assertApproxEqual(circleIntersect2D([-1, -4], -2, [-8, -3], -2), [], "Not intersecting circles");
             }
         }
         // test core/vector-2d/isosceles2D()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -323,23 +323,24 @@ module testCoreVector2D() {
         // test core/vector-2d/parallel2D()
         testModule("parallel2D()", 3) {
             testUnit("no parameter", 1) {
-                assertEqual(parallel2D(), true, "Without parameter the function should return true");
+                assertEqual(parallel2D(), [[0, 0], [0, 0]], "Without parameter the function should return the origin");
             }
             testUnit("wrong type", 4) {
-                assertEqual(parallel2D("10", "10", "10", "10"), true, "Cannot tell if strings are parallels");
-                assertEqual(parallel2D(true, true, true, true), true, "Cannot tell if boolean are parallels");
-                assertEqual(parallel2D([], [], [], []), true, "Cannot tell if empty arrays are parallels");
-                assertEqual(parallel2D(["1"], ["2"], ["3"], ["4"]), true, "Cannot tell if arrays are parallels");
+                assertEqual(parallel2D("10", "10", "10"), [[0, 0], [0, 0]], "Cannot compute parallel of strings");
+                assertEqual(parallel2D(true, true, true), [[0, 0], [0, 0]], "Cannot compute parallel of boolean");
+                assertEqual(parallel2D([], [], []), [[0, 0], [0, 0]], "Cannot compute parallel of empty arrays");
+                assertEqual(parallel2D(["1"], ["2"], ["3"]), [[0, 0], [0, 0]], "Cannot compute parallel of arrays");
             }
-            testUnit("check", 8) {
-                assertEqual(parallel2D(0, 1, 2, 3), true, "Numbers should be converted to vectors");
-                assertEqual(parallel2D([0, 0], [1, 1], [2, 2], [3, 3]), true, "45° positive segments");
-                assertEqual(parallel2D([0, 0], [-1, 1], [-2, 2], [-3, 3]), true, "45° negative segments");
-                assertEqual(parallel2D([0, 0], [3, 0], [1, 2], [3, 2]), true, "horizontal segments");
-                assertEqual(parallel2D([0, 0], [0, 3], [2, 1], [2, 3]), true, "vertical segments");
-                assertEqual(parallel2D([4, 5], [6, 7], [2, 3], [0, 1]), true, "parallels segments");
-                assertEqual(parallel2D([4, 5], [8, 7], [2, 3], [5, 1]), false, "not parallels segments");
-                assertEqual(parallel2D([0, 0], [3, 0], [1, 2], [1, 4]), false, "perpendicular segments");
+            testUnit("check", 9) {
+                assertApproxEqual(parallel2D(0, 1, 2), [[-2 * cos(135), -2 * sin(135)], [1 - 2 * cos(135), 1 - 2 * sin(135)]], "Numbers should be converted to vectors");
+                assertApproxEqual(parallel2D([0, 0], [1, 1], 2), [[-2 * cos(135), -2 * sin(135)], [1 - 2 * cos(135), 1 - 2 * sin(135)]], "45° positive line with a distance of 2");
+                assertApproxEqual(parallel2D([0, 0], [1, 1], -2), [[2 * cos(135), 2 * sin(135)], [1 + 2 * cos(135), 1 + 2 * sin(135)]], "45° positive line with a distance of -2");
+                assertApproxEqual(parallel2D([0, 0], [-1, -1], 2), [[2 * cos(135), 2 * sin(135)], [-1 + 2 * cos(135), -1 + 2 * sin(135)]], "45° negative line with a distance of 2");
+                assertApproxEqual(parallel2D([0, 0], [-1, -1], -2), [[-2 * cos(135), -2 * sin(135)], [-1 - 2 * cos(135), -1 - 2 * sin(135)]], "45° negative line with a distance of -2");
+                assertEqual(parallel2D([0, 2], [3, 2], 3), [[0, -1], [3, -1]], "horizontal line with a distance of 3");
+                assertEqual(parallel2D([0, 2], [3, 2], -3), [[0, 5], [3, 5]], "horizontal line with a distance of -3");
+                assertEqual(parallel2D([4, -2], [4, 8], 3), [[7, -2], [7, 8]], "vertical line with a distance of 3");
+                assertEqual(parallel2D([4, -2], [4, 8], -3), [[1, -2], [1, 8]], "vertical line with a distance of -3");
             }
         }
         // test core/vector-2d/intersect2D()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 26) {
+    testPackage("core/vector-2d.scad", 27) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -322,6 +322,44 @@ module testCoreVector2D() {
                 assertEqual(intersect2D([0, -3], [1, 0], [0, 3], [1, 0]), [1, 0], "Lines crossing on X axis");
                 assertEqual(intersect2D([-3, 0], [0, 1], [3, 0], [0, 1]), [0, 1], "Lines crossing on Y axis");
                 assertEqual(intersect2D([-3, 1], [3, 8], [-2, 5], [7, 3]), [-3, 1] + (-38 / -75) * [6, 7], "Lines crossing on Y axis");
+            }
+        }
+        // test core/vector-2d/tangent2D()
+        testModule("tangent2D()", 5) {
+            testUnit("no parameter", 1) {
+                assertEqual(tangent2D(), [0, 0], "Without parameter the function should return the origin");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(tangent2D("10", "10", "10"), [0, 0], "Cannot compute tangent of strings, should return the origin");
+                assertEqual(tangent2D(true, true, true), [0, 0], "Cannot compute tangent of boolean, should return the origin");
+                assertEqual(tangent2D([], [], []), [0, 0], "Cannot compute tangent of empty arrays, should return the origin");
+                assertEqual(tangent2D(["1"], ["2"], ["3"]), [0, 0], "Cannot compute tangent of arrays, should return the origin");
+            }
+            testUnit("inside circle", 2) {
+                assertApproxEqual(tangent2D(1, 2, 3), [1, 1], "Numbers should be converted to vectors");
+                assertApproxEqual(tangent2D([6, 4], [5, 6], 3), [6, 4], "The point is inside the circle");
+            }
+            testUnit("positive", 9) {
+                assertApproxEqual(tangent2D(3, 2, 1), [3, 2], "Numbers should be converted to vectors");
+                assertApproxEqual(tangent2D([11, 5], [19, 11], 2), [11, 5] + arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10)), "First quadrant, a cicle on the right");
+                assertApproxEqual(tangent2D([19, 11], [11, 5], 2), [19, 11] + arcPoint(sqrt(96), atan2(-6, -8) + asin(2 / 10)), "First quadrant, a cicle on the left");
+                assertApproxEqual(tangent2D([-11, 5], [-19, 11], 2), [-11, 5] + arcPoint(sqrt(96), atan2(6, -8) + asin(2 / 10)), "Second quadrant, a cicle on the left");
+                assertApproxEqual(tangent2D([-19, 11], [-11, 5], 2), [-19, 11] + arcPoint(sqrt(96), atan2(-6, 8) + asin(2 / 10)), "Second quadrant, a cicle on the right");
+                assertApproxEqual(tangent2D([-11, -5], [-19, -11], 2), [-11, -5] + arcPoint(sqrt(96), atan2(-6, -8) + asin(2 / 10)), "Third quadrant, a cicle on the left");
+                assertApproxEqual(tangent2D([-19, -11], [-11, -5], 2), [-19, -11] + arcPoint(sqrt(96), atan2(6, 8) + asin(2 / 10)), "Third quadrant, a cicle on the right");
+                assertApproxEqual(tangent2D([11, -5], [19, -11], 2), [11, -5] + arcPoint(sqrt(96), atan2(-6, 8) + asin(2 / 10)), "Fourth quadrant, a cicle on the right");
+                assertApproxEqual(tangent2D([19, -11], [11, -5], 2), [19, -11] + arcPoint(sqrt(96), atan2(6, -8) + asin(2 / 10)), "Fourth quadrant, a cicle on the left");
+            }
+            testUnit("negative", 9) {
+                assertApproxEqual(tangent2D(3, 2, -1), [2, 3], "Numbers should be converted to vectors");
+                assertApproxEqual(tangent2D([11, 5], [19, 11], -2), [11, 5] + arcPoint(sqrt(96), atan2(6, 8) + asin(-2 / 10)), "First quadrant, a cicle on the right");
+                assertApproxEqual(tangent2D([19, 11], [11, 5], -2), [19, 11] + arcPoint(sqrt(96), atan2(-6, -8) + asin(-2 / 10)), "First quadrant, a cicle on the left");
+                assertApproxEqual(tangent2D([-11, 5], [-19, 11], -2), [-11, 5] + arcPoint(sqrt(96), atan2(6, -8) + asin(-2 / 10)), "Second quadrant, a cicle on the left");
+                assertApproxEqual(tangent2D([-19, 11], [-11, 5], -2), [-19, 11] + arcPoint(sqrt(96), atan2(-6, 8) + asin(-2 / 10)), "Second quadrant, a cicle on the right");
+                assertApproxEqual(tangent2D([-11, -5], [-19, -11], -2), [-11, -5] + arcPoint(sqrt(96), atan2(-6, -8) + asin(-2 / 10)), "Third quadrant, a cicle on the left");
+                assertApproxEqual(tangent2D([-19, -11], [-11, -5], -2), [-19, -11] + arcPoint(sqrt(96), atan2(6, 8) + asin(-2 / 10)), "Third quadrant, a cicle on the right");
+                assertApproxEqual(tangent2D([11, -5], [19, -11], -2), [11, -5] + arcPoint(sqrt(96), atan2(-6, 8) + asin(-2 / 10)), "Fourth quadrant, a cicle on the right");
+                assertApproxEqual(tangent2D([19, -11], [11, -5], -2), [19, -11] + arcPoint(sqrt(96), atan2(6, -8) + asin(-2 / 10)), "Fourth quadrant, a cicle on the left");
             }
         }
         // test core/vector-2d/angle2D()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 29) {
+    testPackage("core/vector-2d.scad", 30) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -253,6 +253,44 @@ module testCoreVector2D() {
                 assertEqual(move2D([1, 2, 3]), [1, 2], "Should truncate too big vector and returns a 2D vector (no direction vector)");
                 assertEqual(move2D([1, 2, 3], [1, 2, 3]), [1, 2], "Should truncate too big vector and returns a 2D vector (direction vector but not distance)");
                 assertEqual(move2D([1, 2, 3], [1, 2, 3], 1), [1, 2] + [1, 2] / norm2D([1, 2]), "Should truncate too big vector and returns a 2D vector (direction vector and distance)");
+            }
+        }
+        // test core/vector-2d/extend2D()
+        testModule("extend2D()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(extend2D(), [0, 0], "Should always produce a 2D vector, even if input is wrong");
+            }
+            testUnit("not vector", 15) {
+                assertEqual(extend2D(1), [1, 1], "Should translate number to 2D vector (only origin)");
+                assertEqual(extend2D(1, 1), [1, 1], "Should translate number to 2D vector (origin and second point)");
+                assertEqual(extend2D(1, 2, 3), [1, 1] + unit2D([1, 1]) * 3, "Should translate number to 2D vector (all parameters)");
+
+                assertEqual(extend2D(true), [0, 0], "Should produce a default 2D vector if input is boolean (only origin)");
+                assertEqual(extend2D(true, true), [0, 0], "Should produce a default 2D vector if input is boolean (origin and second point)");
+                assertEqual(extend2D(true, true, true), [0, 0], "Should produce a default 2D vector if input is boolean (all parameters)");
+
+                assertEqual(extend2D("1"), [0, 0], "Should produce a default 2D vector if input is string (only origin)");
+                assertEqual(extend2D("1", "1"), [0, 0], "Should produce a default 2D vector if input is string (origin and second point)");
+                assertEqual(extend2D("1", "1", "1"), [0, 0], "Should produce a default 2D vector if input is string (all parameters)");
+
+                assertEqual(extend2D(["1"]), [0, 0], "Should produce a default 2D vector if input is array (only origin)");
+                assertEqual(extend2D(["1"], ["1"]), [0, 0], "Should produce a default 2D vector if input is array (origin and second point)");
+                assertEqual(extend2D(["1"], ["1"], ["1"]), [0, 0], "Should produce a default 2D vector if input is array (all parameters)");
+
+                assertEqual(extend2D(["1", 1]), [0, 1], "Should produce a corrected 2D vector if input is wrong (only origin)");
+                assertEqual(extend2D(["1", 1], ["1", 1]), [0, 1], "Should produce a corrected 2D vector if input is wrong (origin and second point)");
+                assertEqual(extend2D(["1", 1], ["1", 1], 1), [0, 1], "Should produce a corrected 2D vector if input is wrong (all parameters)");
+            }
+            testUnit("vector", 9) {
+                assertEqual(extend2D([1]), [1, 0], "Should complete incomplete 2D vector (only origin)");
+                assertEqual(extend2D([1], [1]), [1, 0], "Should complete incomplete 2D vector (origin and second point)");
+                assertEqual(extend2D([1], [1], 1), [1, 0], "Should complete incomplete 2D vector (all parameters)");
+                assertEqual(extend2D([1, 2]), [1, 2], "Should return the provided 2D vector (only origin)");
+                assertEqual(extend2D([1, 2], [3, 4]), [1, 2], "Should return the provided 2D vector (origin and second point)");
+                assertEqual(extend2D([1, 2], [3, 4], 3), [1, 2] + unit2D([2, 2]) * 3, "Should return a 2D vector (all parameters)");
+                assertEqual(extend2D([1, 2, 3]), [1, 2], "Should truncate too big vector and returns a 2D vector (only origin)");
+                assertEqual(extend2D([1, 2, 3], [4, 5, 6]), [1, 2], "Should truncate too big vector and returns a 2D vector (origin and second point)");
+                assertEqual(extend2D([1, 2, 3], [3, 4, 5], 3), [1, 2] + unit2D([2, 2]) * 3, "Should truncate too big vector and returns a 2D vector (all parameters)");
             }
         }
         // test core/vector-2d/center2D()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 27) {
+    testPackage("core/vector-2d.scad", 28) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -360,6 +360,36 @@ module testCoreVector2D() {
                 assertApproxEqual(tangent2D([-19, -11], [-11, -5], -2), [-19, -11] + arcPoint(sqrt(96), atan2(6, 8) + asin(-2 / 10)), "Third quadrant, a cicle on the right");
                 assertApproxEqual(tangent2D([11, -5], [19, -11], -2), [11, -5] + arcPoint(sqrt(96), atan2(-6, 8) + asin(-2 / 10)), "Fourth quadrant, a cicle on the right");
                 assertApproxEqual(tangent2D([19, -11], [11, -5], -2), [19, -11] + arcPoint(sqrt(96), atan2(6, -8) + asin(-2 / 10)), "Fourth quadrant, a cicle on the left");
+            }
+        }
+        // test core/vector-2d/isosceles2D()
+        testModule("isosceles2D()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(isosceles2D(), [0, 0], "Without parameter the function should return the origin");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(isosceles2D("10", "10", "10"), [0, 0], "Cannot compute edge of strings, should return the origin");
+                assertEqual(isosceles2D(true, true, true), [0, 0], "Cannot compute edge of boolean, should return the origin");
+                assertEqual(isosceles2D([], [], []), [0, 0], "Cannot compute intersection of edge arrays, should return the origin");
+                assertEqual(isosceles2D(["1"], ["2"], ["3"]), [0, 0], "Cannot compute edge of arrays, should return the origin");
+            }
+            testUnit("height", 7) {
+                assertApproxEqual(isosceles2D(1, 2, 3), [1, 1] + arcPoint(pythagore(3, norm2D([1, 1]) / 2), 45 + atan2(3, norm2D([1, 1]) / 2)), "Numbers should be converted to vectors");
+                assertApproxEqual(isosceles2D([10, 5], [20, 5], 10), [10, 5] + arcPoint(pythagore(10, 5), atan2(10, 5)), "Horizontal triangle, edge on the top");
+                assertApproxEqual(isosceles2D([20, 5], [10, 5], 10), [20, 5] - arcPoint(pythagore(10, 5), atan2(10, 5)), "Horizontal triangle, edge on the bottom");
+                assertApproxEqual(isosceles2D([5, 10], [5, 20], 10), [5, 10] + arcPoint(pythagore(10, 5), atan2(5, -10)), "Vertical triangle, edge on the left");
+                assertApproxEqual(isosceles2D([5, 20], [5, 10], 10), [5, 20] - arcPoint(pythagore(10, 5), atan2(5, -10)), "Vertical triangle, edge on the right");
+                assertApproxEqual(isosceles2D([10, 10], [18, 16], 10), [10, 10] + arcPoint(pythagore(10, 5), atan2(10, 5) + atan2(6, 8)), "Tilted triangle, edge on the top");
+                assertApproxEqual(isosceles2D([18, 16], [10, 10], 10), [18, 16] - arcPoint(pythagore(10, 5), atan2(10, 5) + atan2(6, 8)), "Tilted triangle, edge on the bottom");
+            }
+            testUnit("angle", 7) {
+                assertApproxEqual(isosceles2D(1, 2, angle=45), [1, 2], "Numbers should be converted to vectors");
+                assertApproxEqual(isosceles2D([10, 5], [20, 5], angle=45), [15, 10], "Horizontal triangle, edge on the top");
+                assertApproxEqual(isosceles2D([20, 5], [10, 5], angle=45), [15, 0], "Horizontal triangle, edge on the bottom");
+                assertApproxEqual(isosceles2D([5, 10], [5, 20], angle=45), [0, 15], "Vertical triangle, edge on the left");
+                assertApproxEqual(isosceles2D([5, 20], [5, 10], angle=45), [10, 15], "Vertical triangle, edge on the right");
+                assertApproxEqual(isosceles2D([10, 10], [18, 16], angle=45), [11, 17], "Tilted triangle, edge on the top");
+                assertApproxEqual(isosceles2D([18, 16], [10, 10], angle=45), [17, 9], "Tilted triangle, edge on the bottom");
             }
         }
         // test core/vector-2d/angle2D()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 28) {
+    testPackage("core/vector-2d.scad", 29) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -390,6 +390,22 @@ module testCoreVector2D() {
                 assertApproxEqual(isosceles2D([5, 20], [5, 10], angle=45), [10, 15], "Vertical triangle, edge on the right");
                 assertApproxEqual(isosceles2D([10, 10], [18, 16], angle=45), [11, 17], "Tilted triangle, edge on the top");
                 assertApproxEqual(isosceles2D([18, 16], [10, 10], angle=45), [17, 9], "Tilted triangle, edge on the bottom");
+            }
+        }
+        // test core/vector-2d/protractor()
+        testModule("protractor()", 2) {
+            testUnit("default value", 3) {
+                assertEqual(protractor(), 0, "Should return 0 if no point was provided");
+                assertEqual(protractor("1", "2"), 0, "Cannot compute angle of strings");
+                assertEqual(protractor(true, true), 0, "Cannot compute angle of booleans");
+            }
+            testUnit("compute angle", 6) {
+                assertEqual(protractor(1, 2), 45, "When single numbers are provided, they should be translated to vector.");
+                assertEqual(protractor([3, 5], [3, 9]), 90, "Positive straight angle");
+                assertEqual(protractor([3, 9], [3, 5]), -90, "Negative straight angle");
+                assertEqual(protractor([3, 2], [6, 7]), atan2(5, 3), "Angle of a positive line");
+                assertEqual(protractor([6, 7], [3, 2]), atan2(-5, -3), "Angle of a negative line");
+                assertEqual(protractor([3, 2], [3, 2]), 0, "Angle of a point");
             }
         }
         // test core/vector-2d/angle2D()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 24) {
+    testPackage("core/vector-2d.scad", 25) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -280,6 +280,28 @@ module testCoreVector2D() {
                 assertEqual(center2D([10], [8], 10, true), [9, 0] + ([0, -2] / norm([0, -2])) * sqrt(100 - pow(norm([-2, 0]) / 2, 2)), "Should accept vector smaller than 2D, then upscale them and compute the center of the circle using 2D");
                 assertEqual(center2D([10, 20, 30], [8, 16, 32], 10, true), [9, 18] + ([4, -2] / norm([4, -2])) * sqrt(100 - pow(norm([2, 4]) / 2, 2)), "Should accept vector bigger than 2D, but should only compute the center of the circle using 2D");
                 assertEqual(center2D([10, 20], [8, 16], 1, true), [9, 18], "Cannot compute the center if the radius is smaller than the distance between the points, should return the point at the middle");
+            }
+        }
+        // test core/vector-2d/parallel2D()
+        testModule("parallel2D()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(parallel2D(), true, "Without parameter the function should return true");
+            }
+            testUnit("wrong type", 4) {
+                assertEqual(parallel2D("10", "10", "10", "10"), true, "Cannot tell if strings are parallels");
+                assertEqual(parallel2D(true, true, true, true), true, "Cannot tell if boolean are parallels");
+                assertEqual(parallel2D([], [], [], []), true, "Cannot tell if empty arrays are parallels");
+                assertEqual(parallel2D(["1"], ["2"], ["3"], ["4"]), true, "Cannot tell if arrays are parallels");
+            }
+            testUnit("check", 8) {
+                assertEqual(parallel2D(0, 1, 2, 3), true, "Numbers should be converted to vectors");
+                assertEqual(parallel2D([0, 0], [1, 1], [2, 2], [3, 3]), true, "45° positive segments");
+                assertEqual(parallel2D([0, 0], [-1, 1], [-2, 2], [-3, 3]), true, "45° negative segments");
+                assertEqual(parallel2D([0, 0], [3, 0], [1, 2], [3, 2]), true, "horizontal segments");
+                assertEqual(parallel2D([0, 0], [0, 3], [2, 1], [2, 3]), true, "vertical segments");
+                assertEqual(parallel2D([4, 5], [6, 7], [2, 3], [0, 1]), true, "parallels segments");
+                assertEqual(parallel2D([4, 5], [8, 7], [2, 3], [5, 1]), false, "not parallels segments");
+                assertEqual(parallel2D([0, 0], [3, 0], [1, 2], [1, 4]), false, "perpendicular segments");
             }
         }
         // test core/vector-2d/angle2D()

--- a/test/core/vector-3d.scad
+++ b/test/core/vector-3d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector3D() {
-    testPackage("core/vector-3d.scad", 13) {
+    testPackage("core/vector-3d.scad", 14) {
         // test core/vector-3d/vector3D()
         testModule("vector3D()", 3) {
             testUnit("no parameter", 1) {
@@ -223,6 +223,54 @@ module testCoreVector3D() {
                 assertEqual(move3D([1, 2, 3, 4]), [1, 2, 3], "Should truncate too big vector and returns a 3D vector (no direction vector)");
                 assertEqual(move3D([1, 2, 3, 4], [1, 2, 3, 4]), [1, 2, 3], "Should truncate too big vector and returns a 3D vector (direction vector but not distance)");
                 assertEqual(move3D([1, 2, 3, 4], [1, 2, 3, 4], 1), [1, 2, 3] + [1, 2, 3] / norm([1, 2, 3]), "Should truncate too big vector and returns a 3D vector (direction vector and distance)");
+            }
+        }
+        // test core/vector-3d/extend3D()
+        testModule("extend3D()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(extend3D(), [0, 0, 0], "Should always produce a 3D vector, even if input is wrong");
+            }
+            testUnit("not vector", 18) {
+                assertEqual(extend3D(1), [1, 1, 1], "Should translate number to 3D vector (only origin)");
+                assertEqual(extend3D(1, 1), [1, 1, 1], "Should translate number to 3D vector (origin and second point)");
+                assertEqual(extend3D(1, 2, 3), [1, 1, 1] + unit3D([1, 1, 1]) * 3, "Should translate number to 3D vector (all parameters)");
+
+                assertEqual(extend3D(true), [0, 0, 0], "Should produce a default 3D vector if input is boolean (only origin)");
+                assertEqual(extend3D(true, true), [0, 0, 0], "Should produce a default 3D vector if input is boolean (origin and second point)");
+                assertEqual(extend3D(true, true, true), [0, 0, 0], "Should produce a default 3D vector if input is boolean (all parameters)");
+
+                assertEqual(extend3D("1"), [0, 0, 0], "Should produce a default 3D vector if input is string (only origin)");
+                assertEqual(extend3D("1", "1"), [0, 0, 0], "Should produce a default 3D vector if input is string (origin and second point)");
+                assertEqual(extend3D("1", "1", "1"), [0, 0, 0], "Should produce a default 3D vector if input is string (all parameters)");
+
+                assertEqual(extend3D(["1"]), [0, 0, 0], "Should produce a default 3D vector if input is array (only origin)");
+                assertEqual(extend3D(["1"], ["1"]), [0, 0, 0], "Should produce a default 3D vector if input is array (origin and second point)");
+                assertEqual(extend3D(["1"], ["1"], ["1"]), [0, 0, 0], "Should produce a default 3D vector if input is array (all parameters)");
+
+                assertEqual(extend3D(["1", 1]), [0, 1, 0], "Should produce a corrected 3D vector if input is wrong or incomplete (only origin)");
+                assertEqual(extend3D(["1", 1], ["1", 1]), [0, 1, 0], "Should produce a corrected 3D vector if input is wrong or incomplete (origin and second point)");
+                assertEqual(extend3D(["1", 1], ["1", 1], 1), [0, 1, 0], "Should produce a corrected 3D vector if input is wrong or incomplete (all parameters)");
+
+                assertEqual(extend3D(["1", 1, 1]), [0, 1, 1], "Should produce a corrected 3D vector if input is wrong (only origin)");
+                assertEqual(extend3D(["1", 1, 1], ["1", 1, 1]), [0, 1, 1], "Should produce a corrected 3D vector if input is wrong (origin and second point)");
+                assertEqual(extend3D(["1", 1, 1], ["1", 1, 1], 1), [0, 1, 1], "Should produce a corrected 3D vector if input is wrong (all parameters)");
+            }
+            testUnit("vector", 12) {
+                assertEqual(extend3D([1]), [1, 0, 0], "Should complete incomplete 3D vector (only origin)");
+                assertEqual(extend3D([1], [2]), [1, 0, 0], "Should complete incomplete 3D vector (origin and second point)");
+                assertEqual(extend3D([1], [2], 3), [1, 0, 0] + unit3D([1, 0, 0]) * 3, "Should complete incomplete 3D vector (all parameters)");
+
+                assertEqual(extend3D([1, 2]), [1, 2, 0], "Should complete incomplete 3D vector (only origin)");
+                assertEqual(extend3D([1, 2], [3, 4]), [1, 2, 0], "Should complete incomplete 3D vector (origin and second point)");
+                assertEqual(extend3D([1, 2], [3, 4], 3), [1, 2, 0] + unit3D([2, 2, 0]) * 3, "Should complete incomplete 3D vector (all parameters)");
+
+                assertEqual(extend3D([1, 2, 3]), [1, 2, 3], "Should return the provided 3D vector (only origin)");
+                assertEqual(extend3D([1, 2, 3], [4, 5, 6]), [1, 2, 3], "Should return the provided 3D vector (origin and second point)");
+                assertEqual(extend3D([1, 2, 3], [4, 5, 6], 3), [1, 2, 3] + unit3D([3, 3, 3]) * 3, "Should return a 3D vector (all parameters)");
+
+                assertEqual(extend3D([1, 2, 3, 4]), [1, 2, 3], "Should truncate too big vector and returns a 3D vector (only origin)");
+                assertEqual(extend3D([1, 2, 3, 4], [5, 6, 7, 8]), [1, 2, 3], "Should truncate too big vector and returns a 3D vector (origin and second point)");
+                assertEqual(extend3D([1, 2, 3, 4], [5, 6, 7, 8], 3), [1, 2, 3] + unit3D([4, 4, 4]) * 3, "Should truncate too big vector and returns a 3D vector (all parameters)");
             }
         }
         // test core/vector-3d/angle3D()

--- a/test/core/version.scad
+++ b/test/core/version.scad
@@ -45,10 +45,10 @@ module testCoreVersion() {
         // test camelSCAD()
         testModule("camelSCAD()", 2) {
             testUnit("as vector", 1) {
-                assertEqual(camelSCAD(), [0, 4, 0], "The current version of the library is 0.4.0");
+                assertEqual(camelSCAD(), [0, 5, 0], "The current version of the library is 0.4.0");
             }
             testUnit("as string", 1) {
-                assertEqual(camelSCAD(true), "0.4.0", "The current version of the library is 0.4.0");
+                assertEqual(camelSCAD(true), "0.5.0", "The current version of the library is 0.4.0");
             }
         }
     }

--- a/test/shape/2D/polygon.scad
+++ b/test/shape/2D/polygon.scad
@@ -34,7 +34,7 @@ use <../../../full.scad>
  * @author jsconan
  */
 module testShape2dPolygon() {
-    testPackage("shape/2D/polygon.scad", 9) {
+    testPackage("shape/2D/polygon.scad", 11) {
         // test shape/2D/polygon/sizeRectangle()
         testModule("sizeRectangle()", 2) {
             testUnit("default values", 3) {
@@ -49,6 +49,33 @@ module testShape2dPolygon() {
                 assertEqual(sizeRectangle([3, 4, 5]), [3, 4], "Should truncate too big size vector");
                 assertEqual(sizeRectangle([3, 4], l=5), [5, 4], "Should set the length with the provided length in the provided size vector");
                 assertEqual(sizeRectangle([3, 4], w=5), [3, 5], "Should set the width with the provided width in the provided size vector");
+            }
+        }
+        // test shape/2D/polygon/sizeChamferedRectangle()
+        testModule("sizeChamferedRectangle()", 3) {
+            testUnit("default values", 3) {
+                assertEqual(sizeChamferedRectangle(), [[1, 1], [0, 0]], "Should always return a size even if not parameter has been provided");
+                assertEqual(sizeChamferedRectangle("12", "12", "12"), [[1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (string)");
+                assertEqual(sizeChamferedRectangle(true, true, true), [[1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (boolean)");
+            }
+            testUnit("compute size", 7) {
+                assertEqual(sizeChamferedRectangle(3), [[3, 3], [0, 0]], "Should produce a size vector from a single number size");
+                assertEqual(sizeChamferedRectangle([3]), [[3, 1], [0, 0]], "Should complete incomplete size vector");
+                assertEqual(sizeChamferedRectangle([3, 4]), [[3, 4], [0, 0]], "Should keep the provided size vector");
+                assertEqual(sizeChamferedRectangle([3, 4, 5]), [[3, 4], [0, 0]], "Should truncate too big size vector");
+                assertEqual(sizeChamferedRectangle([3, 4], l=5), [[5, 4], [0, 0]], "Should set the length with the provided length in the provided size vector");
+                assertEqual(sizeChamferedRectangle([3, 4], w=5), [[3, 5], [0, 0]], "Should set the width with the provided width in the provided size vector");
+                assertEqual(sizeChamferedRectangle(l=4, w=5), [[4, 5], [0, 0]], "Should set the size from the provided length and width");
+            }
+            testUnit("compute chamfer", 8) {
+                assertEqual(sizeChamferedRectangle(3, 1), [[3, 3], [1, 1]], "Should produce a chamfer vector from a single number size");
+                assertEqual(sizeChamferedRectangle(5, [2]), [[5, 5], [0, 0]], "Should not complete incomplete chamfer vector");
+                assertEqual(sizeChamferedRectangle(5, [0, 2]), [[5, 5], [0, 0]], "Should not allow incomplete chamfer vector");
+                assertEqual(sizeChamferedRectangle([8, 8], [2, 3]), [[8, 8], [2, 3]], "Should keep the provided chamfer vector");
+                assertEqual(sizeChamferedRectangle([8, 8], [2, 3, 4]), [[8, 8], [2, 3]], "Should truncate too big chamfer vector");
+                assertEqual(sizeChamferedRectangle([8, 8], [2, 2], cl=3), [[8, 8], [3, 2]], "Should set the length with the provided length in the provided chamfer vector");
+                assertEqual(sizeChamferedRectangle([8, 8], [2, 2], cw=3), [[8, 8], [2, 3]], "Should set the width with the provided width in the provided chamfer vector");
+                assertEqual(sizeChamferedRectangle(cl=4, cw=5), [[8, 10], [4, 5]], "Should set the chamfer from the provided length and width");
             }
         }
         // test shape/2D/polygon/sizeTrapezium()
@@ -130,6 +157,26 @@ module testShape2dPolygon() {
                 assertEqual(drawRectangle([3, 4]), [[1.5, 2], [-1.5, 2], [-1.5, -2], [1.5, -2]], "Should return a list of points to draw a rectangle using the provided size vector");
                 assertEqual(drawRectangle([3, 4], l=5), [[2.5, 2], [-2.5, 2], [-2.5, -2], [2.5, -2]], "Should return a list of points to draw a rectangle using the provided size vector with the provided length");
                 assertEqual(drawRectangle([3, 4], w=5), [[1.5, 2.5], [-1.5, 2.5], [-1.5, -2.5], [1.5, -2.5]], "Should return a list of points to draw a rectangle using the provided size vector with the provided width");
+            }
+        }
+        // test shape/2D/polygon/drawChamferedRectangle()
+        testModule("drawChamferedRectangle()", 3) {
+            testUnit("default values", 3) {
+                assertEqual(drawChamferedRectangle(), [[0.5, 0.5], [-0.5, 0.5], [-0.5, -0.5], [0.5, -0.5]], "Should return a list of points to draw a rectangle with a size of 1");
+                assertEqual(drawChamferedRectangle("12", "12", "12"), [[0.5, 0.5], [-0.5, 0.5], [-0.5, -0.5], [0.5, -0.5]], "Should return a list of points to draw a rectangle with a size of 1 if wrong parameter has been provided (string)");
+                assertEqual(drawChamferedRectangle(true, true, true), [[0.5, 0.5], [-0.5, 0.5], [-0.5, -0.5], [0.5, -0.5]], "Should return a list of points to draw a rectangle with a size of 1 if wrong parameter has been provided (boolean)");
+            }
+            testUnit("draw shape without chamfer", 4) {
+                assertEqual(drawChamferedRectangle(3), [[1.5, 1.5], [-1.5, 1.5], [-1.5, -1.5], [1.5, -1.5]], "Should return a list of points to draw a rectangle. Single number size should be translated into vector");
+                assertEqual(drawChamferedRectangle([3, 4]), [[1.5, 2], [-1.5, 2], [-1.5, -2], [1.5, -2]], "Should return a list of points to draw a rectangle using the provided size vector");
+                assertEqual(drawChamferedRectangle([3, 4], l=5), [[2.5, 2], [-2.5, 2], [-2.5, -2], [2.5, -2]], "Should return a list of points to draw a rectangle using the provided size vector with the provided length");
+                assertEqual(drawChamferedRectangle([3, 4], w=5), [[1.5, 2.5], [-1.5, 2.5], [-1.5, -2.5], [1.5, -2.5]], "Should return a list of points to draw a rectangle using the provided size vector with the provided width");
+            }
+            testUnit("draw shape with chamfer", 4) {
+                assertEqual(drawChamferedRectangle(3, 1), [[1.5, 0.5], [0.5, 1.5], [-0.5, 1.5], [-1.5, 0.5], [-1.5, -0.5], [-0.5, -1.5], [0.5, -1.5], [1.5, -0.5]], "Should return a list of points to draw a chamfered rectangle. Single number size should be translated into vector");
+                assertEqual(drawChamferedRectangle([8, 9], [1, 1]), [[4, 3.5], [3, 4.5], [-3, 4.5], [-4, 3.5], [-4, -3.5], [-3, -4.5], [3, -4.5], [4, -3.5]], "Should return a list of points to draw a chamfered rectangle using the provided size vector");
+                assertEqual(drawChamferedRectangle([8, 9], [1, 1], cl=2), [[4, 3.5], [2, 4.5], [-2, 4.5], [-4, 3.5], [-4, -3.5], [-2, -4.5], [2, -4.5], [4, -3.5]], "Should return a list of points to draw a chamfered rectangle using the provided size vector with the provided chamfer length");
+                assertEqual(drawChamferedRectangle([8, 9], [1, 1], cw=2), [[4, 2.5], [3, 4.5], [-3, 4.5], [-4, 2.5], [-4, -2.5], [-3, -4.5], [3, -4.5], [4, -2.5]], "Should return a list of points to draw a chamfered rectangle using the provided size vector with the provided chamfer width");
             }
         }
         // test shape/2D/polygon/drawTrapezium()

--- a/test/shape/3D/polyhedron.scad
+++ b/test/shape/3D/polyhedron.scad
@@ -34,7 +34,7 @@ use <../../../full.scad>
  * @author jsconan
  */
 module testShape3dPolyhedron() {
-    testPackage("shape/3D/polyhedron.scad", 4) {
+    testPackage("shape/3D/polyhedron.scad", 5) {
         // test shape/3D/polyhedron/sizeBox()
         testModule("sizeBox()", 2) {
             testUnit("default values", 3) {
@@ -50,7 +50,35 @@ module testShape3dPolyhedron() {
                 assertEqual(sizeBox([3, 4, 5, 6]), [3, 4, 5], "Should truncate too big size vector");
                 assertEqual(sizeBox([3, 4, 2], l=5), [5, 4, 2], "Should set the length with the provided length in the provided size vector");
                 assertEqual(sizeBox([3, 4, 2], w=5), [3, 5, 2], "Should set the width with the provided width in the provided size vector");
-                assertEqual(sizeBox([3, 4, 2], h=5), [3, 4, 5], "Should set the height with the provided width in the provided size vector");
+                assertEqual(sizeBox([3, 4, 2], h=5), [3, 4, 5], "Should set the height with the provided height in the provided size vector");
+            }
+        }
+        // test shape/3D/polyhedron/sizeChamferedBox()
+        testModule("sizeChamferedBox()", 3) {
+            testUnit("default values", 3) {
+                assertEqual(sizeChamferedBox(), [[1, 1, 1], [0, 0]], "Should always return a size even if not parameter has been provided");
+                assertEqual(sizeChamferedBox("12", "12", "12"), [[1, 1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (string)");
+                assertEqual(sizeChamferedBox(true, true, true), [[1, 1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (boolean)");
+            }
+            testUnit("compute size", 8) {
+                assertEqual(sizeChamferedBox(3), [[3, 3, 3], [0, 0]], "Should produce a size vector from a single number size");
+                assertEqual(sizeChamferedBox([3]), [[3, 1, 1], [0, 0]], "Should complete incomplete size vector");
+                assertEqual(sizeChamferedBox([3, 2]), [[3, 2, 1], [0, 0]], "Should complete incomplete size vector");
+                assertEqual(sizeChamferedBox([3, 4, 5]), [[3, 4, 5], [0, 0]], "Should keep the provided size vector");
+                assertEqual(sizeChamferedBox([3, 4, 5, 6]), [[3, 4, 5], [0, 0]], "Should truncate too big size vector");
+                assertEqual(sizeChamferedBox([3, 4, 2], l=5), [[5, 4, 2], [0, 0]], "Should set the length with the provided length in the provided size vector");
+                assertEqual(sizeChamferedBox([3, 4, 2], w=5), [[3, 5, 2], [0, 0]], "Should set the width with the provided width in the provided size vector");
+                assertEqual(sizeChamferedBox([3, 4, 2], h=5), [[3, 4, 5], [0, 0]], "Should set the height with the provided width in the provided size vector");
+            }
+            testUnit("compute chamfer", 8) {
+                assertEqual(sizeChamferedBox(3, 1), [[3, 3, 3], [1, 1]], "Should produce a chamfer vector from a single number size");
+                assertEqual(sizeChamferedBox([3, 3, 3], [1]), [[3, 3, 3], [0, 0]], "Should not complete incomplete chamfer vector");
+                assertEqual(sizeChamferedBox([3, 3, 3], [0, 1]), [[3, 3, 3], [0, 0]], "Should not allow incomplete chamfer vector");
+                assertEqual(sizeChamferedBox([3, 4, 5], [1, 2]), [[3, 4, 5], [1, 2]], "Should keep the provided chamfer vector");
+                assertEqual(sizeChamferedBox([3, 4, 5], [1, 2, 3]), [[3, 4, 5], [1, 2]], "Should truncate too big chamfer vector");
+                assertEqual(sizeChamferedBox([6, 6, 6], [1, 1], cl=2), [[6, 6, 6], [2, 1]], "Should set the length with the provided length in the provided chamfer vector");
+                assertEqual(sizeChamferedBox([6, 6, 6], [1, 1], cw=2), [[6, 6, 6], [1, 2]], "Should set the width with the provided width in the provided chamfer vector");
+                assertEqual(sizeChamferedBox([6, 6, 6], cl=2, cw=2), [[6, 6, 6], [2, 2]], "Should set the chamfer from the provided length and width");
             }
         }
         // test shape/3D/polyhedron/sizeTrapeziumBox()


### PR DESCRIPTION
Add core functions:
- `parallel2D()`: computes a parallel line.
- `intersect2D()`: computes the point at the intersection of two lines defined by four points.
- `tangent2D()`: computes the point at the tangent between a circle and a line passing through a particular point.
- `isosceles2D()`: computes the third edge of an isosceles triangle defined by the two other edges and either the height or the angle.
- `protractor()`: computes the angle of a line defined by two points.
- `extend2D()`: computes the 2D point at the wanted distance from the origin on the defined 2D line.
- `extend3D()`: computes the 3D point at the wanted distance from the origin on the defined 3D line.
- `apothem()`: Computes the apothem of a regular N-sides polygon. An apothem is a line from the center of a regular polygon at right angles to any of its sides.
- `circumradius()`: Computes the radius of a circle circumscribing a regular N-sides polygon.
- `quadraticEquation()`: Resolve a quadratic equation given the A, B and C terms.
- `circleLineIntersect2D()`: Computes the points at the intersection of a circle and a line.
- `circleIntersect2D()`: Computes the points at the intersection of two circles.

Add shapes:
- `chamferedRectangle(size, chamfer, l, w, cl, cw)`:  Creates a chamfered rectangle at the origin.
- `chamferedBox(size, chamfer, l, w, h, cl, cw, center)`: Creates a chamfered box at the origin.

Improvements on the core function `path()`:
- accept either points or separated coordinates in commands `P`, `L`,  and `T`.
- added commands to compute intersection and tangent lines from the last point.

Fixes:
- Fix an issue occurring with the function `arc()`, when the provided angles are descending.
- Fix misuse of cat command, that could lead to a performance issue.
