### PR TITLE
Release 0.8.0

### DIFF
--- a/core/maths.scad
+++ b/core/maths.scad
@@ -129,6 +129,22 @@ function getArcLength(angle, radius, diameter) =
 ;
 
 /**
+ * Gets the angle of an arc given the radius and the length
+ * @param Number length - The length of the arc
+ * @param Number [radius] - The radius of the circle
+ * @param Number [diameter] - The diameter of the circle
+ * @returns Number
+ */
+function getArcAngle(length, radius, diameter) =
+    let(
+        diameter = numberOr(diameter, float(radius) * 2),
+        length = float(length)
+    )
+    !diameter ? 0
+   :(length * DEGREES) / (PI * diameter)
+;
+
+/**
  * Gets the angle value at a particular index in a regular polygon.
  * @param Number index - The index of the angle
  * @param Number [count] - The number of sides in the polygon

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -160,6 +160,22 @@ function getChordLength(angle, radius, diameter) =
 ;
 
 /**
+ * Gets the angle of a chord given the radius and the length
+ * @param Number length - The length of the chord
+ * @param Number [radius] - The radius of the circle
+ * @param Number [diameter] - The diameter of the circle
+ * @returns Number
+ */
+function getChordAngle(length, radius, diameter) =
+    let(
+        diameter = numberOr(diameter, float(radius) * 2),
+        length = float(length)
+    )
+    !length ? 0
+   :asin(length / diameter) * 2
+;
+
+/**
  * Gets the angle value at a particular index in a regular polygon.
  * @param Number index - The index of the angle
  * @param Number [count] - The number of sides in the polygon

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -114,6 +114,21 @@ function getAngle(x, y) =
 ;
 
 /**
+ * Gets the length of an arc given the radius and the angle
+ * @param Number angle - The angle of the arc
+ * @param Number [radius] - The radius of the circle
+ * @param Number [diameter] - The diameter of the circle
+ * @returns Number
+ */
+function getArcLength(angle, radius, diameter) =
+    let(
+        diameter = numberOr(diameter, float(radius) * 2),
+        angle = float(angle)
+    )
+    PI * diameter * angle / DEGREES
+;
+
+/**
  * Gets the angle value at a particular index in a regular polygon.
  * @param Number index - The index of the angle
  * @param Number [count] - The number of sides in the polygon

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -145,6 +145,21 @@ function getArcAngle(length, radius, diameter) =
 ;
 
 /**
+ * Gets the length of a chord given the radius and the angle
+ * @param Number angle - The angle of the chord
+ * @param Number [radius] - The radius of the circle
+ * @param Number [diameter] - The diameter of the circle
+ * @returns Number
+ */
+function getChordLength(angle, radius, diameter) =
+    let(
+        diameter = numberOr(diameter, float(radius) * 2),
+        angle = float(angle)
+    )
+    diameter * sin(angle / 2)
+;
+
+/**
  * Gets the angle value at a particular index in a regular polygon.
  * @param Number index - The index of the angle
  * @param Number [count] - The number of sides in the polygon

--- a/core/version.scad
+++ b/core/version.scad
@@ -36,7 +36,7 @@
  * The version of the library.
  * @type Vector
  */
-CAMEL_SCAD_VERSION = [0, 7, 0];
+CAMEL_SCAD_VERSION = [0, 8, 0];
 
 /**
  * The minimal version of OpenSCAD required by the library.

--- a/shape/2D/ellipse.scad
+++ b/shape/2D/ellipse.scad
@@ -176,7 +176,7 @@ module pie(r, a=RIGHT, d, a1, a2, rx, ry, dx, dy) {
  */
 module chord(r, a=RIGHT, d, a1, a2, rx, ry, dx, dy) {
     polygon(
-        points = arc(v=sizeEllipse(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy), a=a, a1=a1, a2=a2),
+        points = arc(r=sizeEllipse(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy), a=a, a1=a1, a2=a2),
         convexity = 10
     );
 }
@@ -201,4 +201,31 @@ module ring(r, w, d, rx, ry, dx, dy, wx, wy) {
         ellipse(r=size[0]);
         ellipse(r=size[1]);
     }
