### PR TITLE
Feature/translate center

### DIFF
--- a/operator/distribute/grid.scad
+++ b/operator/distribute/grid.scad
@@ -38,17 +38,21 @@
  * @param Vector [intervalX] - The interval between each columns.
  * @param Vector [intervalY] - The interval between each lines.
  * @param Number [line] - The max number of elements per lines.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module distributeGrid(intervalX = [1, 0, 0],
                       intervalY = [0, 1, 0],
-                      line      = 2) {
+                      line      = 2,
+                      center    = false) {
 
     intervalX = vector3D(intervalX);
     intervalY = vector3D(intervalY);
     line = max(floor(abs(float(line))), 1);
+    offsetX = center ? -intervalX * (line - 1) / 2 : [0, 0, 0];
+    offsetY = center ? -intervalY * floor($children / line) / 2 : [0, 0, 0];
 
     for (i = [0 : $children - 1]) {
-        translate(intervalX * (i % line) + intervalY * floor(i / line)) {
+        translate(offsetX + intervalX * (i % line) + offsetY + intervalY * floor(i / line)) {
             children(i);
         }
     }

--- a/operator/distribute/mirror.scad
+++ b/operator/distribute/mirror.scad
@@ -38,6 +38,7 @@
  *
  * @param Vector [interval] - The interval between each elements.
  * @param Vector [axis] - The normal vector of the mirroring plan around which mirror the elements.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  * @param Number [intervalX] - The X interval between each repeated children
  *                             (will overwrite the X coordinate in the `interval` vector).
  * @param Number [intervalY] - The Y interval between each repeated children
@@ -53,14 +54,16 @@
  */
 module distributeMirror(interval = [0, 0, 0],
                         axis     = [1, 0, 0],
+                        center   = false,
                         intervalX, intervalY, intervalZ,
                         axisX, axisY, axisZ) {
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
     axis = apply3D(axis, axisX, axisY, axisZ);
+    offset = center ? -interval * ($children - 1) / 2 : [0, 0, 0];
 
     for (i = [0 : $children - 1]) {
-        translate(interval * i) {
+        translate(offset + interval * i) {
             if (i % 2) {
                 mirror(axis) {
                     children(i);

--- a/operator/distribute/rotate.scad
+++ b/operator/distribute/rotate.scad
@@ -40,6 +40,7 @@
  * @param Vector [axis] - The rotation axis around which rotate the elements.
  * @param Vector [interval] - The interval between each elements.
  * @param Vector [origin] - The rotate origin.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  * @param Number [intervalX] - The X interval between each repeated children
  *                             (will overwrite the X coordinate in the `interval` vector).
  * @param Number [intervalY] - The Y interval between each repeated children
@@ -57,6 +58,7 @@ module distributeRotate(angle    = DEGREES,
                         axis     = [0, 0, 1],
                         interval = [0, 0, 0],
                         origin   = [0, 0, 0],
+                        center   = false,
                         intervalX, intervalY, intervalZ,
                         axisX, axisY, axisZ,
                         originX, originY, originZ) {
@@ -66,9 +68,10 @@ module distributeRotate(angle    = DEGREES,
     angle = deg(angle);
     partAngle = angle / (angle % DEGREES ? $children - 1 : $children);
     axis = apply3D(axis, axisX, axisY, axisZ) * partAngle;
+    offset = center ? -interval * ($children - 1) / 2 : [0, 0, 0];
 
     for (i = [0 : $children - 1]) {
-        translate(interval * i) {
+        translate(offset + interval * i) {
             rotateOrigin(a=axis * i, o=origin) {
                 children(i);
             }

--- a/operator/distribute/translate.scad
+++ b/operator/distribute/translate.scad
@@ -36,6 +36,7 @@
  * Distributes the children modules with the provided `interval`.
  *
  * @param Vector [interval] - The interval between each elements.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  * @param Number [intervalX] - The X interval between each repeated children
  *                             (will overwrite the X coordinate in the `interval` vector).
  * @param Number [intervalY] - The Y interval between each repeated children
@@ -44,12 +45,14 @@
  *                             (will overwrite the Z coordinate in the `interval` vector).
  */
 module distribute(interval = [0, 0, 0],
+                  center   = false,
                   intervalX, intervalY, intervalZ) {
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
+    offset = center ? -interval * ($children - 1) / 2 : [0, 0, 0];
 
     for (i = [0 : $children - 1]) {
-        translate(interval * i) {
+        translate(offset + interval * i) {
             children(i);
         }
     }

--- a/operator/repeat/mirror.scad
+++ b/operator/repeat/mirror.scad
@@ -62,7 +62,7 @@ module repeatMirror(count    = 2,
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
     axis = apply3D(axis, axisX, axisY, axisZ);
-    offset = center ? -interval * (count - 1) / 2 : 0;
+    offset = center ? -interval * (count - 1) / 2 : [0, 0, 0];
 
     for (i = [0 : count - 1]) {
         translate(offset + interval * i) {

--- a/operator/repeat/mirror.scad
+++ b/operator/repeat/mirror.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2020 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@
  * @param Number [count] - The number of times the children must be repeated.
  * @param Vector [interval] - The interval between each repeated children.
  * @param Vector [axis] - The normal vector of the mirroring plan around which mirror the children.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  * @param Number [intervalX] - The X interval between each repeated children
  *                             (will overwrite the X coordinate in the `interval` vector).
  * @param Number [intervalY] - The Y interval between each repeated children
@@ -55,14 +56,16 @@
 module repeatMirror(count    = 2,
                     interval = [0, 0, 0],
                     axis     = [1, 0, 0],
+                    center   = false,
                     intervalX, intervalY, intervalZ,
                     axisX, axisY, axisZ) {
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
     axis = apply3D(axis, axisX, axisY, axisZ);
+    offset = center ? -interval * (count - 1) / 2 : 0;
 
     for (i = [0 : count - 1]) {
-        translate(interval * i) {
+        translate(offset + interval * i) {
             if (i % 2) {
                 mirror(axis) {
                     children();
@@ -84,16 +87,18 @@ module repeatMirror(count    = 2,
  * @param Vector [axisY] - The rotation axis around which rotate the children along the Y axis.
  * @param Vector [intervalX] - The interval between each repeated children along the X axis.
  * @param Vector [intervalY] - The interval between each repeated children along the Y axis.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module repeatMirror2D(countX    = 2,
                       countY    = 2,
                       axisX     = [1, 0, 0],
                       axisY     = [0, 1, 0],
                       intervalX = [0, 0, 0],
-                      intervalY = [0, 0, 0]) {
+                      intervalY = [0, 0, 0],
+                      center    = false) {
 
-    repeatMirror(count=countY, interval=vector3D(intervalY), axis=vector3D(axisY)) {
-        repeatMirror(count=countX, interval=vector3D(intervalX), axis=vector3D(axisX)) {
+    repeatMirror(count=countY, interval=vector3D(intervalY), axis=vector3D(axisY), center=center) {
+        repeatMirror(count=countX, interval=vector3D(intervalX), axis=vector3D(axisX), center=center) {
             children();
         }
     }
@@ -112,6 +117,7 @@ module repeatMirror2D(countX    = 2,
  * @param Vector [intervalX] - The interval between each repeated children along the X axis.
  * @param Vector [intervalY] - The interval between each repeated children along the Y axis.
  * @param Vector [intervalZ] - The interval between each repeated children along the Z axis.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module repeatMirror3D(countX    = 2,
                       countY    = 2,
@@ -121,11 +127,12 @@ module repeatMirror3D(countX    = 2,
                       axisZ     = [0, 0, 1],
                       intervalX = [0, 0, 0],
                       intervalY = [0, 0, 0],
-                      intervalZ = [0, 0, 0]) {
+                      intervalZ = [0, 0, 0],
+                      center    = false) {
 
-    repeatMirror(count=countZ, interval=vector3D(intervalZ), axis=vector3D(axisZ)) {
-        repeatMirror(count=countY, interval=vector3D(intervalY), axis=vector3D(axisY)) {
-            repeatMirror(count=countX, interval=vector3D(intervalX), axis=vector3D(axisX)) {
+    repeatMirror(count=countZ, interval=vector3D(intervalZ), axis=vector3D(axisZ), center=center) {
+        repeatMirror(count=countY, interval=vector3D(intervalY), axis=vector3D(axisY), center=center) {
+            repeatMirror(count=countX, interval=vector3D(intervalX), axis=vector3D(axisX), center=center) {
                 children();
             }
         }

--- a/operator/repeat/rotate.scad
+++ b/operator/repeat/rotate.scad
@@ -58,6 +58,7 @@ module repeatRotate(count    = 2,
                     axis     = [0, 0, 1],
                     interval = [0, 0, 0],
                     origin   = [0, 0, 0],
+                    center   = false,
                     intervalX, intervalY, intervalZ,
                     axisX, axisY, axisZ,
                     originX, originY, originZ) {
@@ -67,9 +68,10 @@ module repeatRotate(count    = 2,
     angle = deg(angle);
     partAngle = angle / (angle % DEGREES ? count - 1 : count);
     axis = apply3D(axis, axisX, axisY, axisZ) * partAngle;
+    offset = center ? -interval * (count - 1) / 2 : [0, 0, 0];
 
     for (i = [0 : count - 1]) {
-        translate(interval * i) {
+        translate(offset + interval * i) {
             rotateOrigin(a=axis * i, o=origin) {
                 children();
             }
@@ -90,6 +92,7 @@ module repeatRotate(count    = 2,
  * @param Vector [intervalY] - The interval between each repeated children along the Y axis.
  * @param Vector [originX] - The rotate origin along the X axis.
  * @param Vector [originY] - The rotate origin along the Y axis.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module repeatRotate2D(countX    = 2,
                       countY    = 2,
@@ -100,10 +103,11 @@ module repeatRotate2D(countX    = 2,
                       intervalX = [0, 0, 0],
                       intervalY = [0, 0, 0],
                       originX   = [0, 0, 0],
-                      originY   = [0, 0, 0]) {
+                      originY   = [0, 0, 0],
+                      center    = false) {
 
-    repeatRotate(count=countY, interval=vector3D(intervalY), angle=angleY, axis=vector3D(axisY), origin=originY) {
-        repeatRotate(count=countX, interval=vector3D(intervalX), angle=angleX, axis=vector3D(axisX), origin=originX) {
+    repeatRotate(count=countY, interval=vector3D(intervalY), angle=angleY, axis=vector3D(axisY), origin=originY, center=center) {
+        repeatRotate(count=countX, interval=vector3D(intervalX), angle=angleX, axis=vector3D(axisX), origin=originX, center=center) {
             children();
         }
     }
@@ -127,6 +131,7 @@ module repeatRotate2D(countX    = 2,
  * @param Vector [originX] - The rotate origin along the X axis.
  * @param Vector [originY] - The rotate origin along the Y axis.
  * @param Vector [originZ] - The rotate origin along the Z axis.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module repeatRotate3D(countX    = 2,
                       countY    = 2,
@@ -142,11 +147,12 @@ module repeatRotate3D(countX    = 2,
                       intervalZ = [0, 0, 0],
                       originX   = [0, 0, 0],
                       originY   = [0, 0, 0],
-                      originZ   = [0, 0, 0]) {
+                      originZ   = [0, 0, 0],
+                      center    = false) {
 
-    repeatRotate(count=countZ, interval=vector3D(intervalZ), angle=angleZ, axis=vector3D(axisZ), origin=originZ) {
-        repeatRotate(count=countY, interval=vector3D(intervalY), angle=angleY, axis=vector3D(axisY), origin=originY) {
-            repeatRotate(count=countX, interval=vector3D(intervalX), angle=angleX, axis=vector3D(axisX), origin=originX) {
+    repeatRotate(count=countZ, interval=vector3D(intervalZ), angle=angleZ, axis=vector3D(axisZ), origin=originZ, center=center) {
+        repeatRotate(count=countY, interval=vector3D(intervalY), angle=angleY, axis=vector3D(axisY), origin=originY, center=center) {
+            repeatRotate(count=countX, interval=vector3D(intervalX), angle=angleX, axis=vector3D(axisX), origin=originX, center=center) {
                 children();
             }
         }

--- a/operator/repeat/translate.scad
+++ b/operator/repeat/translate.scad
@@ -51,7 +51,7 @@ module repeat(count    = 2,
               intervalX, intervalY, intervalZ) {
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
-    offset = center ? -interval * (count - 1) / 2 : 0;
+    offset = center ? -interval * (count - 1) / 2 : [0, 0, 0];
 
     for (i = [0 : count - 1]) {
         translate(offset + interval * i) {

--- a/operator/repeat/translate.scad
+++ b/operator/repeat/translate.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2020 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@
  *
  * @param Number [count] - The number of times the children must be repeated.
  * @param Vector [interval] - The interval between each repeated children.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  * @param Number [intervalX] - The X interval between each repeated children
  *                             (will overwrite the X coordinate in the `interval` vector).
  * @param Number [intervalY] - The Y interval between each repeated children
@@ -46,12 +47,14 @@
  */
 module repeat(count    = 2,
               interval = [0, 0, 0],
+              center   = false,
               intervalX, intervalY, intervalZ) {
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
+    offset = center ? -interval * (count - 1) / 2 : 0;
 
     for (i = [0 : count - 1]) {
-        translate(interval * i) {
+        translate(offset + interval * i) {
             children();
         }
     }
@@ -64,14 +67,16 @@ module repeat(count    = 2,
  * @param Number [countY] - The number of times the children must be repeated along the Y axis.
  * @param Vector [intervalX] - The interval between each repeated children along the X axis.
  * @param Vector [intervalY] - The interval between each repeated children along the Y axis.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module repeat2D(countX    = 2,
                 countY    = 2,
                 intervalX = [0, 0, 0],
-                intervalY = [0, 0, 0]) {
+                intervalY = [0, 0, 0],
+                center    = false) {
 
-    repeat(count=countY, interval=vector3D(intervalY)) {
-        repeat(count=countX, interval=vector3D(intervalX)) {
+    repeat(count=countY, interval=vector3D(intervalY), center=center) {
+        repeat(count=countX, interval=vector3D(intervalX), center=center) {
             children();
         }
     }
@@ -86,17 +91,19 @@ module repeat2D(countX    = 2,
  * @param Vector [intervalX] - The interval between each repeated children along the X axis.
  * @param Vector [intervalY] - The interval between each repeated children along the Y axis.
  * @param Vector [intervalZ] - The interval between each repeated children along the Z axis.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module repeat3D(countX    = 2,
                 countY    = 2,
                 countZ    = 2,
                 intervalX = [0, 0, 0],
                 intervalY = [0, 0, 0],
-                intervalZ = [0, 0, 0]) {
+                intervalZ = [0, 0, 0],
+                center    = false) {
 
-    repeat(count=countZ, interval=vector3D(intervalZ)) {
-        repeat(count=countY, interval=vector3D(intervalY)) {
-            repeat(count=countX, interval=vector3D(intervalX)) {
+    repeat(count=countZ, interval=vector3D(intervalZ), center=center) {
+        repeat(count=countY, interval=vector3D(intervalY), center=center) {
+            repeat(count=countX, interval=vector3D(intervalX), center=center) {
                 children();
             }
         }
@@ -105,46 +112,44 @@ module repeat3D(countX    = 2,
 
 /**
  * Repeats horizontally a shape in two directions, the interval is set by the size of the shape.
- * @param Vector size - The size of the shape
- * @param Vector [count] - The number of shapes on each axis
- * @param Boolean [center] - Whether or not center the repeated shapes
+ * @param Vector size - The size of the shape.
+ * @param Vector [count] - The number of shapes on each axis.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module repeatShape2D(size, count = 1, center) {
     size = vector2D(size);
     count = vector2D(count);
 
-    translate(center ? -vmul(size, count - [1, 1]) / 2 : 0) {
-        repeat2D(
-            countX = count[0],
-            countY = count[1],
-            intervalX = [size[0], 0, 0],
-            intervalY = [0, size[1], 0]
-        ) {
-            children();
-        }
+    repeat2D(
+        countX = count[0],
+        countY = count[1],
+        intervalX = [size[0], 0, 0],
+        intervalY = [0, size[1], 0],
+        center = center
+    ) {
+        children();
     }
 }
 
 /**
  * Repeats a shape in three directions, the interval is set by the size of the shape.
- * @param Vector size - The size of the shape
- * @param Vector [count] - The number of shapes on each axis
- * @param Boolean [center] - Whether or not center the repeated shapes
+ * @param Vector size - The size of the shape.
+ * @param Vector [count] - The number of shapes on each axis.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
  */
 module repeatShape3D(size, count = 1, center) {
     size = vector3D(size);
     count = vector3D(count);
 
-    translate(center ? -vmul(size, count - [1, 1, 1]) / 2 : 0) {
-        repeat3D(
-            countX = count[0],
-            countY = count[1],
-            countZ = count[2],
-            intervalX = [size[0], 0, 0],
-            intervalY = [0, size[1], 0],
-            intervalZ = [0, 0, size[2]]
-        ) {
-            children();
-        }
+    repeat3D(
+        countX = count[0],
+        countY = count[1],
+        countZ = count[2],
+        intervalX = [size[0], 0, 0],
+        intervalY = [0, size[1], 0],
+        intervalZ = [0, 0, size[2]],
+        center = center
+    ) {
+        children();
     }
 }


### PR DESCRIPTION
Add an option to center the repeated shapes in `repeat*`, `mirror*`, `rotate*`, and `distributed*` operators, `false` by default.