### PR TITLE
Feature/arc values

### DIFF
--- a/core/maths.scad
+++ b/core/maths.scad
@@ -129,6 +129,22 @@ function getArcLength(angle, radius, diameter) =
 ;
 
 /**
+ * Gets the angle of an arc given the radius and the length
+ * @param Number length - The length of the arc
+ * @param Number [radius] - The radius of the circle
+ * @param Number [diameter] - The diameter of the circle
+ * @returns Number
+ */
+function getArcAngle(length, radius, diameter) =
+    let(
+        diameter = numberOr(diameter, float(radius) * 2),
+        length = float(length)
+    )
+    !diameter ? 0
+   :(length * DEGREES) / (PI * diameter)
+;
+
+/**
  * Gets the angle value at a particular index in a regular polygon.
  * @param Number index - The index of the angle
  * @param Number [count] - The number of sides in the polygon

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -114,6 +114,21 @@ function getAngle(x, y) =
 ;
 
 /**
+ * Gets the length of an arc given the radius and the angle
+ * @param Number angle - The angle of the arc
+ * @param Number [radius] - The radius of the circle
+ * @param Number [diameter] - The diameter of the circle
+ * @returns Number
+ */
+function getArcLength(angle, radius, diameter) =
+    let(
+        diameter = numberOr(diameter, float(radius) * 2),
+        angle = float(angle)
+    )
+    PI * diameter * angle / DEGREES
+;
+
+/**
  * Gets the angle value at a particular index in a regular polygon.
  * @param Number index - The index of the angle
  * @param Number [count] - The number of sides in the polygon

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 18) {
+    testPackage("core/maths.scad", 19) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -317,6 +317,25 @@ module testCoreMaths() {
                 assertEqual(getAngle(-2, 1), atan2(1, -2), "Angle of vector [-2,1]");
                 assertEqual(getAngle(2, -1), 360 + atan2(-1, 2), "Angle of vector [2,-1]");
                 assertEqual(getAngle(-2, -1), 360 + atan2(-1, -2), "Angle of vector [-2,-1]");
+            }
+        }
+        // test core/maths/getArcLength()
+        testModule("getArcLength()", 2) {
+            testUnit("default value", 5) {
+                assertEqual(getArcLength(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(getArcLength([], []), 0, "Cannot compute length of arc from arrays");
+                assertEqual(getArcLength([1, 2], [3, 4]), 0, "Cannot compute length of arc from vectors");
+                assertEqual(getArcLength("1", "2"), 0, "Cannot compute length of arc from strings");
+                assertEqual(getArcLength(true, true), 0, "Cannot compute length of arc from booleans");
+            }
+            testUnit("compute length", 7) {
+                assertEqual(getArcLength(0, 0), 0, "Length of arc from 0");
+                assertEqual(getArcLength(0, 1), 0, "Length of arc from angle 0");
+                assertEqual(getArcLength(90, 100), PI * 200 / 4, "Length of arc from from radius 100, angle 90");
+                assertEqual(getArcLength(angle=90, radius=100), PI * 200 / 4, "Length of arc from from radius 100, angle 90");
+                assertEqual(getArcLength(angle=90, diameter=200), PI * 200 / 4, "Length of arc from from diameter 200, angle 90");
+                assertEqual(getArcLength(angle=66, diameter=193), PI * 193 * (66 / 360), "Length of arc from from diameter 193, angle 66");
+                assertEqual(getArcLength(angle=66, radius=193), PI * 386 * (66 / 360), "Length of arc from from radius 193, angle 66");
             }
         }
         // test core/maths/getPolygonAngle()

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 19) {
+    testPackage("core/maths.scad", 20) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -336,6 +336,25 @@ module testCoreMaths() {
                 assertEqual(getArcLength(angle=90, diameter=200), PI * 200 / 4, "Length of arc from from diameter 200, angle 90");
                 assertEqual(getArcLength(angle=66, diameter=193), PI * 193 * (66 / 360), "Length of arc from from diameter 193, angle 66");
                 assertEqual(getArcLength(angle=66, radius=193), PI * 386 * (66 / 360), "Length of arc from from radius 193, angle 66");
+            }
+        }
+        // test core/maths/getArcAngle()
+        testModule("getArcAngle()", 2) {
+            testUnit("default value", 5) {
+                assertEqual(getArcAngle(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(getArcAngle([], []), 0, "Cannot compute angle of arc from arrays");
+                assertEqual(getArcAngle([1, 2], [3, 4]), 0, "Cannot compute angle of arc from vectors");
+                assertEqual(getArcAngle("1", "2"), 0, "Cannot compute angle of arc from strings");
+                assertEqual(getArcAngle(true, true), 0, "Cannot compute angle of arc from booleans");
+            }
+            testUnit("compute length", 7) {
+                assertEqual(getArcAngle(0, 0), 0, "Angle of arc from 0");
+                assertEqual(getArcAngle(0, 1), 0, "Angle of arc from length 0");
+                assertEqual(getArcAngle(90, 100), 32400 / (PI * 200), "Angle of arc from from radius 100, length 90");
+                assertEqual(getArcAngle(length=90, radius=100), 32400 / (PI * 200), "Angle of arc from from radius 100, length 90");
+                assertEqual(getArcAngle(length=90, diameter=200), 32400 / (PI * 200), "Angle of arc from from diameter 200, length 90");
+                assertEqual(getArcAngle(length=66, diameter=193), 23760 / (PI * 193), "Angle of arc from from diameter 193, length 66");
+                assertEqual(getArcAngle(length=66, radius=193), 23760 / (PI * 386), "Angle of arc from from radius 193, length 66");
             }
         }
         // test core/maths/getPolygonAngle()


### PR DESCRIPTION
Add core functions:
- `getArcLength()`: Gets the length of an arc given the radius and the angle
- `getArcAngle()`: Gets the angle of an arc given the radius and the length