### PR TITLE
Fix/typo in function name

### DIFF
--- a/core/maths.scad
+++ b/core/maths.scad
@@ -128,14 +128,14 @@ function getPolygonAngle(index, count = 4) =
 ;
 
 /**
- * Computes a length based on the Pythagore's theorem.
+ * Computes a length based on the Pythagoras's theorem.
  *
  * @param Number a - The A side of the rectangle (0 or undef to compute this value).
  * @param Number b - The B side of the rectangle (0 or undef to compute this value).
  * @param Number c - The hypotenuse of the rectangle (0 or undef to compute this value).
  * @returns Number
  */
-function pythagore(a, b, c) =
+function pythagoras(a, b, c) =
     sqrt(c ? pow(float(c), 2) - pow(a ? float(a) : float(b), 2)
            : pow(float(a), 2) + pow(float(b), 2))
 ;

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -219,7 +219,7 @@ function center2D(a, b, r, negative) =
     move2D(
         middle2D(a, b),
         normal(ab),
-        pythagore(0, norm(ab) / 2, float(r))
+        pythagoras(0, norm(ab) / 2, float(r))
     )
 ;
 
@@ -296,7 +296,7 @@ function tangent2D(p, c, r) =
     )
     d > r ? (
         let(
-            t = pythagore(0, r, d),
+            t = pythagoras(0, r, d),
             a = getAngle(v[0], v[1]) + asin(r / d)
         )
         p + arcPoint(t, a)
@@ -334,7 +334,7 @@ function circleLineIntersect2D(i, j, c, r) =
         )
         a <= r ? (
             let(
-                b = pythagore(a, 0, r)
+                b = pythagoras(a, 0, r)
             )
             [
                 [i[0], c[1] - b],
@@ -350,7 +350,7 @@ function circleLineIntersect2D(i, j, c, r) =
        )
        a <= r ? (
            let(
-               b = pythagore(a, 0, r)
+               b = pythagoras(a, 0, r)
            )
            [
                [c[0] - b, i[1]],
@@ -489,7 +489,7 @@ function isosceles2D(a, b, h, angle) =
     h != undef ? (
         let(
             h = float(h),
-            r = pythagore(h, d),
+            r = pythagoras(h, d),
             angle = getAngle(d, h)
         )
         a + arcPoint(r, w + angle)

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -346,30 +346,30 @@ module testCoreMaths() {
                 assertEqual(getPolygonAngle(13, 8), 360 / 8 * 5, "Octogon, index 13");
             }
         }
-        // test core/maths/pythagore()
-        testModule("pythagore()") {
+        // test core/maths/pythagoras()
+        testModule("pythagoras()") {
             testUnit("no parameter", 1) {
-                assertEqual(pythagore(), 0, "Without parameter the function should return 0");
+                assertEqual(pythagoras(), 0, "Without parameter the function should return 0");
             }
             testUnit("wrong type", 5) {
-                assertEqual(pythagore("10", "10"), 0, "Strings should be converted to 0");
-                assertEqual(pythagore(true, true), 0, "Booleans should be converted to 0");
-                assertEqual(pythagore([], []), 0, "Empty arrays should be converted to 0");
-                assertEqual(pythagore(["1"], ["2"]), 0, "Arrays should be converted to 0");
-                assertEqual(pythagore([1], [2]), 0, "Vectors should be converted to 0");
+                assertEqual(pythagoras("10", "10"), 0, "Strings should be converted to 0");
+                assertEqual(pythagoras(true, true), 0, "Booleans should be converted to 0");
+                assertEqual(pythagoras([], []), 0, "Empty arrays should be converted to 0");
+                assertEqual(pythagoras(["1"], ["2"]), 0, "Arrays should be converted to 0");
+                assertEqual(pythagoras([1], [2]), 0, "Vectors should be converted to 0");
             }
             testUnit("number", 9) {
-                assertEqual(pythagore(0), 0, "If the only one parameter is 0, the function should not fail, but should return 0");
-                assertEqual(pythagore(0, 0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
+                assertEqual(pythagoras(0), 0, "If the only one parameter is 0, the function should not fail, but should return 0");
+                assertEqual(pythagoras(0, 0, 0), 0, "If all parameters are 0 the function should not fail, but should return 0");
 
-                assertEqual(pythagore(a=10), 10, "If only one parameter is provided, the function cannot compute the result, but it should return the provided value");
-                assertEqual(pythagore(b=20), 20, "If only one parameter is provided, the function cannot compute the result, but it should return the provided value");
-                assertEqual(pythagore(c=30), 30, "If only one parameter is provided, the function cannot compute the result, but it should return the provided value");
+                assertEqual(pythagoras(a=10), 10, "If only one parameter is provided, the function cannot compute the result, but it should return the provided value");
+                assertEqual(pythagoras(b=20), 20, "If only one parameter is provided, the function cannot compute the result, but it should return the provided value");
+                assertEqual(pythagoras(c=30), 30, "If only one parameter is provided, the function cannot compute the result, but it should return the provided value");
 
-                assertEqual(pythagore(a=2, b=3), sqrt(4+9), "If A and B are provided the function should compute C");
-                assertEqual(pythagore(a=5, c=7), sqrt(49-25), "If A and C are provided the function should compute B");
-                assertEqual(pythagore(a=3, c=8), sqrt(64-9), "If B and C are provided the function should compute A");
-                assertEqual(pythagore(a=3, b=5, c=8), sqrt(64-9), "If A, B and C are provided the function should compute B");
+                assertEqual(pythagoras(a=2, b=3), sqrt(4+9), "If A and B are provided the function should compute C");
+                assertEqual(pythagoras(a=5, c=7), sqrt(49-25), "If A and C are provided the function should compute B");
+                assertEqual(pythagoras(a=3, c=8), sqrt(64-9), "If B and C are provided the function should compute A");
+                assertEqual(pythagoras(a=3, b=5, c=8), sqrt(64-9), "If A, B and C are provided the function should compute B");
 
             }
         }

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -566,13 +566,13 @@ module testCoreVector2D() {
                 assertEqual(isosceles2D(["1"], ["2"], ["3"]), [0, 0], "Cannot compute edge of arrays, should return the origin");
             }
             testUnit("height", 7) {
-                assertApproxEqual(isosceles2D(1, 2, 3), [1, 1] + arcPoint(pythagore(3, norm2D([1, 1]) / 2), 45 + atan2(3, norm2D([1, 1]) / 2)), "Numbers should be converted to vectors");
-                assertApproxEqual(isosceles2D([10, 5], [20, 5], 10), [10, 5] + arcPoint(pythagore(10, 5), atan2(10, 5)), "Horizontal triangle, edge on the top");
-                assertApproxEqual(isosceles2D([20, 5], [10, 5], 10), [20, 5] - arcPoint(pythagore(10, 5), atan2(10, 5)), "Horizontal triangle, edge on the bottom");
-                assertApproxEqual(isosceles2D([5, 10], [5, 20], 10), [5, 10] + arcPoint(pythagore(10, 5), atan2(5, -10)), "Vertical triangle, edge on the left");
-                assertApproxEqual(isosceles2D([5, 20], [5, 10], 10), [5, 20] - arcPoint(pythagore(10, 5), atan2(5, -10)), "Vertical triangle, edge on the right");
-                assertApproxEqual(isosceles2D([10, 10], [18, 16], 10), [10, 10] + arcPoint(pythagore(10, 5), atan2(10, 5) + atan2(6, 8)), "Tilted triangle, edge on the top");
-                assertApproxEqual(isosceles2D([18, 16], [10, 10], 10), [18, 16] - arcPoint(pythagore(10, 5), atan2(10, 5) + atan2(6, 8)), "Tilted triangle, edge on the bottom");
+                assertApproxEqual(isosceles2D(1, 2, 3), [1, 1] + arcPoint(pythagoras(3, norm2D([1, 1]) / 2), 45 + atan2(3, norm2D([1, 1]) / 2)), "Numbers should be converted to vectors");
+                assertApproxEqual(isosceles2D([10, 5], [20, 5], 10), [10, 5] + arcPoint(pythagoras(10, 5), atan2(10, 5)), "Horizontal triangle, edge on the top");
+                assertApproxEqual(isosceles2D([20, 5], [10, 5], 10), [20, 5] - arcPoint(pythagoras(10, 5), atan2(10, 5)), "Horizontal triangle, edge on the bottom");
+                assertApproxEqual(isosceles2D([5, 10], [5, 20], 10), [5, 10] + arcPoint(pythagoras(10, 5), atan2(5, -10)), "Vertical triangle, edge on the left");
+                assertApproxEqual(isosceles2D([5, 20], [5, 10], 10), [5, 20] - arcPoint(pythagoras(10, 5), atan2(5, -10)), "Vertical triangle, edge on the right");
+                assertApproxEqual(isosceles2D([10, 10], [18, 16], 10), [10, 10] + arcPoint(pythagoras(10, 5), atan2(10, 5) + atan2(6, 8)), "Tilted triangle, edge on the top");
+                assertApproxEqual(isosceles2D([18, 16], [10, 10], 10), [18, 16] - arcPoint(pythagoras(10, 5), atan2(10, 5) + atan2(6, 8)), "Tilted triangle, edge on the bottom");
             }
             testUnit("angle", 7) {
                 assertApproxEqual(isosceles2D(1, 2, angle=45), [1, 2], "Numbers should be converted to vectors");


### PR DESCRIPTION
Fix typo in the name of function `pythagoras()` (was` pythagore()` before)