+}
+
+/**
+ * Creates a ring segment at the origin.
+ *
+ * @param Number|Vector [r] - The radius or a vector that contains horizontal and vertical radius.
+ * @param Number|Vector [w] - The thickness of the ring.
+ * @param Number|Vector [d] - The diameter or a vector that contains horizontal and vertical diameters.
+ * @param Number [a] - The angle of the segment
+ * @param Number [a1] - The start angle of the segment
+ * @param Number [a2] - The end angle of the segment
+ * @param Number [rx] - The horizontal radius.
+ * @param Number [ry] - The vertical radius.
+ * @param Number [dx] - The horizontal diameter.
+ * @param Number [dy] - The vertical diameter.
+ * @param Number [wx] - The horizontal thickness of the ring hole.
+ * @param Number [wy] - The vertical thickness of the ring hole.
+ */
+module ringSegment(r, w, a=RIGHT, d, a1, a2, rx, ry, dx, dy, wx, wy) {
+    size = sizeRing(r=r, w=w, d=d, rx=rx, ry=ry, dx=dx, dy=dy, wx=wx, wy=wy);
+    polygon(
+        points = concat(
+            arc(r=size[0], a=a, a1=a1, a2=a2),
+            reverse(arc(r=size[1], a=a, a1=a1, a2=a2))
+        ),
+        convexity = 10
+    );
 }

