### PR TITLE
Fix/string array

### DIFF
--- a/core/list.scad
+++ b/core/list.scad
@@ -99,7 +99,7 @@ function reverse(collection) =
  * @param Array collection - The array to flatten.
  * @returns Array
  */
-function flatten(collection) = [ for (a = arrayOr(collection, [])) for (b = a) b ];
+function flatten(collection) = [ for (a = arrayOr(collection, [])) for (b = isString(a) ? [a] : a) b ];
 
 /**
  * Finds the index of a key in a collection.

--- a/core/type.scad
+++ b/core/type.scad
@@ -62,7 +62,7 @@ function isInfinity(value) = (value >= INFINITY || value <= -INFINITY);
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is numeric.
  */
-function isNumber(value) = (sign(value) != undef);
+function isNumber(value) = (value == value && sign(value) != undef);
 
 /**
  * Checks if the value is integer.
@@ -78,7 +78,7 @@ function isInteger(value) = (value != undef && floor(value) == value);
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is equal to 0 or near enough.
  */
-function isZero(value) = (sign(value) != undef && value > -EPSILON && value < EPSILON);
+function isZero(value) = (isNumber(value) && value > -EPSILON && value < EPSILON);
 
 /**
  * Checks if the value is boolean.
@@ -151,7 +151,7 @@ function number(value) = value == true ? 1 : float(value);
  * @param * value - The value to cast.
  * @returns Number - Returns a number. If the value cannot be casted, 0 will be returned.
  */
-function float(value) = sign(value) ? value : 0;
+function float(value) = value && isNumber(value) ? value : 0;
 
 /**
  * Typecasts the value to a float, and ensures it is a safe divisor.
@@ -160,7 +160,7 @@ function float(value) = sign(value) ? value : 0;
  * @param * value - The value to cast.
  * @returns Number - Returns a number. If the value cannot be casted, of if the value is 0, 1 will be returned.
  */
-function divisor(value) = sign(value) ? value : 1;
+function divisor(value) = value && isNumber(value) ? value : 1;
 
 /**
  * Typecasts the value to an integer.
@@ -169,9 +169,10 @@ function divisor(value) = sign(value) ? value : 1;
  * @returns Number - Returns a number. If the value cannot be casted, 0 will be returned.
  */
 function integer(value) =
-    let( s = sign(value) )
-    s > 0 ? floor(value)
-   :s < 0 ? ceil(value)
+    !value ? 0
+   :let( value = float(value) )
+    value > 0 ? floor(value)
+   :value < 0 ? ceil(value)
    :0
 ;
 

--- a/core/vector.scad
+++ b/core/vector.scad
@@ -40,9 +40,13 @@
  * @returns Vector
  */
 function vadd(v, value) =
-    len(v) ?
-    let( value = float(value) )
-    [ for (i = v) float(i) + value ]
+    len(v) ? (
+        let(
+            v = array(v),
+            value = float(value)
+        )
+        [ for (i = v) float(i) + value ]
+    )
    :[]
 ;
 
@@ -54,9 +58,13 @@ function vadd(v, value) =
  * @returns Vector
  */
 function vsub(v, value) =
-    len(v) ?
-    let( value = float(value) )
-    [ for (i = v) float(i) - value ]
+    len(v) ? (
+        let(
+            v = array(v),
+            value = float(value)
+        )
+        [ for (i = v) float(i) - value ]
+    )
    :[]
 ;
 
@@ -106,8 +114,13 @@ function vdiv(a, b) =
  * @returns Vector
  */
 function vmin(v, value) =
-    len(v) ? let( value = float(value) )
-    [ for (i = v) min(float(i), value) ]
+    len(v) ? (
+        let(
+            v = array(v),
+            value = float(value)
+        )
+        [ for (i = v) min(float(i), value) ]
+    )
    :[]
 ;
 
@@ -119,8 +132,13 @@ function vmin(v, value) =
  * @returns Vector
  */
 function vmax(v, value) =
-    len(v) ? let( value = float(value) )
-    [ for (i = v) max(float(i), value) ]
+    len(v) ? (
+        let(
+            v = array(v),
+            value = float(value)
+        )
+        [ for (i = v) max(float(i), value) ]
+    )
    :[]
 ;
 
@@ -132,8 +150,13 @@ function vmax(v, value) =
  * @returns Vector
  */
 function vpow(v, power=2) =
-    len(v) ? let( power = float(power) )
-    [ for (i = v) pow(float(i), power) ]
+    len(v) ? (
+        let(
+            v = array(v),
+            power = float(power)
+        )
+        [ for (i = v) pow(float(i), power) ]
+    )
    :[]
 ;
 
@@ -144,8 +167,11 @@ function vpow(v, power=2) =
  * @returns Vector
  */
 function vabs(v) =
-    len(v) ? [ for (i = v) abs(float(i)) ]
-           : []
+    len(v) ? (
+        let( v = array(v) )
+        [ for (i = v) abs(float(i)) ]
+    )
+   :[]
 ;
 
 /**
@@ -155,8 +181,11 @@ function vabs(v) =
  * @returns Vector
  */
 function vsign(v) =
-    len(v) ? [ for (i = v) float(sign(i)) ]
-           : []
+    len(v) ? (
+        let( v = array(v) )
+        [ for (i = v) float(sign(i)) ]
+    )
+   :[]
 ;
 
 /**

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -406,7 +406,7 @@ module testCoreMaths() {
                 assertEqual(apothem(6, 8), 8 * cos(30), "Apothem of an hexagon, using the default order of parameters");
                 assertEqual(apothem(6, 8, 10), 8 * cos(30), "Apothem of an hexagon, using the default order of parameters with all provided (radius should predomin)");
 
-                assertEqual(apothem(n=4, r=sqrt(32) / 2), apothem(n=4, l=4), "Apothem of a square, comparing results using radius and side");
+                assertApproxEqual(apothem(n=4, r=sqrt(32) / 2), apothem(n=4, l=4), "Apothem of a square, comparing results using radius and side");
                 assertApproxEqual(apothem(n=4, l=4), 2, "Apothem of a square, comparing results and side");
                 assertApproxEqual(apothem(n=6, r=4), apothem(n=6, l=4), "Apothem of an hexagon, comparing results using radius and side");
             }


### PR DESCRIPTION
Fix compatibility issue with camelSCAD and OpenSCAD 2019.05 due to change in strings management.
- check array of strings in `flatten()`
- check string in `vadd()`, `vsub()`, `vmin()`, `vmax()`, `vpow()`, `vabs()`, `vsign()`
- fix stricness issue in unit test for `apothem()`
- improve detection of numbers