### PR TITLE
Feature/parallel rendering

### DIFF
--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -41,4 +41,5 @@ source "${scriptpath}/utils.sh"
 
 scadcheck
 scadformat
+scadprocesses
 scadrenderall "${srcpath}" "${dstpath}" "$@"


### PR DESCRIPTION
Improve the render script utils:
- spawn several processes when rendering multiple files
- add function `scadprocesses()`: set and display the number of parallel processes to spawn when rendering multiple files