### PR TITLE
Feature/cross

### DIFF
--- a/core/line.scad
+++ b/core/line.scad
@@ -207,3 +207,22 @@ function outline(points, distance) =
             )
     ] : points
 ;
+
+/**
+ * Adds a value to each point of a line.
+ *
+ * @param Vector[] points - The points defining the line.
+ * @param Number|Vector value - The value to add to the line.
+ * @returns Vector[]
+ */
+function lineAdd(points, value) =
+    let(
+        l = max(
+            float(len(value)),
+            float(len(points[0]))
+        ),
+        value = vector3D(value)
+    )
+    l > 2 ? [ for (p = points) vector3D(p) + value ]
+          : [ for (p = points) vector2D(p) + value ]
+;

--- a/core/line.scad
+++ b/core/line.scad
@@ -226,3 +226,36 @@ function lineAdd(points, value) =
     l > 2 ? [ for (p = points) vector3D(p) + value ]
           : [ for (p = points) vector2D(p) + value ]
 ;
+
+/**
+ * Builds a vector of faces to be used in a polyhedron. The function accepts the
+ * number of points defining one main face of the polyhedron, then returns the
+ * faces vector that contains the indices of each face enclosing the solid. This
+ * only apply on simple polyhedron where two opposite faces share the same
+ * number of points?.
+ * @param Number length - The number of points for one main face of the polyhedron
+ * @returns Vector[]
+ */
+function simplePolyhedronFaces(length) =
+    let(
+        length = integer(length)
+    )
+    length < 3 ? []
+   :let(
+       r1 = 0,
+       r2 = length - 1,
+       r3 = length,
+       r4 = length * 2 - 1
+   )
+    concat([
+        range(r1, r2),
+        range(r3, r4)
+    ], [
+        for (i = [r1 : r2]) [
+            r1 + i,
+            (r1 + i + 1) % length,
+            r3 + (i + 1) % length,
+            r3 + i
+        ]
+    ])
+;

--- a/core/line.scad
+++ b/core/line.scad
@@ -233,6 +233,7 @@ function lineAdd(points, value) =
  * faces vector that contains the indices of each face enclosing the solid. This
  * only apply on simple polyhedron where two opposite faces share the same
  * number of points?.
+ *
  * @param Number length - The number of points for one main face of the polyhedron
  * @returns Vector[]
  */
@@ -258,4 +259,33 @@ function simplePolyhedronFaces(length) =
             r3 + i
         ]
     ])
+;
+
+/**
+ * Composes a list of points to be used in a simple polyhedron.
+ *
+ * @param Vector[] [bottom] - The list of points for the bottom face.
+ * @param Vector[] [top] - The list of points for the top face.
+ * @param Vector[] [points] - The list of points for a main face.
+ * @param Vector [distane] - The distance between two main faces.
+ * @param Number [x] - The distance between two main faces on the X-axis.
+ * @param Number [y] - The distance between two main faces on the Y-axis.
+ * @param Number [z] - The distance between two main faces on the Z-axis.
+ * @returns Vector[]
+ */
+function simplePolyhedronPoints(bottom, top, points, distance, x, y, z) =
+    let(
+       distance = apply3D(v=distance, x=x, y=y, z=z)
+    )
+    top && bottom ? concat(
+        [ for (p = bottom) vector3D(p) ],
+        [ for (p = top) vector3D(p) + distance ]
+    )
+   :let(
+       points = [ for (p = (points ? points : (top ? top : bottom))) vector3D(p) ]
+   )
+   concat(
+       points,
+       [ for (p = points) p + distance ]
+   )
 ;

--- a/core/line.scad
+++ b/core/line.scad
@@ -232,7 +232,7 @@ function lineAdd(points, value) =
  * number of points defining one main face of the polyhedron, then returns the
  * faces vector that contains the indices of each face enclosing the solid. This
  * only apply on simple polyhedron where two opposite faces share the same
- * number of points?.
+ * number of points.
  *
  * @param Number length - The number of points for one main face of the polyhedron
  * @returns Vector[]

--- a/shape/2D/polygon.scad
+++ b/shape/2D/polygon.scad
@@ -146,6 +146,28 @@ function sizeStar(size, core, edges, l, w, cl, cw) =
 ;
 
 /**
+ * Computes the size of a cross shape.
+ *
+ * @param Number|Vector [size] - The outer size of the cross.
+ * @param Number|Vector [core] - The size of the core.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [cl] - The core length.
+ * @param Number [cw] - The core width.
+ * @returns Vector[] - Returns two vectors containing the outer and core size of the cross
+ */
+function sizeCross(size, core, l, w, cl, cw) =
+    let(
+        size = divisor2D(apply2D(size, l, w)),
+        core = apply2D(core, cl, cw)
+    )
+    [
+        size,
+        core
+    ]
+;
+
+/**
  * Computes the points that draw the sketch of a rectangle shape.
  *
  * @param Number|Vector [size] - The size of the rectangle.
@@ -324,6 +346,46 @@ function drawStar(size, core, edges, l, w, cl, cw) =
 ;
 
 /**
+ * Computes the points that draw the sketch of a cross shape.
+ *
+ * @param Number|Vector [size] - The outer size of the cross.
+ * @param Number|Vector [core] - The size of the core.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [cl] - The core length.
+ * @param Number [cw] - The core width.
+ * @returns Vector[]
+ */
+function drawCross(size, core, l, w, cl, cw) =
+    let(
+        size = sizeCross(size=size, core=core, l=l, w=w, cl=cl, cw=cw),
+        outer = size[0] / 2,
+        inner = size[1] / 2
+    )
+    inner == [0, 0] ?
+    [
+        [ outer[0],  outer[1]],
+        [-outer[0],  outer[1]],
+        [-outer[0], -outer[1]],
+        [ outer[0], -outer[1]]
+    ]
+   :[
+        [ inner[0],  inner[1]],
+        [ inner[0],  outer[1]],
+        [-inner[0],  outer[1]],
+        [-inner[0],  inner[1]],
+        [-outer[0],  inner[1]],
+        [-outer[0], -inner[1]],
+        [-inner[0], -inner[1]],
+        [-inner[0], -outer[1]],
+        [ inner[0], -outer[1]],
+        [ inner[0], -inner[1]],
+        [ outer[0], -inner[1]],
+        [ outer[0],  inner[1]]
+    ]
+;
+
+/**
  * Creates a rectangle at the origin.
  *
  * @param Number|Vector [size] - The size of the rectangle.
@@ -416,6 +478,23 @@ module hexagon(size, pointy, adjust, l, w, s) {
 module star(size, core, edges, l, w, cl, cw) {
     polygon(
         points = drawStar(size=size, core=core, edges=edges, l=l, w=w, cl=cl, cw=cw),
+        convexity = 10
+    );
+}
+
+/**
+ * Creates a cross at the origin.
+ *
+ * @param Number|Vector [size] - The outer size of the cross.
+ * @param Number|Vector [core] - The size of the core.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [cl] - The core length.
+ * @param Number [cw] - The core width.
+ */
+module regularCross(size, core, l, w, cl, cw) {
+    polygon(
+        points = drawCross(size=size, core=core, l=l, w=w, cl=cl, cw=cw),
         convexity = 10
     );
 }

