### PR TITLE
Feature/outline

### DIFF
--- a/core/line.scad
+++ b/core/line.scad
@@ -180,3 +180,30 @@ function path(p, points, i) =
     )
     path(p=p, points=concat(values[0] == point ? slice(points, 0, -1) : points, values), i=i + 1)
 ;
+
+/**
+ * Computes the outline of a polygon. The outline can be at a particular distance.
+ *
+ * @param Vector[] points - The points defining the polygon to outline.
+ * @param Number distance - The distance from the polygon for the outline.
+ *                          A positive distance will place the outline outside,
+ *                          while a negative distance will place it inside.
+ * @returns Vector[]
+ */
+function outline(points, distance) =
+    let(
+        points = array(points),
+        l = len(points),
+        prev = l - 1,
+        next = 1
+    )
+    l >= 3 ? [
+        for (i = [0 : 1 : l - 1])
+            vertexOutline2D(
+                a=points[(i + prev) % l],
+                v=points[i],
+                b=points[(i + next) % l],
+                distance=distance
+            )
+    ] : points
+;

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -96,6 +96,24 @@ function fragments(r, d) =
 function astep(r, a=DEGREES, d) = min(DEGREES / fragments(r=r, d=d), float(a));
 
 /**
+ * Computes the angle of a point on a circle
+ *
+ * @param Number [x] - The X coordinate of the point
+ * @param Number [y] - The Y coordinate of the point
+ * @returns Number
+ */
+function getAngle(x, y) =
+    let(
+        x = float(x),
+        y = float(y),
+        a = x || y ? atan2(y, x)
+                   : 0
+    )
+    a >= 0 ? a
+           : a + DEGREES
+;
+
+/**
  * Computes a length based on the Pythagore's theorem.
  *
  * @param Number a - The A side of the rectangle (0 or undef to compute this value).

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -533,6 +533,32 @@ function vertexAngle2D(a, b, v) =
 ;
 
 /**
+ * Computes the outline of a vertex at the given distance from the edges.
+ * The vertex is defined by three points.
+ * The distance from the edges is placed on a normal vector from each edge,
+ * and the outline point should be at the intersect of those vectors
+ *
+ * @param Vector [a] - The first point
+ * @param Vector [b] - The second point
+ * @param Vector [v] - The vertex point
+ * @param Number [distance] - The distance from the edges,
+ *                            on a perpendicular line from each edge
+ * @returns Vector
+ */
+function vertexOutline2D(a, b, v, distance) =
+    let(
+        v = vector2D(v),
+        a = vector2D(a) - v,
+        b = vector2D(b) - v,
+        angleA = getAngle(a[0], a[1]),
+        angleB = getAngle(b[0], b[1]),
+        angle = (angleB - angleA) / 2,
+        length = float(distance) / divisor(abs(sin(angle)))
+    )
+    v + arcp([length, length], angle < 0 ? angleB - angle + STRAIGHT : angleA + angle)
+;
+
+/**
  * Computes the coordinates of a 2D point on a sinusoid wave.
  *
  * @param Number x - The X-coordinate of the point.

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -275,7 +275,7 @@ function tangent2D(p, c, r) =
     d > r ? (
         let(
             t = pythagore(0, r, d),
-            a = atan2(v[1], v[0]) + asin(r / d)
+            a = getAngle(v[0], v[1]) + asin(r / d)
         )
         p + arcPoint(t, a)
     )
@@ -462,13 +462,13 @@ function isosceles2D(a, b, h, angle) =
         b = vector2D(b),
         v = b - a,
         d = norm2D(v) / 2,
-        w = atan2(v[1], v[0])
+        w = getAngle(v[0], v[1])
     )
     h != undef ? (
         let(
             h = float(h),
             r = pythagore(h, d),
-            angle = atan2(h, d)
+            angle = getAngle(d, h)
         )
         a + arcPoint(r, w + angle)
     )
@@ -497,8 +497,7 @@ function protractor(a, b) =
     let(
         v = vector2D(b) - vector2D(a)
     )
-    v[0] || v[1] ? atan2(v[1], v[0])
-                 : 0
+    getAngle(v[0], v[1])
 ;
 
 /**
@@ -513,7 +512,24 @@ function angle2D(a, b) =
         a = vector2D(a),
         b = vector2D(b)
     )
-    float(acos((a * b) / (norm(a) * norm(b))))
+    vangle(a, b)
+;
+
+/**
+ * Computes the vertex angle given three 2D points.
+ *
+ * @param Vector [a] - The first point
+ * @param Vector [b] - The second point
+ * @param Vector [v] - The vertex point
+ * @returns Number
+ */
+function vertexAngle2D(a, b, v) =
+    let(
+        v = vector2D(v),
+        a = vector2D(a) - v,
+        b = vector2D(b) - v
+    )
+    vangle(a, b)
 ;
 
 /**

--- a/core/vector-3d.scad
+++ b/core/vector-3d.scad
@@ -152,7 +152,24 @@ function angle3D(a, b) =
         a = vector3D(a),
         b = vector3D(b)
     )
-    float(acos((a * b) / (norm(a) * norm(b))))
+    vangle(a, b)
+;
+
+/**
+ * Computes the vertex angle given three 3D point.
+ *
+ * @param Vector [a] - The first point
+ * @param Vector [b] - The second point
+ * @param Vector [v] - The vertex point
+ * @returns Number
+ */
+function vertexAngle3D(a, b, v) =
+    let(
+        v = vector3D(v),
+        a = vector3D(a) - v,
+        b = vector3D(b) - v
+    )
+    vangle(a, b)
 ;
 
 /**

--- a/core/vector.scad
+++ b/core/vector.scad
@@ -244,3 +244,18 @@ function vboolean(a, bool) =
     :len(a) == 0 ? a
     :[ for (b = a) b ? t : f ]
 ;
+
+/**
+ * Computes the angle between two vectors.
+ *
+ * @param Vector [a] - The first vector
+ * @param Vector [b] - The second vector
+ * @returns Number
+ */
+function vangle(a, b) =
+    let(
+        a = a ? a : [0, 0, 0],
+        b = b ? b : [0, 0, 0]
+    )
+    float(acos((a * b) / (norm(a) * norm(b))))
+;

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreLine() {
-    testPackage("core/line.scad", 4) {
+    testPackage("core/line.scad", 5) {
         // test core/line/arc()
         testModule("arc()", 9) {
             testUnit("no parameter", 1) {
@@ -280,6 +280,29 @@ module testCoreLine() {
                 assertEqual(len(cubic2), 5, "Path with 1 cubic bezier from an absolute point should produce a list of points");
                 assertEqual(cubic2[0], [5, 6], "Path with 1 cubic bezier from an absolute point should start at the provided point");
                 assertEqual(cubic2[4], [16, 18], "Path with 1 cubic bezier from an absolute point should end with the last control point");
+            }
+        }
+        // test core/line/outline()
+        testModule("outline()", 5) {
+            testUnit("no parameter", 1) {
+                assertEqual(outline(), [], "Cannot build an outline without parameters");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(outline("1", "1"), ["1"], "Cannot build an outline using strings");
+                assertEqual(outline(true, true), [true], "Cannot build an outline using booleans");
+                assertEqual(outline([1], [1]), [1], "Cannot build an outline using vectors");
+            }
+            testUnit("short line", 2) {
+                assertEqual(outline([0], 1), [0], "The outline needs at least 3 points");
+                assertEqual(outline([0, 1], 1), [0, 1], "The outline needs at least 3 points");
+            }
+            testUnit("ouside", 2) {
+                assertEqual(outline([[1, 1], [2, 1], [2, 2], [1, 2]], 1), [[0, 0], [3, 0], [3, 3], [0, 3]], "Outline of a square");
+                assertEqual(outline([[2, 1], [1, 1], [1, 2], [-1, 2], [-1, 1], [-2, 1], [-2, -1], [-1, -1], [-1, -2], [1, -2], [1, -1], [2, -1]], 1), [[3, 2], [2, 2], [2, 3], [-2, 3], [-2, 2], [-3, 2], [-3, -2], [-2, -2], [-2, -3], [2, -3], [2, -2], [3, -2]], "Outline of a cross");
+            }
+            testUnit("inside", 2) {
+                assertEqual(outline([[0, 0], [3, 0], [3, 3], [0, 3]], -1), [[1, 1], [2, 1], [2, 2], [1, 2]], "Outline of a square");
+                assertEqual(outline([[3, 2], [2, 2], [2, 3], [-2, 3], [-2, 2], [-3, 2], [-3, -2], [-2, -2], [-2, -3], [2, -3], [2, -2], [3, -2]], -1), [[2, 1], [1, 1], [1, 2], [-1, 2], [-1, 1], [-2, 1], [-2, -1], [-1, -1], [-1, -2], [1, -2], [1, -1], [2, -1]], "Outline of a cross");
             }
         }
     }

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 16) {
+    testPackage("core/maths.scad", 17) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -293,6 +293,30 @@ module testCoreMaths() {
                 assertEqual(astep(d=200, a=0.1, $fn=0, $fa=1, $fs=1), 0.1, "When the $fn value is not set, the number of fragments should be computed using $fa and $fs. A circle with a diameter of 100 should be fragmented in 63 facets with $fa=1 $fs=1, but the returned angle should be the provided one if lesser");
                 assertEqual(astep(d=200, a=0.1, $fn=0, $fa=1, $fs=1.5), 0.1, "When the $fn value is not set, the number of fragments should be computed using $fa and $fs. A circle with a diameter of 100 should be fragmented in 42 facets with $fa=1 $fs=1.5, but the returned angle should be the provided one if lesser");
                 assertEqual(astep(d=200, a=0.1, $fn=0, $fa=0.5, $fs=0.5), 0.1, "When the $fn value is not set, the number of fragments should be computed using $fa and $fs. A circle with a diameter of 100 should be fragmented in 63 facets with $fa=1 $fs=1, but the returned angle should be the provided one if lesser");
+            }
+        }
+        // test core/maths/getAngle()
+        testModule("getAngle()", 2) {
+            testUnit("default value", 5) {
+                assertEqual(getAngle(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(getAngle([], []), 0, "Cannot compute angle of arrays");
+                assertEqual(getAngle([1, 2], [3, 4]), 0, "Cannot compute angle of vectors");
+                assertEqual(getAngle("1", "2"), 0, "Cannot compute angle of strings");
+                assertEqual(getAngle(true, true), 0, "Cannot compute angle of booleans");
+            }
+            testUnit("compute angle", 12) {
+                assertEqual(getAngle(0, 0), 0, "Angle of vector [0,0]");
+                assertEqual(getAngle(0, 1), 90, "Angle of vector [0,1]");
+                assertEqual(getAngle(0, -1), 270, "Angle of vector [0,-1]");
+                assertEqual(getAngle(1, 0), 0, "Angle of vector [1,0]");
+                assertEqual(getAngle(-1, 0), 180, "Angle of vector [-1,0]");
+                assertEqual(getAngle(1, 1), 45, "Angle of vector [1,1]");
+                assertEqual(getAngle(-1, -1), 225, "Angle of vector [-1,-1]");
+                assertEqual(getAngle(1, 2), atan2(2, 1), "Angle of vector [1,2]");
+                assertEqual(getAngle(2, 1), atan2(1, 2), "Angle of vector [2,1]");
+                assertEqual(getAngle(-2, 1), atan2(1, -2), "Angle of vector [-2,1]");
+                assertEqual(getAngle(2, -1), 360 + atan2(-1, 2), "Angle of vector [2,-1]");
+                assertEqual(getAngle(-2, -1), 360 + atan2(-1, -2), "Angle of vector [-2,-1]");
             }
         }
         // test core/maths/pythagore()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 33) {
+    testPackage("core/vector-2d.scad", 34) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -578,6 +578,73 @@ module testCoreVector2D() {
                 assertEqual(vertexAngle2D([2, 1], [0, 1], [1, 1]), 180, "Vectors with opposite direction have an angle of 180°");
                 assertEqual(round(vertexAngle2D([5, 7], rotp([1, 2], -75) + [4, 5], [4, 5])), 75, "Rotated vector should produce the expected angle");
                 assertEqual(round(vertexAngle2D([5, 7], rotp([1, 2], 75) + [4, 5], [4, 5])), 75, "Vector rotated with a negative angle should produce the expected angle");
+            }
+        }
+        // test core/vector-2d/vertexOutline2D()
+        testModule("vertexOutline2D()", 5) {
+            testUnit("default value", 5) {
+                assertEqual(vertexOutline2D(), [0, 0], "Should return [0, 0] if no parameter was provided");
+                assertEqual(vertexOutline2D("1", "2", "3", "4"),  [0, 0], "Cannot compute angle of strings");
+                assertEqual(vertexOutline2D(true, true, true, true),  [0, 0], "Cannot compute angle of booleans");
+                assertEqual(vertexOutline2D([], [], [], 0),  [0, 0], "Empty arrays should produce 0° angle");
+                assertEqual(vertexOutline2D([], [], [], 1),  [1, 0], "Empty arrays should produce 0° angle, the distance is then projected in this direction");
+            }
+            testUnit("single number", 2) {
+                assertApproxEqual(vertexOutline2D(a=3, v=2, b=1, distance=1), arcp([1, 1], 135) + [2, 2], "Single numbers, point above");
+                assertApproxEqual(vertexOutline2D(a=1, v=2, b=3, distance=1), arcp([1, 1], 315) + [2, 2], "Single numbers, point below");
+            }
+            testUnit("flat line", 8) {
+                assertApproxEqual(vertexOutline2D(a=[-1, 0], v=[0, 0], b=[1, 0], distance=1), [0, -1], "horizontal, left to right");
+                assertApproxEqual(vertexOutline2D(a=[1, 0], v=[0, 0], b=[-1, 0], distance=1), [0, 1], "horizontal, right to left");
+                assertApproxEqual(vertexOutline2D(a=[0, 1], v=[0, 0], b=[0, -1], distance=1), [-1, 0], "vertical, top to bottom");
+                assertApproxEqual(vertexOutline2D(a=[0, -1], v=[0, 0], b=[0, 1], distance=1), [1, 0], "vertical, bottom to top");
+
+                assertApproxEqual(vertexOutline2D(a=[1, -1], v=[0, 0], b=[-1, 1], distance=1), arcp([1, 1], 45), "bottom right to top left");
+                assertApproxEqual(vertexOutline2D(a=[1, 1], v=[0, 0], b=[-1, -1], distance=1), arcp([1, 1], 135), "top right to bottom left");
+                assertApproxEqual(vertexOutline2D(a=[-1, 1], v=[0, 0], b=[1, -1], distance=1), arcp([1, 1], 225), "top left to bottom right");
+                assertApproxEqual(vertexOutline2D(a=[-1, -1], v=[0, 0], b=[1, 1], distance=1), arcp([1, 1], 315), "bottom left to top right");
+            }
+            testUnit("inside vertex", 16) {
+                assertApproxEqual(vertexOutline2D(a=[2, 1], v=[1, 1], b=[1, 2], distance=1), [2, 2], "quadrant 1 [1,1], top right");
+                assertApproxEqual(vertexOutline2D(a=[2, 2], v=[2, 1], b=[1, 1], distance=1), [1, 2], "quadrant 1 [1,1], top left");
+                assertApproxEqual(vertexOutline2D(a=[1, 2], v=[2, 2], b=[2, 1], distance=1), [1, 1], "quadrant 1 [1,1], bottom left");
+                assertApproxEqual(vertexOutline2D(a=[1, 1], v=[1, 2], b=[2, 2], distance=1), [2, 1], "quadrant 1 [1,1], bottom right");
+
+                assertApproxEqual(vertexOutline2D(a=[-1, 1], v=[-2, 1], b=[-2, 2], distance=1), [-1, 2], "quadrant 2 [-1,1], top right");
+                assertApproxEqual(vertexOutline2D(a=[-1, 2], v=[-1, 1], b=[-2, 1], distance=1), [-2, 2], "quadrant 2 [-1,1], top left");
+                assertApproxEqual(vertexOutline2D(a=[-2, 2], v=[-1, 2], b=[-1, 1], distance=1), [-2, 1], "quadrant 2 [-1,1], bottom left");
+                assertApproxEqual(vertexOutline2D(a=[-2, 1], v=[-2, 2], b=[-1, 2], distance=1), [-1, 1], "quadrant 2 [-1,1], bottom right");
+
+                assertApproxEqual(vertexOutline2D(a=[-1, -2], v=[-2, -2], b=[-2, -1], distance=1), [-1, -1], "quadrant 3 [-1,-1], top right");
+                assertApproxEqual(vertexOutline2D(a=[-1, -1], v=[-1, -2], b=[-2, -2], distance=1), [-2, -1], "quadrant 3 [-1,-1], top left");
+                assertApproxEqual(vertexOutline2D(a=[-2, -1], v=[-1, -1], b=[-1, -2], distance=1), [-2, -2], "quadrant 3 [-1,-1], bottom left");
+                assertApproxEqual(vertexOutline2D(a=[-2, -2], v=[-2, -1], b=[-1, -1], distance=1), [-1, -2], "quadrant 3 [-1,-1], bottom right");
+
+                assertApproxEqual(vertexOutline2D(a=[2, -2], v=[1, -2], b=[1, -1], distance=1), [2, -1], "quadrant 4 [1,-1], top right");
+                assertApproxEqual(vertexOutline2D(a=[2, -1], v=[2, -2], b=[1, -2], distance=1), [1, -1], "quadrant 4 [1,-1], top left");
+                assertApproxEqual(vertexOutline2D(a=[1, -1], v=[2, -1], b=[2, -2], distance=1), [1, -2], "quadrant 4 [1,-1], bottom left");
+                assertApproxEqual(vertexOutline2D(a=[1, -2], v=[1, -1], b=[2, -1], distance=1), [2, -2], "quadrant 4 [1,-1], bottom right");
+            }
+            testUnit("outside vertex", 16) {
+                assertApproxEqual(vertexOutline2D(a=[2, 1], v=[2, 2], b=[1, 2], distance=1), [3, 3], "quadrant 1 [1,1], top right");
+                assertApproxEqual(vertexOutline2D(a=[2, 2], v=[1, 2], b=[1, 1], distance=1), [0, 3], "quadrant 1 [1,1], top left");
+                assertApproxEqual(vertexOutline2D(a=[1, 2], v=[1, 1], b=[2, 1], distance=1), [0, 0], "quadrant 1 [1,1], bottom left");
+                assertApproxEqual(vertexOutline2D(a=[1, 1], v=[2, 1], b=[2, 2], distance=1), [3, 0], "quadrant 1 [1,1], bottom right");
+
+                assertApproxEqual(vertexOutline2D(a=[-1, 1], v=[-1, 2], b=[-2, 2], distance=1), [0, 3], "quadrant 2 [-1,1], top right");
+                assertApproxEqual(vertexOutline2D(a=[-1, 2], v=[-2, 2], b=[-2, 1], distance=1), [-3, 3], "quadrant 2 [-1,1], top left");
+                assertApproxEqual(vertexOutline2D(a=[-2, 2], v=[-2, 1], b=[-1, 1], distance=1), [-3, 0], "quadrant 2 [-1,1], bottom left");
+                assertApproxEqual(vertexOutline2D(a=[-2, 1], v=[-1, 1], b=[-1, 2], distance=1), [0, 0], "quadrant 2 [-1,1], bottom right");
+
+                assertApproxEqual(vertexOutline2D(a=[-1, -2], v=[-1, -1], b=[-2, -1], distance=1), [0, 0], "quadrant 3 [-1,-1], top right");
+                assertApproxEqual(vertexOutline2D(a=[-1, -1], v=[-2, -1], b=[-2, -2], distance=1), [-3, 0], "quadrant 3 [-1,-1], top left");
+                assertApproxEqual(vertexOutline2D(a=[-2, -1], v=[-2, -2], b=[-1, -2], distance=1), [-3, -3], "quadrant 3 [-1,-1], bottom left");
+                assertApproxEqual(vertexOutline2D(a=[-2, -2], v=[-1, -2], b=[-1, -1], distance=1), [0, -3], "quadrant 3 [-1,-1], bottom right");
+
+                assertApproxEqual(vertexOutline2D(a=[2, -2], v=[2, -1], b=[1, -1], distance=1), [3, 0], "quadrant 4 [1,-1], top right");
+                assertApproxEqual(vertexOutline2D(a=[2, -1], v=[1, -1], b=[1, -2], distance=1), [0, 0], "quadrant 4 [1,-1], top left");
+                assertApproxEqual(vertexOutline2D(a=[1, -1], v=[1, -2], b=[2, -2], distance=1), [0, -3], "quadrant 4 [1,-1], bottom left");
+                assertApproxEqual(vertexOutline2D(a=[1, -2], v=[2, -2], b=[2, -1], distance=1), [3, -3], "quadrant 4 [1,-1], bottom right");
             }
         }
         // test core/vector-2d/sinp()

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector2D() {
-    testPackage("core/vector-2d.scad", 32) {
+    testPackage("core/vector-2d.scad", 33) {
         // test core/vector-2d/vector2D()
         testModule("vector2D()", 3) {
             testUnit("no parameter", 1) {
@@ -539,27 +539,45 @@ module testCoreVector2D() {
                 assertEqual(protractor(true, true), 0, "Cannot compute angle of booleans");
             }
             testUnit("compute angle", 6) {
-                assertEqual(protractor(1, 2), 45, "When single numbers are provided, they should be translated to vector.");
+                assertEqual(protractor(1, 2), 45, "When single numbers are provided, they should be translated to vector");
                 assertEqual(protractor([3, 5], [3, 9]), 90, "Positive straight angle");
-                assertEqual(protractor([3, 9], [3, 5]), -90, "Negative straight angle");
+                assertEqual(protractor([3, 9], [3, 5]), 270, "Negative straight angle");
                 assertEqual(protractor([3, 2], [6, 7]), atan2(5, 3), "Angle of a positive line");
-                assertEqual(protractor([6, 7], [3, 2]), atan2(-5, -3), "Angle of a negative line");
+                assertEqual(protractor([6, 7], [3, 2]), 360 + atan2(-5, -3), "Angle of a negative line");
                 assertEqual(protractor([3, 2], [3, 2]), 0, "Angle of a point");
             }
         }
         // test core/vector-2d/angle2D()
         testModule("angle2D()", 2) {
             testUnit("default value", 3) {
-                assertEqual(angle2D(), 0, "Should return 0 if no vector was provided");
+                assertEqual(angle2D(), 0, "Should return 0 if no parameter was provided");
                 assertEqual(angle2D("1", "2"), 0, "Cannot compute angle of strings");
                 assertEqual(angle2D(true, true), 0, "Cannot compute angle of booleans");
             }
-            testUnit("compute angle", 5) {
-                assertEqual(round(angle2D(1, 2)), 0, "When single numbers are provided, they should be translated to vector. Vectors with same direction does not have angle.");
+            testUnit("compute angle", 6) {
+                assertEqual(round(angle2D(1, 2)), 0, "When single numbers are provided, they should be translated to vector");
                 assertEqual(angle2D([1, 0], [0, 1]), 90, "Orthogonal vectors have an angle of 90°");
                 assertEqual(angle2D([1, 0], [0, -1]), 90, "Orthogonal vectors have an angle of 90°, whatever their direction");
                 assertEqual(angle2D([1, 0], [-1, 0]), 180, "Vectors with opposite direction have an angle of 180°");
-                assertEqual(round(angle2D([1, 2], rotp([1, 2], 75))), 75, "Should have an angle of 75°");
+                assertEqual(round(angle2D([1, 2], rotp([1, 2], 75))), 75, "Rotated vector should produce the expected angle");
+                assertEqual(round(angle2D([1, 2], rotp([1, 2], -75))), 75, "Vector rotated with a negative angle should produce the expected angle");
+            }
+        }
+        // test core/vector-2d/vertexAngle2D()
+        testModule("vertexAngle2D()", 2) {
+            testUnit("default value", 3) {
+                assertEqual(vertexAngle2D(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(vertexAngle2D("1", "2", "3"), 0, "Cannot compute angle of strings");
+                assertEqual(vertexAngle2D(true, true, true), 0, "Cannot compute angle of booleans");
+            }
+            testUnit("compute angle", 7) {
+                assertEqual(round(vertexAngle2D(1, 2, 3)), 0, "When single numbers are provided, they should be translated to vector (0° case)");
+                assertEqual(round(vertexAngle2D(a=1, v=2, b=3)), 180, "When single numbers are provided, they should be translated to vector (180° case)");
+                assertEqual(vertexAngle2D([2, 1], [1, 2], [1, 1]), 90, "Orthogonal vectors have an angle of 90°");
+                assertEqual(vertexAngle2D([2, 1], [1, 0], [1, 1]), 90, "Orthogonal vectors have an angle of 90°, whatever their direction");
+                assertEqual(vertexAngle2D([2, 1], [0, 1], [1, 1]), 180, "Vectors with opposite direction have an angle of 180°");
+                assertEqual(round(vertexAngle2D([5, 7], rotp([1, 2], -75) + [4, 5], [4, 5])), 75, "Rotated vector should produce the expected angle");
+                assertEqual(round(vertexAngle2D([5, 7], rotp([1, 2], 75) + [4, 5], [4, 5])), 75, "Vector rotated with a negative angle should produce the expected angle");
             }
         }
         // test core/vector-2d/sinp()

--- a/test/core/vector-3d.scad
+++ b/test/core/vector-3d.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector3D() {
-    testPackage("core/vector-3d.scad", 14) {
+    testPackage("core/vector-3d.scad", 15) {
         // test core/vector-3d/vector3D()
         testModule("vector3D()", 3) {
             testUnit("no parameter", 1) {
@@ -276,16 +276,33 @@ module testCoreVector3D() {
         // test core/vector-3d/angle3D()
         testModule("angle3D()", 2) {
             testUnit("default value", 3) {
-                assertEqual(angle3D(), 0, "Should return 0 if no vector was provided");
+                assertEqual(angle3D(), 0, "Should return 0 if no parameter was provided");
                 assertEqual(angle3D("1", "2"), 0, "Cannot compute angle of strings");
                 assertEqual(angle3D(true, true), 0, "Cannot compute angle of booleans");
             }
-            testUnit("compute angle", 5) {
-                assertEqual(round(angle3D(1, 2)), 0, "When single numbers are provided, they should be translated to vector. Vectors with same direction does not have angle.");
+            testUnit("compute angle", 6) {
+                assertEqual(round(angle3D(1, 2)), 0, "When single numbers are provided, they should be translated to vector");
                 assertEqual(angle3D([1, 0, 0], [0, 1, 0]), 90, "Orthogonal vectors have an angle of 90°");
                 assertEqual(angle3D([1, 0, 0], [0, -1, 0]), 90, "Orthogonal vectors have an angle of 90°, whatever their direction");
                 assertEqual(angle3D([1, 1, 1], [-1, -1, -1]), 0, "Vectors with opposite direction have an angle of 0°");
-                assertEqual(round(angle3D([1, 2, 3], rotate3DX([1, 2, 3], 10))), 10, "Should have an angle of 10");
+                assertEqual(round(angle3D([1, 2, 3], rotate3DX([1, 2, 3], 10))), 10, "Rotated vector should produce the expected angle");
+                assertEqual(round(angle3D([1, 2, 3], rotate3DX([1, 2, 3], -10))), 10, "Vector rotated with a negative angle should produce the expected angle");
+            }
+        }
+        // test core/vector-3d/vertexAngle3D()
+        testModule("vertexAngle3D()", 2) {
+            testUnit("default value", 3) {
+                assertEqual(vertexAngle3D(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(vertexAngle3D("1", "2", "3"), 0, "Cannot compute angle of strings");
+                assertEqual(vertexAngle3D(true, true, true), 0, "Cannot compute angle of booleans");
+            }
+            testUnit("compute angle", 6) {
+                assertEqual(round(vertexAngle3D(1, 2, 3)), 0, "When single numbers are provided, they should be translated to vector");
+                assertEqual(vertexAngle3D([2, 1, 1], [1, 2, 1], [1, 1, 1]), 90, "Orthogonal vectors have an angle of 90°");
+                assertEqual(vertexAngle3D([2, 1, 1], [1, 0, 1], [1, 1, 1]), 90, "Orthogonal vectors have an angle of 90°, whatever their direction");
+                assertEqual(vertexAngle3D([2, 2, 2], [0, 0, 0], [1, 1, 1]), 0, "Vectors with opposite direction have an angle of 0°");
+                assertEqual(round(vertexAngle3D([5, 7, 9], rotate3DX([1, 2, 3], 10) + [4, 5, 6], [4, 5, 6])), 10, "Rotated vector should produce the expected angle");
+                assertEqual(round(vertexAngle3D([5, 7, 9], rotate3DX([1, 2, 3], -10) + [4, 5, 6], [4, 5, 6])), 10, "Vector rotated with a negative angle should produce the expected angle");
             }
         }
         // test core/vector-3d/rotate3DX()

--- a/test/core/vector.scad
+++ b/test/core/vector.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreVector() {
-    testPackage("core/vector.scad", 14) {
+    testPackage("core/vector.scad", 15) {
         // test core/vector/vadd()
         testModule("vadd()", 5) {
             testUnit("no parameter", 1) {
@@ -345,6 +345,25 @@ module testCoreVector() {
                 assertEqual(vboolean(["", "foo", "bar", ""], true), [false, true, true, false], "Array of strings should produce array of false and true if boolean type was requested");
                 assertEqual(vboolean([[], [0], [1], []]), [0, 1, 1, 0], "Array of arrays should produce array of 0 and 1 if boolean type was not requested");
                 assertEqual(vboolean([[], [0], [1], []], true), [false, true, true, false], "Array of arrays should produce array of false and true if boolean type was requested");
+            }
+        }
+        // test core/vector/vangle()
+        testModule("vangle()", 2) {
+            testUnit("default value", 5) {
+                assertEqual(vangle(), 0, "Cannot compute angle if no parameter was provided");
+                assertEqual(vangle(1, 2), 0, "Cannot compute angle of numbers");
+                assertEqual(vangle([], []), 0, "Cannot compute angle of empty arrays");
+                assertEqual(vangle("1", "2"), 0, "Cannot compute angle of strings");
+                assertEqual(vangle(true, true), 0, "Cannot compute angle of booleans");
+            }
+            testUnit("compute angle", 7) {
+                assertEqual(vangle([0, 0], [0, 0]), 0, "Origin vectors have an angle of 0°");
+                assertEqual(round(vangle([1, 1], [2, 2])), 0, "Aligned vectors have an angle of 0°");
+                assertEqual(vangle([1, 0], [0, 1]), 90, "Orthogonal vectors have an angle of 90°");
+                assertEqual(vangle([1, 0], [0, -1]), 90, "Orthogonal vectors have an angle of 90°, whatever their direction");
+                assertEqual(vangle([1, 0], [-1, 0]), 180, "Vectors with opposite direction have an angle of 180°");
+                assertEqual(round(vangle([6, 5], rotp([6, 5], -75))), 75, "Rotated vector should produce the expected angle");
+                assertEqual(round(vangle([1, 2], rotp([1, 2], 75))), 75, "Vector rotated with a negative angle should produce the expected angle");
             }
         }
     }


### PR DESCRIPTION
Add core functions:
- `vangle()`: Computes the angle between two vectors.
- `getAngle()`: Computes the angle of a point on a circle.
- `vertexAngle2D()`: Computes the vertex angle given three 2D points.
- `vertexAngle3D()`: Computes the vertex angle given three 3D points.
- `vertexOutline2D()`: Computes the outline of a vertex at the given distance from the edges.
- `outline()`: Computes the outline of a polygon. The outline can be at a particular distance.

With the add of `vangle()` and `getAngle()`, the following functions have beed updated:
- `angle2D()` and `angle3D()` now make use of `vangle()` to compute the angle instead of directly applying the formula.
- `tangent2D()`, `isosceles2D()`, `protractor()` now make use of `getAngle()` to compute the angles. The biggest change is on the `protractor()` that should always return a positive value within the `0..360` range.