### PR TITLE
Fix/script scad

### DIFF
--- a/scripts/utils/scad.sh
+++ b/scripts/utils/scad.sh
@@ -134,8 +134,10 @@ scadcall() {
     local outputpath="$1"; shift
     local params=()
     for var in "$@"; do
-        params+=("-D")
-        params+=("${var}")
+        if [ "${var}" != "" ]; then
+            params+=("-D")
+            params+=("${var}")
+        fi
     done
     ${scadcmd} --render -o "${outputpath}" "${sourcepath}" "${params[@]}"
 }


### PR DESCRIPTION
Ignore empty var definitions in additional params for `scadcall()`