--- a/shape/2D/polygon.scad
+++ b/shape/2D/polygon.scad
@@ -168,7 +168,7 @@ function sizeCross(size, core, l, w, cl, cw) =
 ;
 
 /**
- * Computes the points that draw the sketch of a rectangle shape.
+ * Computes the points that draws the sketch of a rectangle shape.
  *
  * @param Number|Vector [size] - The size of the rectangle.
  * @param Number [l] - The overall length.
@@ -177,19 +177,18 @@ function sizeCross(size, core, l, w, cl, cw) =
  */
 function drawRectangle(size, l, w) =
     let(
-        size = sizeRectangle(size=size, l=l, w=w),
-        half = size / 2
+        size = sizeRectangle(size=size, l=l, w=w) / 2
     )
     [
-        [ half[0],  half[1]],
-        [-half[0],  half[1]],
-        [-half[0], -half[1]],
-        [ half[0], -half[1]]
+        [ size[0],  size[1]],
+        [-size[0],  size[1]],
+        [-size[0], -size[1]],
+        [ size[0], -size[1]]
     ]
 ;
 
 /**
- * Computes the points that draw the sketch of a chamfered rectangle shape.
+ * Computes the points that draws the sketch of a chamfered rectangle shape.
  *
  * @param Number|Vector [size] - The size of the chamfered rectangle.
  * @param Number|Vector [chamfer] - The size of the chamfers.
@@ -202,31 +201,30 @@ function drawRectangle(size, l, w) =
 function drawChamferedRectangle(size, chamfer, l, w, cl, cw) =
     let(
         specs = sizeChamferedRectangle(size=size, chamfer=chamfer, l=l, w=w, cl=cl, cw=cw),
-        size = specs[0],
-        chamfer = specs[1],
-        half = size / 2
+        size = specs[0] / 2,
+        chamfer = specs[1]
     )
     chamfer[0]
    ?[
-        [ half[0],  half[1] - chamfer[1]],
-        [ half[0] - chamfer[0],  half[1]],
-        [-half[0] + chamfer[0],  half[1]],
-        [-half[0],  half[1] - chamfer[1]],
-        [-half[0], -half[1] + chamfer[1]],
-        [-half[0] + chamfer[0], -half[1]],
-        [ half[0] - chamfer[0], -half[1]],
-        [ half[0], -half[1] + chamfer[1]]
+        [ size[0],  size[1] - chamfer[1]],
+        [ size[0] - chamfer[0],  size[1]],
+        [-size[0] + chamfer[0],  size[1]],
+        [-size[0],  size[1] - chamfer[1]],
+        [-size[0], -size[1] + chamfer[1]],
+        [-size[0] + chamfer[0], -size[1]],
+        [ size[0] - chamfer[0], -size[1]],
+        [ size[0], -size[1] + chamfer[1]]
     ]
    :[
-        [ half[0],  half[1]],
-        [-half[0],  half[1]],
-        [-half[0], -half[1]],
-        [ half[0], -half[1]]
+        [ size[0],  size[1]],
+        [-size[0],  size[1]],
+        [-size[0], -size[1]],
+        [ size[0], -size[1]]
     ]
 ;
 
 /**
- * Computes the points that draw the sketch of a trapezium shape.
+ * Computes the points that draws the sketch of a trapezium shape.
  *
  * @param Number|Vector [size] - The size of the trapezium.
  * @param Number [a] - The length of the bottom base.
@@ -236,19 +234,18 @@ function drawChamferedRectangle(size, chamfer, l, w, cl, cw) =
  */
 function drawTrapezium(size, a, b, w) =
     let(
-        size = sizeTrapezium(size=size, a=a, b=b, w=w),
-        half = size / 2
+        size = sizeTrapezium(size=size, a=a, b=b, w=w) / 2
     )
     [
-        [ half[1],  half[2]],
-        [-half[1],  half[2]],
-        [-half[0], -half[2]],
-        [ half[0], -half[2]]
+        [ size[1],  size[2]],
+        [-size[1],  size[2]],
+        [-size[0], -size[2]],
+        [ size[0], -size[2]]
     ]
 ;
 
 /**
- * Computes the points that draw the sketch of a regular polygon.
+ * Computes the points that draws the sketch of a regular polygon.
  *
  * @param Number|Vector [size] - The size of the polygon.
  * @param Number [n] - The number of facets (min. 3).
@@ -271,7 +268,7 @@ function drawRegularPolygon(size, n, l, w, s) =
 ;
 
 /**
- * Computes the points that draw the sketch of an hexagon.
+ * Computes the points that draws the sketch of an hexagon.
  *
  * @param Number|Vector [size] - The size of the hexagon.
  * @param Boolean [pointy] - Tells if the hexagon must be pointy topped (default: false, Flat topped).
@@ -311,7 +308,7 @@ function drawHexagon(size, pointy, adjust, l, w, s) =
 ;
 
 /**
- * Computes the points that draw the sketch of a star shape.
+ * Computes the points that draws the sketch of a star shape.
  *
  * @param Number|Vector [size] - The outer size of the star.
  * @param Number|Vector [core] - The size of the core.
@@ -346,7 +343,7 @@ function drawStar(size, core, edges, l, w, cl, cw) =
 ;
 
 /**
- * Computes the points that draw the sketch of a cross shape.
+ * Computes the points that draws the sketch of a cross shape.
  *
  * @param Number|Vector [size] - The outer size of the cross.
  * @param Number|Vector [core] - The size of the core.

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -156,6 +156,29 @@ function sizeStarBox(size, core, edges, l, w, h, cl, cw) =
 ;
 
 /**
+ * Computes the size of a cross shape.
+ *
+ * @param Number|Vector [size] - The outer size of the cross.
+ * @param Number|Vector [core] - The size of the core.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [h] - The height of the box.
+ * @param Number [cl] - The core length.
+ * @param Number [cw] - The core width.
+ * @returns Vector[] - Returns two vectors containing the outer and core size of the cross
+ */
+function sizeCrossBox(size, core, l, w, h, cl, cw) =
+    let(
+        size = divisor3D(apply3D(size, l, w, h)),
+        core = apply2D(core, cl, cw)
+    )
+    [
+        size,
+        core
+    ]
+;
+
+/**
  * Creates a box at the origin.
  *
  * @param Number|Vector [size] - The size of the box.
@@ -252,7 +275,7 @@ module hexagonBox(size, pointy, adjust, l, w, h, s, center) {
  * @param Number [edges] - The number of star edges (min. 3).
  * @param Number [l] - The overall length.
  * @param Number [w] - The overall width
- * @param Number [h] - The overall height..
+ * @param Number [h] - The overall height.
  * @param Number [cl] - The core length.
  * @param Number [cw] - The core width.
  * @param Boolean [center] - Whether or not center the box on the vertical axis.
@@ -261,6 +284,25 @@ module starBox(size, core, edges, l, w, h, cl, cw, center) {
     size = sizeStarBox(size=size, core=core, edges=edges, l=l, w=w, h=h, cl=cl, cw=cw);
     linear_extrude(height=size[0][2], center=center, convexity=10) {
         star(size[0], size[1], size[2]);
+    }
+}
+
+/**
+ * Creates a cross box at the origin.
+ *
+ * @param Number|Vector [size] - The outer size of the cross.
+ * @param Number|Vector [core] - The size of the core.
+ * @param Number [l] - The overall length.
+ * @param Number [w] - The overall width.
+ * @param Number [h] - The overall height.
+ * @param Number [cl] - The core length.
+ * @param Number [cw] - The core width.
+ * @param Boolean [center] - Whether or not center the box on the vertical axis.
+ */
+module regularCrossBox(size, core, l, w, h, cl, cw, center) {
+    size = sizeCrossBox(size=size, core=core, l=l, w=w, h=h, cl=cl, cw=cw);
+    linear_extrude(height=size[0][2], center=center, convexity=10) {
+        regularCross(size[0], size[1]);
     }
 }
 

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -288,3 +288,30 @@ module meshBox(size, count, gap, pointy, linear, even, l, w, h, cx, cy, gx, gy, 
         mesh(size=size, count=count, gap=gap, pointy=pointy, linear=linear, even=even, cx=cx, cy=cy, gx=gx, gy=gy);
     }
 }
