### PR TITLE
Release 0.14.1

### DIFF
--- a/core/version.scad
+++ b/core/version.scad
@@ -36,7 +36,7 @@
  * The version of the library.
  * @type Vector
  */
-CAMEL_SCAD_VERSION = [0, 14, 0];
+CAMEL_SCAD_VERSION = [0, 14, 1];
 
 /**
  * The minimal version of OpenSCAD required by the library.

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -47,34 +47,6 @@ recurse=
 # include libs
 source "${scriptpath}/utils.sh"
 
-# Renders all the files from the folder.
-#
-# @param sourcepath - The path of the folder containing the files to render.
-# @param destpath - The path to the output folder.
-renderpath() {
-    local src=$1; shift
-    local dst=$1; shift
-    scadrenderall "${src}" "${dst}" "$@"
-}
-
-# Renders all the files including the sub-folders.
-#
-# @param sourcepath - The path of the folder containing the files to render.
-# @param destpath - The path to the output folder.
-renderall() {
-    local src=$1; shift
-    local dst=$1; shift
-    local folders=($(find ${src} -type d -print))
-    local i=0
-    for folderpath in "${folders[@]}"; do
-        folder=$(echo ${folderpath#${src}})
-        local files=($(find ${folderpath} -maxdepth 1 -type f -print))
-        if [ "${files}" != "" ]; then
-            renderpath "${src}${folder}" "${dst}${folder}" "$@"
-        fi
-    done
-}
-
 # load parameters
 while (( "$#" )); do
     case $1 in
@@ -161,7 +133,7 @@ fi
 # render the files
 printmessage "${C_MSG}Rendering the files"
 if [ "${recurse}" != "" ]; then
-    renderall "${srcpath}" "${dstpath}" "$@"
+    scadrenderallrecurse "${srcpath}" "${dstpath}" "$@"
 else
-    renderpath "${srcpath}" "${dstpath}" "$@"
+    scadrenderall "${srcpath}" "${dstpath}" "$@"
 fi

--- a/scripts/slice.sh
+++ b/scripts/slice.sh
@@ -49,34 +49,6 @@ recurse=
 # include libs
 source "${scriptpath}/utils.sh"
 
-# Slice all the files from the folder.
-#
-# @param sourcepath - The path of the folder containing the model files to slice.
-# @param destpath - The path to the output folder.
-slicepath() {
-    local src=$1; shift
-    local dst=$1; shift
-    slic3rsliceall "${src}" "${dst}" --align-xy 0,0 "$@"
-}
-
-# Slice all the files including the sub-folders.
-#
-# @param sourcepath - The path of the folder containing the model files to slice.
-# @param destpath - The path to the output folder.
-sliceall() {
-    local src=$1; shift
-    local dst=$1; shift
-    local folders=($(find ${src} -type d -print))
-    local i=0
-    for folderpath in "${folders[@]}"; do
-        folder=$(echo ${folderpath#${src}})
-        local files=($(find ${folderpath} -maxdepth 1 -type f -print))
-        if [ "${files}" != "" ]; then
-            slicepath "${src}${folder}" "${dst}${folder}" "$@"
-        fi
-    done
-}
-
 # load parameters
 while (( "$#" )); do
     case $1 in
@@ -181,7 +153,7 @@ fi
 # slice the files
 printmessage "${C_MSG}Slicing the rendered files"
 if [ "${recurse}" != "" ]; then
-    sliceall "${srcpath}" "${dstpath}" "$@"
+    slic3rsliceallrecurse "${srcpath}" "${dstpath}" --align-xy 0,0 "$@"
 else
-    slicepath "${srcpath}" "${dstpath}" "$@"
+    slic3rsliceall "${srcpath}" "${dstpath}" --align-xy 0,0 "$@"
 fi

--- a/scripts/utils/files.sh
+++ b/scripts/utils/files.sh
@@ -111,3 +111,20 @@ createpath() {
         fi
     fi
 }
+
+# Recursively list all folders from a path, matching a files pattern.
+#
+# @param sourcepath - The input path in which recursively search the files pattern.
+# @param pattern - The files pattern each folder much contain.
+recursepath() {
+    local input=$1; shift
+    local pattern=$1; shift
+    local folders=($(find ${input} -type d -print 2>/dev/null))
+    for folderpath in "${folders[@]}"; do
+        folder=$(echo ${folderpath#${input}})
+        local files=($(find ${folderpath}/${pattern} -maxdepth 1 -type f -print 2>/dev/null))
+        if [ "${files}" != "" ]; then
+            echo "${folder}"
+        fi
+    done
+}

--- a/scripts/utils/slic3r.sh
+++ b/scripts/utils/slic3r.sh
@@ -249,3 +249,26 @@ slic3rsliceall() {
     wait
     printmessage "Done!"
 }
+
+# Slices the models from a path and its sub-folders.
+# Several processes will be spawned at a time to parallelize the slicing and speeds it up.
+# Exits with error code E_EMPTY if it is empty.
+# Exits with error code E_CREATE if the output folder cannot be created.
+#
+# @example
+# slic3rsliceall "bar" "foo/bar"
+#
+# @param sourcepath - The path of the folder containing the models to slice.
+# @param destpath - The path to the output folder.
+# @param ... - A list of additional parameters.
+slic3rsliceallrecurse() {
+    local src=$1; shift
+    local dst=$1; shift
+    local folders=($(recursepath "${src}" "*.${slic3rext}"))
+    if [ "${folders}" == "" ]; then
+        printerror "There is nothing to slice at ${src}!" ${E_EMPTY}
+    fi
+    for folder in "${folders[@]}"; do
+        slic3rsliceall "${src}${folder}" "${dst}${folder}" "$@"
+    done
+}

--- a/test/core/version.scad
+++ b/test/core/version.scad
@@ -45,10 +45,10 @@ module testCoreVersion() {
         // test camelSCAD()
         testModule("camelSCAD()", 2) {
             testUnit("as vector", 1) {
-                assertEqual(camelSCAD(), [0, 14, 0], "The current version of the library is 0.14.0");
+                assertEqual(camelSCAD(), [0, 14, 1], "The current version of the library is 0.14.1");
             }
             testUnit("as string", 1) {
-                assertEqual(camelSCAD(true), "0.14.0", "The current version of the library is 0.14.0");
+                assertEqual(camelSCAD(true), "0.14.1", "The current version of the library is 0.14.1");
             }
         }
     }


### PR DESCRIPTION
Fix a script early break when the source path only contains folders.

Add script utils:
- `recursepath()`: print the list of subfolders
- `scadrenderallrecurse()`: render all files in the path and its sub-folders
- `slic3rsliceallrecurse()`: slice all files in the path and its sub-folders