### PR TITLE
Release 0.14.0

### DIFF
--- a/core/version.scad
+++ b/core/version.scad
@@ -36,7 +36,7 @@
  * The version of the library.
  * @type Vector
  */
-CAMEL_SCAD_VERSION = [0, 13, 0];
+CAMEL_SCAD_VERSION = [0, 14, 0];
 
 /**
  * The minimal version of OpenSCAD required by the library.

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -32,14 +32,136 @@
 # @author jsconan
 #
 
+# script config
 scriptpath=$(dirname $0)
 project=$(pwd)
 srcpath=${project}
-dstpath=${project}/output
+dstpath=${project}
+input=
+output="output"
+format=
+parallel=
+cleanUp=
+recurse=
 
+# include libs
 source "${scriptpath}/utils.sh"
 
+# Renders all the files from the folder.
+#
+# @param sourcepath - The path of the folder containing the files to render.
+# @param destpath - The path to the output folder.
+renderpath() {
+    local src=$1; shift
+    local dst=$1; shift
+    scadrenderall "${src}" "${dst}" "$@"
+}
+
+# Renders all the files including the sub-folders.
+#
+# @param sourcepath - The path of the folder containing the files to render.
+# @param destpath - The path to the output folder.
+renderall() {
+    local src=$1; shift
+    local dst=$1; shift
+    local folders=($(find ${src} -type d -print))
+    local i=0
+    for folderpath in "${folders[@]}"; do
+        folder=$(echo ${folderpath#${src}})
+        local files=($(find ${folderpath} -maxdepth 1 -type f -print))
+        if [ "${files}" != "" ]; then
+            renderpath "${src}${folder}" "${dst}${folder}" "$@"
+        fi
+    done
+}
+
+# load parameters
+while (( "$#" )); do
+    case $1 in
+        "-i"|"--input")
+            input=$2
+            shift
+        ;;
+        "-o"|"--output")
+            output=$2
+            shift
+        ;;
+        "-f"|"--format")
+            format=$2
+            shift
+        ;;
+        "-p"|"--parallel")
+            parallel=$2
+            shift
+        ;;
+        "-c"|"--clean")
+            cleanUp=1
+        ;;
+        "-r"|"--recurse")
+            recurse=1
+        ;;
+        "-h"|"--help")
+            echo -e "${C_INF}Renders OpenSCAD files${C_RST}"
+            echo -e "  ${C_INF}Usage:${C_RST}"
+            echo -e "${C_CTX}\t$0 [command] [-h|--help] [-o|--option value]${C_RST}"
+            echo
+            echo -e "${C_MSG}  -h,  --help         ${C_RST}Show this help"
+            echo -e "${C_MSG}  -i   --input        ${C_RST}Set the folder that contains the input files (default: ./${input})"
+            echo -e "${C_MSG}  -o   --output       ${C_RST}Set the folder that contains the output files (default: ./${output})"
+            echo -e "${C_MSG}  -f   --format       ${C_RST}Set the output format"
+            echo -e "${C_MSG}  -p   --parallel     ${C_RST}Set the number of parallel processes"
+            echo -e "${C_MSG}  -c   --clean        ${C_RST}Clean up the output folder before rendering"
+            echo -e "${C_MSG}  -r   --recurse      ${C_RST}Recurse into sub-directories"
+            echo
+            exit 0
+        ;;
+        *)
+            ls $1 >/dev/null 2>&1
+            if [ "$?" == "0" ]; then
+                srcpath=$1
+            else
+                printerror "Unknown parameter ${1}"
+            fi
+        ;;
+    esac
+    shift
+done
+
+# set the paths
+if [ "${input}" != "" ]; then
+    srcpath=${project}/${input}
+fi
+if [ "${output}" != "" ]; then
+    dstpath=${project}/${output}
+fi
+
+# check the paths
+if [ ! -d "${srcpath}" ]; then
+    printerror "The input path ${srcpath} does not exist!"
+fi
+if [ ! -d "${dstpath}" ]; then
+    printmessage ${C_ERR}"Warning! The output path ${dstpath} does not exist!"
+fi
+
+# check OpenSCAD
 scadcheck
-scadformat
-scadprocesses
-scadrenderall "${srcpath}" "${dstpath}" "$@"
+
+# defines the output format
+scadformat "${format}"
+
+# defines the number of parallel processes
+scadprocesses "${parallel}"
+
+# clean up the output
+if [ "${cleanUp}" != "" ]; then
+    printmessage "${C_CTX}Cleaning up the output folder"
+    rm -rf "${dstpath}"
+fi
+
+# render the files
+printmessage "${C_MSG}Rendering the files"
+if [ "${recurse}" != "" ]; then
+    renderall "${srcpath}" "${dstpath}" "$@"
+else
+    renderpath "${srcpath}" "${dstpath}" "$@"
+fi

--- a/scripts/slice.sh
+++ b/scripts/slice.sh
@@ -32,15 +32,156 @@
 # @author jsconan
 #
 
+# script config
 scriptpath=$(dirname $0)
 project=$(pwd)
-srcpath=${project}/output
-dstpath=${project}/dist
+srcpath=${project}
+dstpath=${project}
+configpath=
+input="output"
+output="dist"
+config=
+format=
+parallel=
+cleanUp=
+recurse=
 
+# include libs
 source "${scriptpath}/utils.sh"
 
+# Slice all the files from the folder.
+#
+# @param sourcepath - The path of the folder containing the model files to slice.
+# @param destpath - The path to the output folder.
+slicepath() {
+    local src=$1; shift
+    local dst=$1; shift
+    slic3rsliceall "${src}" "${dst}" --align-xy 0,0 "$@"
+}
+
+# Slice all the files including the sub-folders.
+#
+# @param sourcepath - The path of the folder containing the model files to slice.
+# @param destpath - The path to the output folder.
+sliceall() {
+    local src=$1; shift
+    local dst=$1; shift
+    local folders=($(find ${src} -type d -print))
+    local i=0
+    for folderpath in "${folders[@]}"; do
+        folder=$(echo ${folderpath#${src}})
+        local files=($(find ${folderpath} -maxdepth 1 -type f -print))
+        if [ "${files}" != "" ]; then
+            slicepath "${src}${folder}" "${dst}${folder}" "$@"
+        fi
+    done
+}
+
+# load parameters
+while (( "$#" )); do
+    case $1 in
+        "-i"|"--input")
+            input=$2
+            shift
+        ;;
+        "-o"|"--output")
+            output=$2
+            shift
+        ;;
+        "-s"|"--config")
+            config=$2
+            shift
+        ;;
+        "-f"|"--format")
+            format=$2
+            shift
+        ;;
+        "-p"|"--parallel")
+            parallel=$2
+            shift
+        ;;
+        "-c"|"--clean")
+            cleanUp=1
+        ;;
+        "-r"|"--recurse")
+            recurse=1
+        ;;
+        "-ps"|"--prusaslicer")
+            useprusaslicer
+        ;;
+        "-h"|"--help")
+            echo -e "${C_INF}Slices model files${C_RST}"
+            echo -e "  ${C_INF}Usage:${C_RST}"
+            echo -e "${C_CTX}\t$0 [command] [-h|--help] [-o|--option value]${C_RST}"
+            echo
+            echo -e "${C_MSG}  -h,  --help         ${C_RST}Show this help"
+            echo -e "${C_MSG}  -i   --input        ${C_RST}Set the folder that contains the input files (default: ./${input})"
+            echo -e "${C_MSG}  -o   --output       ${C_RST}Set the folder that contains the output files (default: ./${output})"
+            echo -e "${C_MSG}  -s   --config       ${C_RST}Set the path to the config file"
+            echo -e "${C_MSG}  -f   --format       ${C_RST}Set the output format"
+            echo -e "${C_MSG}  -p   --parallel     ${C_RST}Set the number of parallel processes"
+            echo -e "${C_MSG}  -c   --clean        ${C_RST}Clean up the output folder before rendering"
+            echo -e "${C_MSG}  -r   --recurse      ${C_RST}Recurse into sub-directories"
+            echo -e "${C_MSG}  -ps  --prusaslicer  ${C_RST}Use PrusaSlicer instead of Slic3r"
+            echo
+            exit 0
+        ;;
+        *)
+            ls $1 >/dev/null 2>&1
+            if [ "$?" == "0" ]; then
+                srcpath=$1
+            else
+                printerror "Unknown parameter ${1}"
+            fi
+        ;;
+    esac
+    shift
+done
+
+# set the paths
+if [ "${input}" != "" ]; then
+    srcpath=${project}/${input}
+fi
+if [ "${output}" != "" ]; then
+    dstpath=${project}/${output}
+fi
+if [ "${config}" != "" ]; then
+    configpath=${project}/${config}
+fi
+
+# check the paths
+if [ ! -d "${srcpath}" ]; then
+    printerror "The input path ${srcpath} does not exist!"
+fi
+if [ ! -d "${dstpath}" ]; then
+    printmessage ${C_ERR}"Warning! The output path ${dstpath} does not exist!"
+fi
+
+# check Slic3r
 slic3rcheck
-slic3rformat
-slic3rconfig
-slic3rprocesses
-slic3rsliceall "${srcpath}" "${dstpath}" "$@"
+
+# defines the input model format
+slic3rformat "${format}"
+
+# defines the config path
+if [ "${configpath}" != "" ] && [ ! -f "${configpath}" ]; then
+    printmessage "${C_ERR}Warning! The config for Slic3r does not exist."
+fi
+slic3rconfig "${configpath}"
+
+# defines the number of parallel processes
+slic3rprocesses "${parallel}"
+
+# clean up the output
+if [ "${cleanUp}" != "" ]; then
+    printmessage "${C_CTX}Cleaning up the output folder"
+    rm -rf "${dstpath}"
+fi
+
+# slice the files
+printmessage "${C_MSG}Slicing the rendered files"
+if [ "${recurse}" != "" ]; then
+    sliceall "${srcpath}" "${dstpath}" "$@"
+else
+    slicepath "${srcpath}" "${dstpath}" "$@"
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -32,12 +32,87 @@
 # @author jsconan
 #
 
+# script config
 scriptpath=$(dirname $0)
 project=$(pwd)
-srcpath=${project}/test
-dstpath=${project}/output
+srcpath=${project}
+dstpath=${project}
+input="test"
+output="output"
+suite=
+defaultsuite="suite"
+cleanUp=
 
 source "${scriptpath}/utils.sh"
 
+# load parameters
+while (( "$#" )); do
+    case $1 in
+        "-i"|"--input")
+            input=$2
+            shift
+        ;;
+        "-o"|"--output")
+            output=$2
+            shift
+        ;;
+        "-d"|"--defaut")
+            defaultsuite=$2
+            shift
+        ;;
+        "-c"|"--clean")
+            cleanUp=1
+        ;;
+        "-h"|"--help")
+            echo -e "${C_INF}Runs a tests suite for OpenSCAD files${C_RST}"
+            echo -e "  ${C_INF}Usage:${C_RST}"
+            echo -e "${C_CTX}\t$0 [command] [-h|--help] [-o|--option value] \"test suite\"${C_RST}"
+            echo
+            echo -e "${C_MSG}  -h,  --help         ${C_RST}Show this help"
+            echo -e "${C_MSG}  -i   --input        ${C_RST}Set the folder that contains the input files (default: ./${input})"
+            echo -e "${C_MSG}  -o   --output       ${C_RST}Set the folder that contains the output files (default: ./${output})"
+            echo -e "${C_MSG}  -d   --default      ${C_RST}Set the default test suite (default: ${defaultsuite})"
+            echo -e "${C_MSG}  -c   --clean        ${C_RST}Clean up the output folder before running the tests suite"
+            echo
+            exit 0
+        ;;
+        *)
+            ls ${srcpath}/$1 >/dev/null 2>&1
+            if [ "$?" == "0" ]; then
+                suite=$1
+            else
+                printerror "Unknown parameter ${1}"
+            fi
+        ;;
+    esac
+    shift
+done
+
+# set the paths
+if [ "${input}" != "" ]; then
+    srcpath=${project}/${input}
+fi
+if [ "${output}" != "" ]; then
+    dstpath=${project}/${output}
+fi
+
+# check the paths
+if [ ! -d "${srcpath}" ]; then
+    printerror "The input path ${srcpath} does not exist!"
+fi
+if [ ! -d "${dstpath}" ]; then
+    printmessage ${C_ERR}"Warning! The output path ${dstpath} does not exist!"
+fi
+
+# check OpenSCAD
 scadcheck
-scadunittest "$1" "${srcpath}" "${dstpath}" "suite"
+
+# clean up the output
+if [ "${cleanUp}" != "" ]; then
+    printmessage "${C_CTX}Cleaning up the output folder"
+    rm -rf "${dstpath}"
+fi
+
+# run the tests
+printmessage "${C_MSG}Running the test suite $(default "${suite}" "${defaultsuite}")"
+scadunittest "${suite}" "${srcpath}" "${dstpath}" "${defaultsuite}"

--- a/test/core/version.scad
+++ b/test/core/version.scad
@@ -45,10 +45,10 @@ module testCoreVersion() {
         // test camelSCAD()
         testModule("camelSCAD()", 2) {
             testUnit("as vector", 1) {
-                assertEqual(camelSCAD(), [0, 13, 0], "The current version of the library is 0.13.0");
+                assertEqual(camelSCAD(), [0, 14, 0], "The current version of the library is 0.14.0");
             }
             testUnit("as string", 1) {
-                assertEqual(camelSCAD(true), "0.13.0", "The current version of the library is 0.13.0");
+                assertEqual(camelSCAD(true), "0.14.0", "The current version of the library is 0.14.0");
             }
         }
     }


### PR DESCRIPTION
Improve the util scripts, adding parameters to make them configurable.

- `./scripts/render.sh`:
```
Renders OpenSCAD files
  Usage:
	./scripts/render.sh [command] [-h|--help] [-o|--option value]

  -h,  --help         Show this help
  -i   --input        Set the folder that contains the input files (default: ./)
  -o   --output       Set the folder that contains the output files (default: ./output)
  -f   --format       Set the output format
  -p   --parallel     Set the number of parallel processes
  -c   --clean        Clean up the output folder before rendering
  -r   --recurse      Recurse into sub-directories
```

- `./scripts/slice.sh`:
```
Slices model files
  Usage:
	./scripts/slice.sh [command] [-h|--help] [-o|--option value]

  -h,  --help         Show this help
  -i   --input        Set the folder that contains the input files (default: ./output)
  -o   --output       Set the folder that contains the output files (default: ./dist)
  -s   --config       Set the path to the config file
  -f   --format       Set the output format
  -p   --parallel     Set the number of parallel processes
  -c   --clean        Clean up the output folder before rendering
  -r   --recurse      Recurse into sub-directories
  -ps  --prusaslicer  Use PrusaSlicer instead of Slic3r
```

- `./scripts/test.sh`:
```
Runs a tests suite for OpenSCAD files
  Usage:
	./scripts/test.sh [command] [-h|--help] [-o|--option value] "test suite"

  -h,  --help         Show this help
  -i   --input        Set the folder that contains the input files (default: ./test)
  -o   --output       Set the folder that contains the output files (default: ./output)
  -d   --default      Set the default test suite (default: suite)
  -c   --clean        Clean up the output folder before running the tests suite
```