+
+/**
+ * Creates a simple polyhedron, where only two opposite faces are defined by a
+ * list of points. Several possibilities are available:
+ * - provides the points for one face, then set a distance for the opposite face
+ * - provides the points for two opposite faces
+ * - provides the points for two opposite faces, then set a distance between them
+ *
+ * Note: both faces should have the same number of points.
+ *
+ * @param Vector[] [bottom] - The list of points for the bottom face.
+ * @param Vector[] [top] - The list of points for the top face.
+ * @param Vector[] [points] - The list of points for a main face.
+ * @param Vector [distane] - The distance between two main faces.
+ * @param Number [x] - The distance between two main faces on the X-axis.
+ * @param Number [y] - The distance between two main faces on the Y-axis.
+ * @param Number [z] - The distance between two main faces on the Z-axis.
+ * @returns Vector[]
+ */
+module simplePolyhedron(bottom, top, points, distance, x, y, z) {
+    points = simplePolyhedronPoints(bottom=bottom, top=top, points=points, distance=distance, x=x, y=y, z=z);
+    polyhedron(
+        points = points,
+        faces = simplePolyhedronFaces(len(points) / 2),
+        convexity = 10
+    );
+}

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreLine() {
-    testPackage("core/line.scad", 5) {
+    testPackage("core/line.scad", 6) {
         // test core/line/arc()
         testModule("arc()", 9) {
             testUnit("no parameter", 1) {
@@ -303,6 +303,32 @@ module testCoreLine() {
             testUnit("inside", 2) {
                 assertEqual(outline([[0, 0], [3, 0], [3, 3], [0, 3]], -1), [[1, 1], [2, 1], [2, 2], [1, 2]], "Outline of a square");
                 assertEqual(outline([[3, 2], [2, 2], [2, 3], [-2, 3], [-2, 2], [-3, 2], [-3, -2], [-2, -2], [-2, -3], [2, -3], [2, -2], [3, -2]], -1), [[2, 1], [1, 1], [1, 2], [-1, 2], [-1, 1], [-2, 1], [-2, -1], [-1, -1], [-1, -2], [1, -2], [1, -1], [2, -1]], "Outline of a cross");
+            }
+        }
+        // test core/line/lineAdd()
+        testModule("lineAdd()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(lineAdd(), [], "Cannot add value to an empty line");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(lineAdd("1", "1"), [[0, 0]], "Cannot add value to strings");
+                assertEqual(lineAdd(true, true), [[0, 0]], "Cannot add value to booleans");
+                assertEqual(lineAdd([], []), [], "Cannot add value to empty vectors");
+            }
+            testUnit("2D vectors", 5) {
+                assertEqual(lineAdd(1, 1), [[2, 2]], "Simple values should be converted to 2D vectors");
+                assertEqual(lineAdd([0, 1], 1), [[1, 1], [2, 2]], "Single value points should be converted to 2D vectors");
+                assertEqual(lineAdd([[2, 3], [1, -2]], [1, 2]), [[3, 5], [2, 0]], "Add 2D vector");
+                assertEqual(lineAdd([[2, 3], [1, -2]], [1]), [[3, 3], [2, -2]], "Add truncated 2D vector");
+                assertEqual(lineAdd([[2], [-2]], [1, 2]), [[3, 2], [-1, 2]], "Add 2D vector to truncated points");
+            }
+            testUnit("3D vectors", 6) {
+                assertEqual(lineAdd(1, [1, 2, 3]), [[2, 3, 4]], "Simple values should be converted to 3D vectors if vector to add is 3D");
+                assertEqual(lineAdd([[1, 2, 3]], 1), [[2, 3, 4]], "Simple values should be converted to 3D vectors if line is 3D");
+                assertEqual(lineAdd([0, 1], [1, 1, 1]), [[1, 1, 1], [2, 2, 2]], "Single value points should be converted to 3D vectors if vector to add is 3D");
+                assertEqual(lineAdd([[2, 3, 1], [1, -2, -1]], [1, 2, 3]), [[3, 5, 4], [2, 0, 2]], "Add 3D vector");
+                assertEqual(lineAdd([[2, 3, 4], [1, -2, 1]], [1]), [[3, 3, 4], [2, -2, 1]], "Add truncated 3D vector");
+                assertEqual(lineAdd([[2], [-2]], [1, 2, 3]), [[3, 2, 3], [-1, 2, 3]], "Add 3D vector to truncated points");
             }
         }
     }

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreLine() {
-    testPackage("core/line.scad", 7) {
+    testPackage("core/line.scad", 8) {
         // test core/line/arc()
         testModule("arc()", 9) {
             testUnit("no parameter", 1) {
@@ -387,6 +387,605 @@ module testCoreLine() {
                     [10, 11, 23, 22],
                     [11, 0, 12, 23]
                 ], "Polyhedron with 12 edges");
+            }
+        }
+        // test core/line/simplePolyhedronPoints()
+        testModule("simplePolyhedronPoints()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(simplePolyhedronPoints(), [], "Cannot get points for an empty polyhedron");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(simplePolyhedronPoints("1"), [[0, 0, 0], [0, 0, 0]], "Cannot get points for a wrong polyhedron (strings)");
+                assertEqual(simplePolyhedronPoints(true), [[0, 0, 0], [0, 0, 0]], "Cannot get points for a wrong polyhedron (booleans)");
+                assertEqual(simplePolyhedronPoints([]), [], "Cannot get points for a wrong polyhedron (vectors)");
+            }
+            testUnit("polyhedron", 67) {
+                assertEqual(simplePolyhedronPoints([1, 2, 3], [4, 5, 6]), [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4], [5, 5, 5], [6, 6, 6]], "Simple numbers should be converted into 3D vectors: bottom and top");
+                assertEqual(simplePolyhedronPoints(points=[1, 2, 3]), [[1, 1, 1], [2, 2, 2], [3, 3, 3], [1, 1, 1], [2, 2, 2], [3, 3, 3]], "Simple numbers should be converted into 3D vectors: points");
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                    "Concat bottom and top"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = 1
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 5, 5], [6, 6, 6], [7, 7, 7]],
+                    "Concat bottom and top, add distance as a number"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1, 2, 3]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 6, 7], [6, 7, 8], [7, 8, 9]],
+                    "Concat bottom and top, add distance as a vector"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 4, 4], [6, 5, 5], [7, 6, 6]],
+                    "Concat bottom and top, complete and add distance (1)"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1, 2]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 6, 4], [6, 7, 5], [7, 8, 6]],
+                    "Concat bottom and top, complete and add distance (2)"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 2, 2], [3, 3, 3], [4, 4, 4]],
+                    "Compose from points, convert distance"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]],
+                    "Compose from points, add distance"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 1, 1], [3, 2, 2], [4, 3, 3]],
+                    "Compose from points, complete distance (1)"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 1], [3, 4, 2], [4, 5, 3]],
+                    "Compose from points, complete distance (2)"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 2, 2], [3, 3, 3], [4, 4, 4]],
+                    "Compose from bottom, convert distance"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]],
+                    "Compose from bottom, add distance"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 1, 1], [3, 2, 2], [4, 3, 3]],
+                    "Compose from bottom, complete distance (1)"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 1], [3, 4, 2], [4, 5, 3]],
+                    "Compose from bottom, complete distance (2)"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 2, 2], [3, 3, 3], [4, 4, 4]],
+                    "Compose from top, convert distance"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]],
+                    "Compose from top, add distance"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 1, 1], [3, 2, 2], [4, 3, 3]],
+                    "Compose from top, complete distance (1)"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2]
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 1], [3, 4, 2], [4, 5, 3]],
+                    "Compose from top, complete distance (2)"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = 1,
+                        x = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [6, 5, 5], [7, 6, 6], [8, 7, 7]],
+                    "Concat bottom and top, add distance as a number and set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = 1,
+                        y = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 6, 5], [6, 7, 6], [7, 8, 7]],
+                    "Concat bottom and top, add distance as a number and set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = 1,
+                        z = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 5, 6], [6, 6, 7], [7, 7, 8]],
+                    "Concat bottom and top, add distance as a number and set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1, 2, 3],
+                        x = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [8, 6, 7], [9, 7, 8], [10, 8, 9]],
+                    "Concat bottom and top, add distance as a vector and set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1, 2, 3],
+                        y = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 8, 7], [6, 9, 8], [7, 10, 9]],
+                    "Concat bottom and top, add distance as a vector and set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1, 2, 3],
+                        z = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 6, 8], [6, 7, 9], [7, 8, 10]],
+                    "Concat bottom and top, add distance as a vector and set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1],
+                        x = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [6, 4, 4], [7, 5, 5], [8, 6, 6]],
+                    "Concat bottom and top, complete and add distance (1), set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1],
+                        y = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 6, 4], [6, 7, 5], [7, 8, 6]],
+                    "Concat bottom and top, complete and add distance (1), set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1],
+                        z = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 4, 6], [6, 5, 7], [7, 6, 8]],
+                    "Concat bottom and top, complete and add distance (1), set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1, 2],
+                        x = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [8, 6, 4], [9, 7, 5], [10, 8, 6]],
+                    "Concat bottom and top, complete and add distance (2), set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1, 2],
+                        y = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 8, 4], [6, 9, 5], [7, 10, 6]],
+                    "Concat bottom and top, complete and add distance (2), set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        top = [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
+                        distance = [1, 2],
+                        z = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 6, 8], [6, 7, 9], [7, 8, 10]],
+                    "Concat bottom and top, complete and add distance (2), set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        x = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [3, 2, 2], [4, 3, 3], [5, 4, 4]],
+                    "Compose from points, convert distance and set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        y = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 2], [3, 4, 3], [4, 5, 4]],
+                    "Compose from points, convert distance and set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        z = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 2, 3], [3, 3, 4], [4, 4, 5]],
+                    "Compose from points, convert distance and set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        x = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 3, 4], [6, 4, 5], [7, 5, 6]],
+                    "Compose from points, add distance, set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        y = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 5, 4], [3, 6, 5], [4, 7, 6]],
+                    "Compose from points, add distance, set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        z = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 5], [3, 4, 6], [4, 5, 7]],
+                    "Compose from points, add distance, set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        x = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [3, 1, 1], [4, 2, 2], [5, 3, 3]],
+                    "Compose from points, complete distance (1), set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        y = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 1], [3, 4, 2], [4, 5, 3]],
+                    "Compose from points, complete distance (1), set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        z = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 1, 3], [3, 2, 4], [4, 3, 5]],
+                    "Compose from points, complete distance (1), set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        x = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 3, 1], [5, 4, 2], [6, 5, 3]],
+                    "Compose from points, complete distance (2), set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        y = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 4, 1], [3, 5, 2], [4, 6, 3]],
+                    "Compose from points, complete distance (2), set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        points = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        z = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]],
+                    "Compose from points, complete distance (2), set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        x = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [3, 2, 2], [4, 3, 3], [5, 4, 4]],
+                    "Compose from bottom, convert distance and set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        y = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 2], [3, 4, 3], [4, 5, 4]],
+                    "Compose from bottom, convert distance and set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        z = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 2, 3], [3, 3, 4], [4, 4, 5]],
+                    "Compose from bottom, convert distance and set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        x = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 3, 4], [6, 4, 5], [7, 5, 6]],
+                    "Compose from bottom, add distance, set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        y = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 5, 4], [3, 6, 5], [4, 7, 6]],
+                    "Compose from bottom, add distance, set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        z = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 5], [3, 4, 6], [4, 5, 7]],
+                    "Compose from bottom, add distance, set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        x = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [3, 1, 1], [4, 2, 2], [5, 3, 3]],
+                    "Compose from bottom, complete distance (1), set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        y = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 1], [3, 4, 2], [4, 5, 3]],
+                    "Compose from bottom, complete distance (1), set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        z = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 1, 3], [3, 2, 4], [4, 3, 5]],
+                    "Compose from bottom, complete distance (1), set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        x = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 3, 1], [5, 4, 2], [6, 5, 3]],
+                    "Compose from bottom, complete distance (2), set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        y = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 4, 1], [3, 5, 2], [4, 6, 3]],
+                    "Compose from bottom, complete distance (2), set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        bottom = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        z = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]],
+                    "Compose from bottom, complete distance (2), set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        x = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [3, 2, 2], [4, 3, 3], [5, 4, 4]],
+                    "Compose from top, convert distance and set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        y = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 2], [3, 4, 3], [4, 5, 4]],
+                    "Compose from top, convert distance and set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = 1,
+                        z = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 2, 3], [3, 3, 4], [4, 4, 5]],
+                    "Compose from top, convert distance and set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        x = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [5, 3, 4], [6, 4, 5], [7, 5, 6]],
+                    "Compose from top, add distance, set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        y = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 5, 4], [3, 6, 5], [4, 7, 6]],
+                    "Compose from top, add distance, set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2, 3],
+                        z = 4
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 5], [3, 4, 6], [4, 5, 7]],
+                    "Compose from top, add distance, set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        x = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [3, 1, 1], [4, 2, 2], [5, 3, 3]],
+                    "Compose from top, complete distance (1), set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        y = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 1], [3, 4, 2], [4, 5, 3]],
+                    "Compose from top, complete distance (1), set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1],
+                        z = 2
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 1, 3], [3, 2, 4], [4, 3, 5]],
+                    "Compose from top, complete distance (1), set z"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        x = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 3, 1], [5, 4, 2], [6, 5, 3]],
+                    "Compose from top, complete distance (2), set x"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        y = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 4, 1], [3, 5, 2], [4, 6, 3]],
+                    "Compose from top, complete distance (2), set y"
+                );
+                assertEqual(
+                    simplePolyhedronPoints(
+                        top = [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                        distance = [1, 2],
+                        z = 3
+                    ),
+                    [[1, 1, 1], [2, 2, 2], [3, 3, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]],
+                    "Compose from top, complete distance (2), set z"
+                );
             }
         }
     }

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreLine() {
-    testPackage("core/line.scad", 6) {
+    testPackage("core/line.scad", 7) {
         // test core/line/arc()
         testModule("arc()", 9) {
             testUnit("no parameter", 1) {
@@ -329,6 +329,64 @@ module testCoreLine() {
                 assertEqual(lineAdd([[2, 3, 1], [1, -2, -1]], [1, 2, 3]), [[3, 5, 4], [2, 0, 2]], "Add 3D vector");
                 assertEqual(lineAdd([[2, 3, 4], [1, -2, 1]], [1]), [[3, 3, 4], [2, -2, 1]], "Add truncated 3D vector");
                 assertEqual(lineAdd([[2], [-2]], [1, 2, 3]), [[3, 2, 3], [-1, 2, 3]], "Add 3D vector to truncated points");
+            }
+        }
+        // test core/line/simplePolyhedronFaces()
+        testModule("simplePolyhedronFaces()", 4) {
+            testUnit("no parameter", 1) {
+                assertEqual(simplePolyhedronFaces(), [], "Cannot get faces for an empty polyhedron");
+            }
+            testUnit("wrong type", 3) {
+                assertEqual(simplePolyhedronFaces("1"), [], "Cannot get faces for a wrong polyhedron (strings)");
+                assertEqual(simplePolyhedronFaces(true), [], "Cannot get faces for a wrong polyhedron (booleans)");
+                assertEqual(simplePolyhedronFaces([]), [], "Cannot get faces for a wrong polyhedron (vectors)");
+            }
+            testUnit("invalid polyhedron", 3) {
+                assertEqual(simplePolyhedronFaces(0), [], "Cannot get faces for an invalid polyhedron (0)");
+                assertEqual(simplePolyhedronFaces(1), [], "Cannot get faces for an invalid polyhedron (1)");
+                assertEqual(simplePolyhedronFaces(2), [], "Cannot get faces for an invalid polyhedron (2)");
+            }
+            testUnit("polyhedron", 4) {
+                assertEqual(simplePolyhedronFaces(3), [
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [0, 1, 4, 3],
+                    [1, 2, 5, 4],
+                    [2, 0, 3, 5]
+                ], "Polyhedron with 3 edges");
+                assertEqual(simplePolyhedronFaces(4), [
+                    [0, 1, 2, 3],
+                    [4, 5, 6, 7],
+                    [0, 1, 5, 4],
+                    [1, 2, 6, 5],
+                    [2, 3, 7, 6],
+                    [3, 0, 4, 7]
+                ], "Polyhedron with 4 edges");
+                assertEqual(simplePolyhedronFaces(5), [
+                    [0, 1, 2, 3, 4],
+                    [5, 6, 7, 8, 9],
+                    [0, 1, 6, 5],
+                    [1, 2, 7, 6],
+                    [2, 3, 8, 7],
+                    [3, 4, 9, 8],
+                    [4, 0, 5, 9]
+                ], "Polyhedron with 5 edges");
+                assertEqual(simplePolyhedronFaces(12), [
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+                    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+                    [0, 1, 13, 12],
+                    [1, 2, 14, 13],
+                    [2, 3, 15, 14],
+                    [3, 4, 16, 15],
+                    [4, 5, 17, 16],
+                    [5, 6, 18, 17],
+                    [6, 7, 19, 18],
+                    [7, 8, 20, 19],
+                    [8, 9, 21, 20],
+                    [9, 10, 22, 21],
+                    [10, 11, 23, 22],
+                    [11, 0, 12, 23]
+                ], "Polyhedron with 12 edges");
             }
         }
     }

--- a/test/shape/2D/polygon.scad
+++ b/test/shape/2D/polygon.scad
@@ -34,7 +34,7 @@ use <../../../full.scad>
  * @author jsconan
  */
 module testShape2dPolygon() {
-    testPackage("shape/2D/polygon.scad", 11) {
+    testPackage("shape/2D/polygon.scad", 13) {
         // test shape/2D/polygon/sizeRectangle()
         testModule("sizeRectangle()", 2) {
             testUnit("default values", 3) {
@@ -143,6 +143,30 @@ module testShape2dPolygon() {
 
                 assertEqual(sizeStar(l=4, w=3, edges=5), [[4, 3], [4, 3] * (1 - 3 / 5), 5], "Should accept separate length and width");
                 assertEqual(sizeStar(l=4, w=3, cl=2, cw=1, edges=5), [[4, 3], [2, 1], 5], "Should accept separate core length and width");
+            }
+        }
+        // test shape/2D/polygon/sizeCross()
+        testModule("sizeCross()", 2) {
+            testUnit("default values", 3) {
+                assertEqual(sizeCross(), [[1, 1], [0, 0]], "Should always return a size even if not parameter has been provided");
+                assertEqual(sizeCross("12", "12", "12"), [[1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (string)");
+                assertEqual(sizeCross(true, true, true), [[1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (boolean)");
+            }
+            testUnit("compute size", 10) {
+                assertEqual(sizeCross(3), [[3, 3], [0, 0]], "Should produce a size vector from a single number size");
+                assertEqual(sizeCross(3, 2), [[3, 3], [2, 2]], "Should produce a size vector from a single number sizes");
+
+                assertEqual(sizeCross([3, 2], 1), [[3, 2], [1, 1]], "Should accept vector for the outer size");
+                assertEqual(sizeCross(3, [1, 2]), [[3, 3], [1, 2]], "Should accept vector for the core size");
+
+                assertEqual(sizeCross([3, 2], 1, l=4), [[4, 2], [1, 1]], "Should accept to override the length");
+                assertEqual(sizeCross([3, 2], 1, w=4), [[3, 4], [1, 1]], "Should accept to override the width");
+
+                assertEqual(sizeCross(3, [1, 1], cl=2), [[3, 3], [2, 1]], "Should accept to override the core length");
+                assertEqual(sizeCross(4, [1, 1], cw=2), [[4, 4], [1, 2]], "Should accept to override the core width");
+
+                assertEqual(sizeCross(l=4, w=3), [[4, 3], [0, 0]], "Should accept separate length and width");
+                assertEqual(sizeCross(l=4, w=3, cl=2, cw=1), [[4, 3], [2, 1]], "Should accept separate core length and width");
             }
         }
         // test shape/2D/polygon/drawRectangle()
@@ -292,6 +316,31 @@ module testShape2dPolygon() {
 
                 assertEqual(drawStar(l=4, w=3, edges=5), [ for(i = [0 : 9]) _rotP(i * 360/10 + 90, i % 2 ? 4 * (1 - 3 / 5) : 4, i % 2 ? 3 * (1 - 3 / 5) : 3) ], "Should return a list of points to draw a star. Should accept separate length and width");
                 assertEqual(drawStar(l=4, w=3, cl=2, cw=1, edges=5), [ for(i = [0 : 9]) _rotP(i * 360/10 + 90, i % 2 ?2 : 4, i % 2 ? 1 : 3) ], "Should return a list of points to draw a star. Should accept separate core length and width");
+            }
+        }
+        // test shape/2D/polygon/drawCross()
+        testModule("drawCross()", 2) {
+            testUnit("default values", 3) {
+                default = [ [0.5, 0.5], [-0.5, 0.5], [-0.5, -0.5], [0.5, -0.5] ];
+                assertEqual(drawCross(), default, "Should return a list of points to draw a cross with a size of 1");
+                assertEqual(drawCross("12", "12", "12"), default, "Should return a list of points to draw a cross with a size of 1 if wrong parameter has been provided (string)");
+                assertEqual(drawCross(true, true, true), default, "Should return a list of points to draw a cross with a size of 1 if wrong parameter has been provided (boolean)");
+            }
+            testUnit("draw shape", 10) {
+                assertEqual(drawCross(3), [[1.5, 1.5], [-1.5, 1.5], [-1.5, -1.5], [1.5, -1.5]], "Should return a list of points to draw a cross. Single number size should be translated into vector");
+                assertEqual(drawCross(3, 2), [[1, 1], [1, 1.5], [-1, 1.5], [-1, 1], [-1.5, 1], [-1.5, -1], [-1, -1], [-1, -1.5], [1, -1.5], [1, -1], [1.5, -1], [1.5,  1]], "Should return a list of points to draw a cross. Should produce a size vector from a single number sizes");
+
+                assertEqual(drawCross([3, 2], 1), [[0.5, 0.5], [0.5, 1], [-0.5, 1], [-0.5, 0.5], [-1.5, 0.5], [-1.5, -0.5], [-0.5, -0.5], [-0.5, -1], [0.5, -1], [0.5, -0.5], [1.5, -0.5], [1.5, 0.5]], "Should return a list of points to draw a cross. Should accept vector for the outer size");
+                assertEqual(drawCross(3, [1, 2]), [[0.5, 1], [0.5, 1.5], [-0.5, 1.5], [-0.5, 1], [-1.5, 1], [-1.5, -1], [-0.5, -1], [-0.5, -1.5], [0.5, -1.5], [0.5, -1], [1.5, -1], [1.5, 1]], "Should return a list of points to draw a cross. Should accept vector for the core size");
+
+                assertEqual(drawCross([3, 2], 1, l=4), [[ 0.5, 0.5], [ 0.5, 1], [-0.5, 1], [-0.5, 0.5], [-2, 0.5], [-2, -0.5], [-0.5, -0.5], [-0.5, -1], [0.5, -1], [0.5, -0.5], [2, -0.5], [2, 0.5]], "Should return a list of points to draw a cross. Should accept to override the length");
+                assertEqual(drawCross([3, 2], 1, w=4), [[0.5, 0.5], [0.5, 2], [-0.5, 2], [-0.5, 0.5], [-1.5, 0.5], [-1.5, -0.5], [-0.5, -0.5], [-0.5, -2], [0.5, -2], [0.5, -0.5], [1.5, -0.5], [1.5, 0.5]], "Should return a list of points to draw a cross. Should accept to override the width");
+
+                assertEqual(drawCross(4, [1, 1], cl=2), [[1, 0.5], [1, 2], [-1, 2], [-1, 0.5], [-2, 0.5], [-2, -0.5], [-1, -0.5], [-1, -2], [1, -2], [1, -0.5], [2, -0.5], [2, 0.5]], "Should return a list of points to draw a cross. Should accept to override the core length");
+                assertEqual(drawCross(4, [1, 1], cw=2), [[0.5, 1], [0.5, 2], [-0.5, 2], [-0.5, 1], [-2, 1], [-2, -1], [-0.5, -1], [-0.5, -2], [0.5, -2], [0.5, -1], [2, -1], [2, 1]], "Should return a list of points to draw a cross. Should accept to override the core width");
+
+                assertEqual(drawCross(l=4, w=3), [[2, 1.5], [-2, 1.5], [-2, -1.5], [2, -1.5]], "Should return a list of points to draw a cross. Should accept separate length and width");
+                assertEqual(drawCross(l=4, w=3, cl=2, cw=1), [[1, 0.5], [1, 1.5], [-1, 1.5], [-1, 0.5], [-2, 0.5], [-2, -0.5], [-1, -0.5], [-1, -1.5], [1, -1.5], [1, -0.5], [2, -0.5], [2, 0.5]], "Should return a list of points to draw a cross. Should accept separate core length and width");
             }
         }
     }

--- a/test/shape/3D/polyhedron.scad
+++ b/test/shape/3D/polyhedron.scad
@@ -34,7 +34,7 @@ use <../../../full.scad>
  * @author jsconan
  */
 module testShape3dPolyhedron() {
-    testPackage("shape/3D/polyhedron.scad", 5) {
+    testPackage("shape/3D/polyhedron.scad", 6) {
         // test shape/3D/polyhedron/sizeBox()
         testModule("sizeBox()", 2) {
             testUnit("default values", 3) {
@@ -151,6 +151,31 @@ module testShape3dPolyhedron() {
 
                 assertEqual(sizeStarBox(l=4, w=3, h=6, edges=5), [[4, 3, 6], [4, 3] * (1 - 3 / 5), 5], "Should accept separate length, width and height");
                 assertEqual(sizeStarBox(l=4, w=3, h=6, cl=2, cw=1, edges=5), [[4, 3, 6], [2, 1], 5], "Should accept separate core length and width");
+            }
+        }
+        // test shape/3D/polygon/sizeCrossBox()
+        testModule("sizeCrossBox()", 2) {
+            testUnit("default values", 3) {
+                assertEqual(sizeCrossBox(), [[1, 1, 1], [0, 0]], "Should always return a size even if not parameter has been provided");
+                assertEqual(sizeCrossBox("12", "12", "12"), [[1, 1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (string)");
+                assertEqual(sizeCrossBox(true, true, true), [[1, 1, 1], [0, 0]], "Should always return a size even if wrong parameter has been provided (boolean)");
+            }
+            testUnit("compute size", 11) {
+                assertEqual(sizeCrossBox(3), [[3, 3, 3], [0, 0]], "Should produce a size vector from a single number size");
+                assertEqual(sizeCrossBox(3, 2), [[3, 3, 3], [2, 2]], "Should produce a size vector from a single number sizes");
+
+                assertEqual(sizeCrossBox([3, 2, 4], 1), [[3, 2, 4], [1, 1]], "Should accept vector for the outer size");
+                assertEqual(sizeCrossBox(3, [1, 2]), [[3, 3, 3], [1, 2]], "Should accept vector for the core size");
+
+                assertEqual(sizeCrossBox([3, 2, 1], 1, l=4), [[4, 2, 1], [1, 1]], "Should accept to override the length");
+                assertEqual(sizeCrossBox([3, 2, 1], 1, w=4), [[3, 4, 1], [1, 1]], "Should accept to override the width");
+                assertEqual(sizeCrossBox([3, 2, 1], 1, h=4), [[3, 2, 4], [1, 1]], "Should accept to override the height");
+
+                assertEqual(sizeCrossBox(3, [1, 1], cl=2), [[3, 3, 3], [2, 1]], "Should accept to override the core length");
+                assertEqual(sizeCrossBox(4, [1, 1], cw=2), [[4, 4, 4], [1, 2]], "Should accept to override the core width");
+
+                assertEqual(sizeCrossBox(l=4, w=3, h=2), [[4, 3, 2], [0, 0]], "Should accept separate length, width and height");
+                assertEqual(sizeCrossBox(l=4, w=3, h=2, cl=2, cw=1), [[4, 3, 2], [2, 1]], "Should accept separate core length and width");
             }
         }
     }


### PR DESCRIPTION
Add core functions:
- `lineAdd()`: Adds a value to each point of a line.
- `simplePolyhedronFaces()`: Builds a vector of faces to be used in a polyhedron. The function accepts the number of points defining one main face of the polyhedron, then returns the faces vector that contains the indices of each face enclosing the solid. This only apply on simple polyhedron where two opposite faces share the same number of points.
- `simplePolyhedronPoints()`: Composes a list of points to be used in a simple polyhedron.
- `sizeCross()`: Computes the size of a cross shape.
- `sizeCrossBox()`: Computes the size of a cross shape.
- `drawCross()`: Computes the points that draws the sketch of a cross shape.

Add 2D shapes:
- `regularCross`: Creates a cross at the origin.

Add 3D shapes:
- `regularCrossBox()`: Creates a cross box at the origin.
- `simplePolyhedron `: Creates a simple polyhedron, where only two opposite faces are defined by a list of points.
