### PR TITLE
Fix/unit test context

### DIFF
--- a/util/test-utils.scad
+++ b/util/test-utils.scad
@@ -58,11 +58,10 @@ CSV = false;
  * Default to HTML
  * @type String
  */
-$outputMode = $outputMode ? $outputMode
-             :CSV         ? "csv"
-             :ANSI        ? "ansi"
-             :CONSOLE     ? "text"
-                          : "html"
+outputMode = CSV        ? "csv"
+            :ANSI       ? "ansi"
+            :CONSOLE    ? "text"
+                        : "html"
 ;
 
 /**
@@ -75,9 +74,9 @@ $outputMode = $outputMode ? $outputMode
  * @returns String
  */
 function formatTestTitle(title, type, big) =
-    $outputMode == "html" ? formatTestTitleHTML(title, type, big)
-   :$outputMode == "ansi" ? formatTestTitleANSI(title, type, big)
-   :$outputMode == "csv"  ? formatTestTitleCSV(title, type, big)
+    outputMode == "html" ? formatTestTitleHTML(title, type, big)
+   :outputMode == "ansi" ? formatTestTitleANSI(title, type, big)
+   :outputMode == "csv"  ? formatTestTitleCSV(title, type, big)
                           : formatTestTitleText(title, type, big)
 ;
 
@@ -92,9 +91,9 @@ function formatTestTitle(title, type, big) =
  */
 function formatAssertResult(result, message, details) =
     let(details = assertDetails(details))
-    $outputMode == "html" ? formatAssertResultHTML(result, message, details)
-   :$outputMode == "ansi" ? formatAssertResultANSI(result, message, details)
-   :$outputMode == "csv"  ? formatAssertResultCSV(result, message, details)
+    outputMode == "html" ? formatAssertResultHTML(result, message, details)
+   :outputMode == "ansi" ? formatAssertResultANSI(result, message, details)
+   :outputMode == "csv"  ? formatAssertResultCSV(result, message, details)
                           : formatAssertResultText(result, message, details)
 ;
 
@@ -108,9 +107,9 @@ function formatAssertResult(result, message, details) =
  * @returns String
  */
 function formatExpectedAsserts(actual, expected, type) =
-    $outputMode == "html" ? formatExpectedAssertsHTML(actual, expected, type)
-   :$outputMode == "ansi" ? formatExpectedAssertsANSI(actual, expected, type)
-   :$outputMode == "csv"  ? formatExpectedAssertsCSV(actual, expected, type)
+    outputMode == "html" ? formatExpectedAssertsHTML(actual, expected, type)
+   :outputMode == "ansi" ? formatExpectedAssertsANSI(actual, expected, type)
+   :outputMode == "csv"  ? formatExpectedAssertsCSV(actual, expected, type)
                           : formatExpectedAssertsText(actual, expected, type)
 ;
 

--- a/util/test.scad
+++ b/util/test.scad
@@ -40,6 +40,8 @@
  */
 module testPackage(title, expected) {
     $testPackage = string(title);
+    $testModule = "";
+    $testUnit = "";
 
     displayTestTitle(title, "package", true);
     children();


### PR DESCRIPTION
Fix context initialization in unit tests, as a lot of warnings regarding context variables were displayed with OpenSCAD 2019.05.