### PR TITLE
Feature/Test script accept file extension

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -34,7 +34,13 @@
 
 name=suite
 if [ "$1" != "" ]; then
-    name=$1
+    folder=$(dirname $1)
+    basename=$(basename $1 .scad)
+    if [ "${folder}" != "." ]; then
+        name="${folder}/${basename}"
+    else
+        name="${basename}"
+    fi
 fi
 
 scriptPath=$(dirname $0)


### PR DESCRIPTION
Filter the extension from the name of the package to test.

Now the test script accept the name of a package with or without the extension.
So both commands are now equivalent:
```
./scripts/test.sh core/vector-2d
```
```
./scripts/test.sh core/vector-2d.scad
```