--- a/shape/3D/ellipsoid.scad
+++ b/shape/3D/ellipsoid.scad
@@ -142,6 +142,28 @@ module pipe(r, h, w=0.1, d, rx, ry, dx, dy, wx, wy, center) {
 }
 
 /**
+ * Creates a pipe segment at the origin.
+ *
+ * @param Number|Vector [r] - The radius of the pipe or a vector that contains horizontal and vertical radius.
+ * @param Number|Vector [w] - The thickness of the pipe.
+ * @param Number [h] - The height of the pipe.
+ * @param Number|Vector [d] - The diameter of the pipe or a vector that contains horizontal and vertical diameters.
+ * @param Number [rx] - The horizontal radius.
+ * @param Number [ry] - The vertical radius.
+ * @param Number [dx] - The horizontal diameter.
+ * @param Number [dy] - The vertical diameter.
+ * @param Number [wx] - The horizontal thickness of the pipe hole.
+ * @param Number [wy] - The vertical thickness of the pipe hole.
+ * @param Boolean [center] - Whether or not center the pipe on the vertical axis.
+ */
+module pipeSegment(r, h, w=0.1, a=90, d, a1, a2, rx, ry, dx, dy, wx, wy, center) {
+    size = sizeEllipsoid(r=r, d=d, rx=rx, ry=ry, rz=h, dx=dx, dy=dy);
+    linear_extrude(height=size[2], center=center, convexity=10) {
+        ringSegment(r=size, a=a, a1=a1, a2=a2, w=w, wx=wx, wy=wy);
+    }
+}
+
+/**
  * Creates a torus at the origin.
  * Note: the tore can be deformed if the ring is not perfectly circular.
  *

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 18) {
+    testPackage("core/maths.scad", 19) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -317,6 +317,25 @@ module testCoreMaths() {
                 assertEqual(getAngle(-2, 1), atan2(1, -2), "Angle of vector [-2,1]");
                 assertEqual(getAngle(2, -1), 360 + atan2(-1, 2), "Angle of vector [2,-1]");
                 assertEqual(getAngle(-2, -1), 360 + atan2(-1, -2), "Angle of vector [-2,-1]");
+            }
+        }
+        // test core/maths/getArcLength()
+        testModule("getArcLength()", 2) {
+            testUnit("default value", 5) {
+                assertEqual(getArcLength(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(getArcLength([], []), 0, "Cannot compute length of arc from arrays");
+                assertEqual(getArcLength([1, 2], [3, 4]), 0, "Cannot compute length of arc from vectors");
+                assertEqual(getArcLength("1", "2"), 0, "Cannot compute length of arc from strings");
+                assertEqual(getArcLength(true, true), 0, "Cannot compute length of arc from booleans");
+            }
+            testUnit("compute length", 7) {
+                assertEqual(getArcLength(0, 0), 0, "Length of arc from 0");
+                assertEqual(getArcLength(0, 1), 0, "Length of arc from angle 0");
+                assertEqual(getArcLength(90, 100), PI * 200 / 4, "Length of arc from from radius 100, angle 90");
+                assertEqual(getArcLength(angle=90, radius=100), PI * 200 / 4, "Length of arc from from radius 100, angle 90");
+                assertEqual(getArcLength(angle=90, diameter=200), PI * 200 / 4, "Length of arc from from diameter 200, angle 90");
+                assertEqual(getArcLength(angle=66, diameter=193), PI * 193 * (66 / 360), "Length of arc from from diameter 193, angle 66");
+                assertEqual(getArcLength(angle=66, radius=193), PI * 386 * (66 / 360), "Length of arc from from radius 193, angle 66");
             }
         }
         // test core/maths/getPolygonAngle()

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 19) {
+    testPackage("core/maths.scad", 20) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -336,6 +336,25 @@ module testCoreMaths() {
                 assertEqual(getArcLength(angle=90, diameter=200), PI * 200 / 4, "Length of arc from from diameter 200, angle 90");
                 assertEqual(getArcLength(angle=66, diameter=193), PI * 193 * (66 / 360), "Length of arc from from diameter 193, angle 66");
                 assertEqual(getArcLength(angle=66, radius=193), PI * 386 * (66 / 360), "Length of arc from from radius 193, angle 66");
+            }
+        }
+        // test core/maths/getArcAngle()
+        testModule("getArcAngle()", 2) {
+            testUnit("default value", 5) {
+                assertEqual(getArcAngle(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(getArcAngle([], []), 0, "Cannot compute angle of arc from arrays");
+                assertEqual(getArcAngle([1, 2], [3, 4]), 0, "Cannot compute angle of arc from vectors");
+                assertEqual(getArcAngle("1", "2"), 0, "Cannot compute angle of arc from strings");
+                assertEqual(getArcAngle(true, true), 0, "Cannot compute angle of arc from booleans");
+            }
+            testUnit("compute length", 7) {
+                assertEqual(getArcAngle(0, 0), 0, "Angle of arc from 0");
+                assertEqual(getArcAngle(0, 1), 0, "Angle of arc from length 0");
+                assertEqual(getArcAngle(90, 100), 32400 / (PI * 200), "Angle of arc from from radius 100, length 90");
+                assertEqual(getArcAngle(length=90, radius=100), 32400 / (PI * 200), "Angle of arc from from radius 100, length 90");
+                assertEqual(getArcAngle(length=90, diameter=200), 32400 / (PI * 200), "Angle of arc from from diameter 200, length 90");
+                assertEqual(getArcAngle(length=66, diameter=193), 23760 / (PI * 193), "Angle of arc from from diameter 193, length 66");
+                assertEqual(getArcAngle(length=66, radius=193), 23760 / (PI * 386), "Angle of arc from from radius 193, length 66");
             }
         }
         // test core/maths/getPolygonAngle()

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 21) {
+    testPackage("core/maths.scad", 22) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -331,11 +331,11 @@ module testCoreMaths() {
             testUnit("compute length", 7) {
                 assertEqual(getArcLength(0, 0), 0, "Length of arc from 0");
                 assertEqual(getArcLength(0, 1), 0, "Length of arc from angle 0");
-                assertEqual(getArcLength(90, 100), PI * 200 / 4, "Length of arc from from radius 100, angle 90");
-                assertEqual(getArcLength(angle=90, radius=100), PI * 200 / 4, "Length of arc from from radius 100, angle 90");
-                assertEqual(getArcLength(angle=90, diameter=200), PI * 200 / 4, "Length of arc from from diameter 200, angle 90");
-                assertEqual(getArcLength(angle=66, diameter=193), PI * 193 * (66 / 360), "Length of arc from from diameter 193, angle 66");
-                assertEqual(getArcLength(angle=66, radius=193), PI * 386 * (66 / 360), "Length of arc from from radius 193, angle 66");
+                assertEqual(getArcLength(90, 100), PI * 200 / 4, "Length of arc from radius 100, angle 90");
+                assertEqual(getArcLength(angle=90, radius=100), PI * 200 / 4, "Length of arc from radius 100, angle 90");
+                assertEqual(getArcLength(angle=90, diameter=200), PI * 200 / 4, "Length of arc from diameter 200, angle 90");
+                assertEqual(getArcLength(angle=66, diameter=193), PI * 193 * (66 / 360), "Length of arc from diameter 193, angle 66");
+                assertEqual(getArcLength(angle=66, radius=193), PI * 386 * (66 / 360), "Length of arc from radius 193, angle 66");
             }
         }
         // test core/maths/getArcAngle()
@@ -350,11 +350,11 @@ module testCoreMaths() {
             testUnit("compute length", 7) {
                 assertEqual(getArcAngle(0, 0), 0, "Angle of arc from 0");
                 assertEqual(getArcAngle(0, 1), 0, "Angle of arc from length 0");
-                assertEqual(getArcAngle(90, 100), 32400 / (PI * 200), "Angle of arc from from radius 100, length 90");
-                assertEqual(getArcAngle(length=90, radius=100), 32400 / (PI * 200), "Angle of arc from from radius 100, length 90");
-                assertEqual(getArcAngle(length=90, diameter=200), 32400 / (PI * 200), "Angle of arc from from diameter 200, length 90");
-                assertEqual(getArcAngle(length=66, diameter=193), 23760 / (PI * 193), "Angle of arc from from diameter 193, length 66");
-                assertEqual(getArcAngle(length=66, radius=193), 23760 / (PI * 386), "Angle of arc from from radius 193, length 66");
+                assertEqual(getArcAngle(90, 100), 32400 / (PI * 200), "Angle of arc from radius 100, length 90");
+                assertEqual(getArcAngle(length=90, radius=100), 32400 / (PI * 200), "Angle of arc from radius 100, length 90");
+                assertEqual(getArcAngle(length=90, diameter=200), 32400 / (PI * 200), "Angle of arc from diameter 200, length 90");
+                assertEqual(getArcAngle(length=66, diameter=193), 23760 / (PI * 193), "Angle of arc from diameter 193, length 66");
+                assertEqual(getArcAngle(length=66, radius=193), 23760 / (PI * 386), "Angle of arc from radius 193, length 66");
             }
         }
         // test core/maths/getChordLength()
@@ -369,11 +369,30 @@ module testCoreMaths() {
             testUnit("compute length", 7) {
                 assertEqual(getChordLength(0, 0), 0, "Length of chord from 0");
                 assertEqual(getChordLength(0, 1), 0, "Length of chord from angle 0");
-                assertEqual(getChordLength(90, 100), 200 * sin(45), "Length of chord from from radius 100, angle 90");
-                assertEqual(getChordLength(angle=90, radius=100), 200 * sin(45), "Length of chord from from radius 100, angle 90");
-                assertEqual(getChordLength(angle=90, diameter=200), 200 * sin(45), "Length of chord from from diameter 200, angle 90");
-                assertEqual(getChordLength(angle=66, diameter=193), 193 * sin(33), "Length of chord from from diameter 193, angle 66");
-                assertEqual(getChordLength(angle=66, radius=193), 386 * sin(33), "Length of chord from from radius 193, angle 66");
+                assertEqual(getChordLength(90, 100), 200 * sin(45), "Length of chord from radius 100, angle 90");
+                assertEqual(getChordLength(angle=90, radius=100), 200 * sin(45), "Length of chord from radius 100, angle 90");
+                assertEqual(getChordLength(angle=90, diameter=200), 200 * sin(45), "Length of chord from diameter 200, angle 90");
+                assertEqual(getChordLength(angle=66, diameter=193), 193 * sin(33), "Length of chord from diameter 193, angle 66");
+                assertEqual(getChordLength(angle=66, radius=193), 386 * sin(33), "Length of chord from radius 193, angle 66");
+            }
+        }
+        // test core/maths/getChordAngle()
+        testModule("getChordAngle()", 2) {
+            testUnit("default value", 5) {
+                assertEqual(getChordAngle(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(getChordAngle([], []), 0, "Cannot compute angle of chord from arrays");
+                assertEqual(getChordAngle([1, 2], [3, 4]), 0, "Cannot compute angle of chord from vectors");
+                assertEqual(getChordAngle("1", "2"), 0, "Cannot compute angle of chord from strings");
+                assertEqual(getChordAngle(true, true), 0, "Cannot compute angle of chord from booleans");
+            }
+            testUnit("compute length", 7) {
+                assertEqual(getChordAngle(0, 0), 0, "Angle of chord from 0");
+                assertEqual(getChordAngle(0, 1), 0, "Angle of chord from length 0");
+                assertEqual(getChordAngle(200 * sin(45), 100), 90, "Angle of chord from radius 100, length 90");
+                assertEqual(getChordAngle(length=200 * sin(45), radius=100), 90, "Angle of chord from radius 100, length 90");
+                assertEqual(getChordAngle(length=200 * sin(45), diameter=200), 90, "Angle of chord from diameter 200, length 90");
+                assertEqual(getChordAngle(length=193 * sin(33), diameter=193), 66, "Angle of chord from diameter 193, length 66");
+                assertEqual(getChordAngle(length=386 * sin(33), radius=193), 66, "Angle of chord from radius 193, length 66");
             }
         }
         // test core/maths/getPolygonAngle()

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 20) {
+    testPackage("core/maths.scad", 21) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -355,6 +355,25 @@ module testCoreMaths() {
                 assertEqual(getArcAngle(length=90, diameter=200), 32400 / (PI * 200), "Angle of arc from from diameter 200, length 90");
                 assertEqual(getArcAngle(length=66, diameter=193), 23760 / (PI * 193), "Angle of arc from from diameter 193, length 66");
                 assertEqual(getArcAngle(length=66, radius=193), 23760 / (PI * 386), "Angle of arc from from radius 193, length 66");
+            }
+        }
+        // test core/maths/getChordLength()
+        testModule("getChordLength()", 2) {
+            testUnit("default value", 5) {
+                assertEqual(getChordLength(), 0, "Should return 0 if no parameter was provided");
+                assertEqual(getChordLength([], []), 0, "Cannot compute length of chord from arrays");
+                assertEqual(getChordLength([1, 2], [3, 4]), 0, "Cannot compute length of chord from vectors");
+                assertEqual(getChordLength("1", "2"), 0, "Cannot compute length of chord from strings");
+                assertEqual(getChordLength(true, true), 0, "Cannot compute length of chord from booleans");
+            }
+            testUnit("compute length", 7) {
+                assertEqual(getChordLength(0, 0), 0, "Length of chord from 0");
+                assertEqual(getChordLength(0, 1), 0, "Length of chord from angle 0");
+                assertEqual(getChordLength(90, 100), 200 * sin(45), "Length of chord from from radius 100, angle 90");
+                assertEqual(getChordLength(angle=90, radius=100), 200 * sin(45), "Length of chord from from radius 100, angle 90");
+                assertEqual(getChordLength(angle=90, diameter=200), 200 * sin(45), "Length of chord from from diameter 200, angle 90");
+                assertEqual(getChordLength(angle=66, diameter=193), 193 * sin(33), "Length of chord from from diameter 193, angle 66");
+                assertEqual(getChordLength(angle=66, radius=193), 386 * sin(33), "Length of chord from from radius 193, angle 66");
             }
         }
         // test core/maths/getPolygonAngle()

--- a/test/core/version.scad
+++ b/test/core/version.scad
@@ -45,10 +45,10 @@ module testCoreVersion() {
         // test camelSCAD()
         testModule("camelSCAD()", 2) {
             testUnit("as vector", 1) {
-                assertEqual(camelSCAD(), [0, 7, 0], "The current version of the library is 0.6.0");
+                assertEqual(camelSCAD(), [0, 8, 0], "The current version of the library is 0.8.0");
             }
             testUnit("as string", 1) {
-                assertEqual(camelSCAD(true), "0.7.0", "The current version of the library is 0.6.0");
+                assertEqual(camelSCAD(true), "0.8.0", "The current version of the library is 0.8.0");
             }
         }
     }


### PR DESCRIPTION
Add core functions:
- `getArcLength()`: Gets the length of an arc given the radius and the angle
- `getArcAngle()`: Gets the angle of an arc given the radius and the length
- `getChordLength()`: Gets the length of a chord given the radius and the angle
- `getChordAngle()`: Gets the angle of a chord given the radius and the length

Add shapes:
- `ringSegment(r, w, a=RIGHT, d, a1, a2, rx, ry, dx, dy, wx, wy)`: Creates a ring section at the origin.
- `pipeSegment(r, h, w=0.1, a=90, d, a1, a2, rx, ry, dx, dy, wx, wy, center)`: Creates a pipe segment at the origin.

Fixes:
- Fixed wrong parameter name used in `chord()` shape