### PR TITLE
Feature/OpenSCAD 2019+ support update

### DIFF
--- a/core/bezier.scad
+++ b/core/bezier.scad
@@ -102,11 +102,11 @@ function quadraticBezierCurve(p0, p1, p2, recurse) =
        :let(
             d12 = p1 - p2,
             d0 = p2 - p0,
-            d1 = abs(d12[0] * d0[1] - d12[1] * d0[0]),
+            d1 = abs(d12.x * d0.y - d12.y * d0.x),
             tolerance = $fs * $fa * BEZIER_TOLERANCE
         )
         d1 > EPSILON ? d1 < tolerance
-                     : let(d = p012 - (p0 + p2) / 2) d[0] + d[1] <= tolerance
+                     : let(d = p012 - (p0 + p2) / 2) d.x + d.y <= tolerance
     )
     finish ? [p012] : concat(
         quadraticBezierCurve(p0, p01, p012, recurse + 1),
@@ -149,14 +149,14 @@ function cubicBezierCurve(p0, p1, p2, p3, recurse) =
             d13 = p1 - p3,
             d23 = p2 - p3,
             d0 = p3 - p0,
-            d1 = abs(d13[0] * d0[1] - d13[1] * d0[0]),
-            d2 = abs(d23[0] * d0[1] - d23[1] * d0[0]),
+            d1 = abs(d13.x * d0.y - d13.y * d0.x),
+            d2 = abs(d23.x * d0.y - d23.y * d0.x),
             tolerance = $fs * $fa * BEZIER_TOLERANCE
         )
         d1 > EPSILON && d2 > EPSILON ? d1 + d2 < tolerance
        :d1 > EPSILON ? d1 < tolerance
        :d2 > EPSILON ? d2 < tolerance
-       :let(d = p0123 - (p0 + p3) / 2) d[0] + d[1] <= tolerance
+       :let(d = p0123 - (p0 + p3) / 2) d.x + d.y <= tolerance
     )
     finish ? [p0123] : concat(
         cubicBezierCurve(p0, p01, p012, p0123, recurse + 1),

--- a/core/bezier.scad
+++ b/core/bezier.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -82,7 +82,7 @@ function cubicBezierPoint(t, p0, p1, p2, p3) =
  * @returns Vector[] - Returns the coordinates of each points in the curve.
  */
 function quadraticBezierCurve(p0, p1, p2, recurse) =
-    isUndef(recurse)
+    is_undef(recurse)
    ?let(
         p0 = vector2D(p0),
         p1 = vector2D(p1),
@@ -124,7 +124,7 @@ function quadraticBezierCurve(p0, p1, p2, recurse) =
  * @returns Vector[] - Returns the coordinates of each points in the curve.
  */
 function cubicBezierCurve(p0, p1, p2, p3, recurse) =
-    isUndef(recurse)
+    is_undef(recurse)
    ?let(
         p0 = vector2D(p0),
         p1 = vector2D(p1),

--- a/core/hex.scad
+++ b/core/hex.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,7 @@
  * @returns Number - The number of ranges.
  */
 function radialHexRange(count) =
-    let( number = isArray(count) && len(count) ? min(count) : float(count) )
+    let( number = is_list(count) && len(count) ? min(count) : float(count) )
     floor((abs(divisor(number)) - 1) / 2)
 ;
 

--- a/core/hex.scad
+++ b/core/hex.scad
@@ -73,8 +73,8 @@ function buildHexGrid(count, linear, cx, cy) =
         count = vabs(divisor2D(count))
     )
     [
-        for (x = [0 : count[0] - 1])
-            for (y = [0 : count[1] - 1])
+        for (x = [0 : count.x - 1])
+            for (y = [0 : count.y - 1])
                 [x, y]
     ]
    :let(
@@ -112,12 +112,12 @@ function offsetHexGrid(size, count, pointy, linear, even, l, w, cx, cy) =
     )
     pointy
    ?[
-        size[0] * SQRT3 * ((even - (count[0] + linear))) / 4,
-        -size[1] * (count[1] - 1) * 3 / 8,
+        size.x * SQRT3 * ((even - (count.x + linear))) / 4,
+        -size.y * (count.y - 1) * 3 / 8,
     ]
    :[
-        -size[0] * (count[0] - 1) * 3 / 8,
-        size[1] * SQRT3 * ((even - (count[1] + linear))) / 4,
+        -size.x * (count.x - 1) * 3 / 8,
+        size.y * SQRT3 * ((even - (count.y + linear))) / 4,
     ]
 ;
 
@@ -142,12 +142,12 @@ function sizeHexGrid(size, count, pointy, linear, l, w, cx, cy) =
     )
     pointy
    ?[
-        size[0] * SQRT3 * (count[0] + linear) / 2,
-        size[1] * (4 + 3 * (count[1] - 1)) / 4,
+        size.x * SQRT3 * (count.x + linear) / 2,
+        size.y * (4 + 3 * (count.y - 1)) / 4,
     ]
    :[
-        size[0] * (4 + 3 * (count[0] - 1)) / 4,
-        size[1] * SQRT3 * (count[1] + linear) / 2
+        size.x * (4 + 3 * (count.x - 1)) / 4,
+        size.y * SQRT3 * (count.y + linear) / 2
     ]
 ;
 
@@ -172,12 +172,12 @@ function sizeHexCell(size, count, pointy, linear, l, w, cx, cy) =
     )
     pointy
    ?[
-        size[0] * 2 / (count[0] + linear) / SQRT3,
-        size[1] * 4 / (4 + 3 * (count[1] - 1))
+        size.x * 2 / (count.x + linear) / SQRT3,
+        size.y * 4 / (4 + 3 * (count.y - 1))
     ]
    :[
-        size[0] * 4 / (4 + 3 * (count[0] - 1)),
-        size[1] * 2 / (count[1] + linear) / SQRT3
+        size.x * 4 / (4 + 3 * (count.x - 1)),
+        size.y * 2 / (count.y + linear) / SQRT3
     ]
 ;
 
@@ -202,12 +202,12 @@ function countHexCell(size, cell, pointy, linear, l, w, cl, cw) =
     )
     pointy
    ?[
-        floor(size[0] * 2 / cell[0] / SQRT3 - linear),
-        floor((size[1] * 4 / cell[1] - 1) / 3)
+        floor(size.x * 2 / cell.x / SQRT3 - linear),
+        floor((size.y * 4 / cell.y - 1) / 3)
     ]
    :[
-        floor((size[0] * 4 / cell[0] - 1) / 3),
-        floor(size[1] * 2 / cell[1] / SQRT3 - linear)
+        floor((size.x * 4 / cell.x - 1) / 3),
+        floor(size.y * 2 / cell.y / SQRT3 - linear)
     ]
 ;
 
@@ -233,11 +233,11 @@ function coordHexCell(hex, size, pointy, linear, even, x, y, l, w) =
     )
     pointy
    ?[
-        size[0] * SQRT3 * (hex[0] + factor * (linear ? hex[1] % 2 : hex[1])),
-        size[1] * hex[1] * 1.5
+        size.x * SQRT3 * (hex.x + factor * (linear ? hex.y % 2 : hex.y)),
+        size.y * hex.y * 1.5
     ]
    :[
-        size[0] * hex[0] * 1.5,
-        size[1] * SQRT3 * (hex[1] + factor * (linear ? hex[0] % 2 : hex[0]))
+        size.x * hex.x * 1.5,
+        size.y * SQRT3 * (hex.y + factor * (linear ? hex.x % 2 : hex.x))
     ]
 ;

--- a/core/line.scad
+++ b/core/line.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +49,7 @@ function arc(r, a=DEGREES, o, a1, a2) =
         a1 = deg(a1),
         a2 = a2 != undef ? deg(a2) : a1 + deg(a)
     )
-    !r[0] || !r[1] || (!a1 && !a2) ? []
+    !r.x || !r.y || (!a1 && !a2) ? []
    :let(
         start = min(a1, a2),
         end = max(a1, a2),

--- a/core/list.scad
+++ b/core/list.scad
@@ -74,7 +74,7 @@ function times(value, count) =
 function range(start, end, step) =
     let(
         s = float(start),
-        simple = s && isUndef(end),
+        simple = s && is_undef(end),
         start = simple ? 0 : s,
         end = simple ? s : float(end),
         step = or(number(step), start > end ? -1 : 1)
@@ -117,7 +117,7 @@ function reverse(collection) =
  * @param Array collection - The array to flatten.
  * @returns Array
  */
-function flatten(collection) = [ for (a = array(collection)) for (b = isString(a) ? [a] : a) b ];
+function flatten(collection) = [ for (a = array(collection)) for (b = is_string(a) ? [a] : a) b ];
 
 /**
  * Finds the index of a key in a collection.
@@ -175,8 +175,8 @@ function slice(collection, start, end) =
     let(
         collection = array(collection),
         length = len(collection),
-        start = isNumber(start) && start < 0 ? max(0, length + start) : integer(start),
-        end = (isNumber(end) && end < 0 ? max(start, length + end) : numberOr(end, length)) - 1
+        start = is_num(start) && start < 0 ? max(0, length + start) : integer(start),
+        end = (is_num(end) && end < 0 ? max(start, length + end) : numberOr(end, length)) - 1
     )
     length && start <= end ? [ for (i = [start : end]) if (i < length) collection[i] ]
                            : []
@@ -196,7 +196,7 @@ function splice(collection, start, remove, elems) =
         collection = array(collection),
         elems = arrayOr(elems, []),
         length = len(collection),
-        start = min(isNumber(start) && start < 0 ? max(0, length + start) : integer(start), length),
+        start = min(is_num(start) && start < 0 ? max(0, length + start) : integer(start), length),
         next = start + numberOr(remove, length - start),
         last = length - 1
     )

--- a/core/list.scad
+++ b/core/list.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -175,8 +175,8 @@ function slice(collection, start, end) =
     let(
         collection = array(collection),
         length = len(collection),
-        start = start < 0 ? max(0, length + start) : integer(start),
-        end = (end < 0 ? max(start, length + end) : numberOr(end, length)) - 1
+        start = isNumber(start) && start < 0 ? max(0, length + start) : integer(start),
+        end = (isNumber(end) && end < 0 ? max(start, length + end) : numberOr(end, length)) - 1
     )
     length && start <= end ? [ for (i = [start : end]) if (i < length) collection[i] ]
                            : []
@@ -196,7 +196,7 @@ function splice(collection, start, remove, elems) =
         collection = array(collection),
         elems = arrayOr(elems, []),
         length = len(collection),
-        start = min(start < 0 ? max(0, length + start) : integer(start), length),
+        start = min(isNumber(start) && start < 0 ? max(0, length + start) : integer(start), length),
         next = start + numberOr(remove, length - start),
         last = length - 1
     )

--- a/core/logic.scad
+++ b/core/logic.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,7 +66,7 @@ function xor(a, b) = (!a && b) || (a && !b);
  * @param * b - The second value.
  * @returns *
  */
-function uor(a, b) = isUndef(a) ? b : a;
+function uor(a, b) = is_undef(a) ? b : a;
 
 /**
  * Returns the second value if the first value is defined.
@@ -75,7 +75,7 @@ function uor(a, b) = isUndef(a) ? b : a;
  * @param * b - The second value.
  * @returns *
  */
-function uand(a, b) = isUndef(a) ? a : b;
+function uand(a, b) = is_undef(a) ? a : b;
 
 /**
  * Gets the first value if it is a number, otherwise gets the second value whatever it is.
@@ -84,7 +84,7 @@ function uand(a, b) = isUndef(a) ? a : b;
  * @param * b - The second value.
  * @return Number|*
  */
-function numberOr(a, b) = isNumber(a) ? a : b;
+function numberOr(a, b) = is_num(a) ? a : b;
 
 /**
  * Gets the first value if it is an integer, otherwise gets the second value whatever it is.
@@ -102,7 +102,7 @@ function integerOr(a, b) = isInteger(a) ? a : b;
  * @param * b - The second value.
  * @return Boolean|*
  */
-function booleanOr(a, b) = isBoolean(a) ? a : b;
+function booleanOr(a, b) = is_bool(a) ? a : b;
 
 /**
  * Gets the first value if it is a string, otherwise gets the second value whatever it is.
@@ -111,7 +111,7 @@ function booleanOr(a, b) = isBoolean(a) ? a : b;
  * @param * b - The second value.
  * @return String|*
  */
-function stringOr(a, b) = isString(a) ? a : b;
+function stringOr(a, b) = is_string(a) ? a : b;
 
 /**
  * Gets the first value if it is an array, otherwise gets the second value whatever it is.
@@ -120,7 +120,7 @@ function stringOr(a, b) = isString(a) ? a : b;
  * @param * b - The second value.
  * @return Array|*
  */
-function arrayOr(a, b) = isArray(a) ? a : b;
+function arrayOr(a, b) = is_list(a) ? a : b;
 
 /**
  * Gets the first value if it is a vector, otherwise gets the second value whatever it is.
@@ -237,8 +237,8 @@ function contains(a, value) =
 function approx(a, b, precision=5,
                 // internal
                 p, l) =
-    isArray(a) ? (
-       !isArray(b) ? false
+    is_list(a) ? (
+       !is_list(b) ? false
        :(
             let(
                 la = len(a),
@@ -275,8 +275,8 @@ function approx(a, b, precision=5,
             approx(a, b, precision, p, half) && approx(a, b, precision, p + half, l - half)
         )
     )
-   :isNumber(a) ? (
-        !isNumber(b) ? false
+   :is_num(a) ? (
+        !is_num(b) ? false
        :(
             let(
                 sa = sign(a),

--- a/core/string.scad
+++ b/core/string.scad
@@ -62,7 +62,7 @@ function substr(s, start, length) =
     let(
         s = string(s),
         l = len(s),
-        start = isNumber(start) && start < 0 ? max(0, start + l) : integer(start),
+        start = is_num(start) && start < 0 ? max(0, start + l) : integer(start),
         end = min(start + numberOr(length, l), l) - 1
     )
     start <= end ? join([for (i = [start : end]) s[i] ]) : ""
@@ -131,13 +131,13 @@ function join(terms, glue, offset=0) =
 function split(s, sep,
                //internal
                positions, offset=0, i=0) =
-    isUndef(positions) ?
+    is_undef(positions) ?
         let(
             s = stringOr(s),
             sep = string(sep),
             positions = and(s, occurences(s, sep))
         )
-        positions ? split(s, sep, positions) : isUndef(s) ? [] : [s]
+        positions ? split(s, sep, positions) : is_undef(s) ? [] : [s]
     :
         let(
             count = len(positions),
@@ -147,7 +147,7 @@ function split(s, sep,
                         p
             ] : [],
             i = index[0],
-            ok = !isUndef(i) && i >= 0 && i < count,
+            ok = !is_undef(i) && i >= 0 && i < count,
             start = [substr(s, offset, ok ? positions[i] - offset : undef)]
         )
         ok ? concat(start, split(s, sep, positions, positions[i] + len(sep), i + 1))
@@ -165,7 +165,7 @@ function split(s, sep,
 function replace(s, from, to,
                  //internal
                  positions, offset=0, i=0) =
-    isUndef(positions) ?
+    is_undef(positions) ?
         let(
             s = string(s),
             from = string(from),
@@ -182,7 +182,7 @@ function replace(s, from, to,
                         p
             ] : [],
             i = index[0],
-            ok = !isUndef(i) && i >= 0 && i < count,
+            ok = !is_undef(i) && i >= 0 && i < count,
             start = substr(s, offset, ok ? positions[i] - offset : undef)
         )
         ok ? str(start, to, replace(s, from, to, positions, positions[i] + len(from), i + 1))

--- a/core/string.scad
+++ b/core/string.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,7 @@ function substr(s, start, length) =
     let(
         s = string(s),
         l = len(s),
-        start = start < 0 ? max(0, start + l) : integer(start),
+        start = isNumber(start) && start < 0 ? max(0, start + l) : integer(start),
         end = min(start + numberOr(length, l), l) - 1
     )
     start <= end ? join([for (i = [start : end]) s[i] ]) : ""
@@ -147,7 +147,7 @@ function split(s, sep,
                         p
             ] : [],
             i = index[0],
-            ok = i >= 0 && i < count,
+            ok = !isUndef(i) && i >= 0 && i < count,
             start = [substr(s, offset, ok ? positions[i] - offset : undef)]
         )
         ok ? concat(start, split(s, sep, positions, positions[i] + len(sep), i + 1))
@@ -182,7 +182,7 @@ function replace(s, from, to,
                         p
             ] : [],
             i = index[0],
-            ok = i >= 0 && i < count,
+            ok = !isUndef(i) && i >= 0 && i < count,
             start = substr(s, offset, ok ? positions[i] - offset : undef)
         )
         ok ? str(start, to, replace(s, from, to, positions, positions[i] + len(from), i + 1))

--- a/core/type.scad
+++ b/core/type.scad
@@ -36,9 +36,10 @@
  * Checks if the value is undefined.
  *
  * @param * value - The value to check.
- * @returns Boolean - Returns `true` whether the value is defined.
+ * @returns Boolean - Returns `true` whether the value is not defined.
+ * @deprecated - Use is_undef instead.
  */
-function isUndef(value) = (value == undef);
+function isUndef(value) = is_undef(value);
 
 /**
  * Checks if the value is NAN (Not A Number).
@@ -46,7 +47,7 @@ function isUndef(value) = (value == undef);
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is NAN.
  */
-function isNAN(value) = (!isUndef(value) && value != value);
+function isNAN(value) = (!is_undef(value) && value != value);
 
 /**
  * Checks if the value is infinite.
@@ -54,15 +55,16 @@ function isNAN(value) = (!isUndef(value) && value != value);
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is infinite.
  */
-function isInfinity(value) = (isNumber(value) && (value >= INFINITY || value <= -INFINITY));
+function isInfinity(value) = (is_num(value) && (value >= INFINITY || value <= -INFINITY));
 
 /**
  * Checks if the value is numeric.
  *
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is numeric.
+ * @deprecated - Use is_num instead.
  */
-function isNumber(value) = (value != undef && value == value && value * 1 == value && concat(value) != value);
+function isNumber(value) = is_num(value);
 
 /**
  * Checks if the value is integer.
@@ -70,7 +72,7 @@ function isNumber(value) = (value != undef && value == value && value * 1 == val
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is integer.
  */
-function isInteger(value) = (isNumber(value) && floor(value) == value);
+function isInteger(value) = (is_num(value) && floor(value) == value);
 
 /**
  * Checks if the value is small enough to be considered equal to 0.
@@ -78,31 +80,34 @@ function isInteger(value) = (isNumber(value) && floor(value) == value);
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is equal to 0 or near enough.
  */
-function isZero(value) = (isNumber(value) && value > -EPSILON && value < EPSILON);
+function isZero(value) = (is_num(value) && value > -EPSILON && value < EPSILON);
 
 /**
  * Checks if the value is boolean.
  *
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is boolean.
+ * @deprecated - Use is_bool instead.
  */
-function isBoolean(value) = (value == true || value == false);
+function isBoolean(value) = is_bool(value);
 
 /**
  * Checks if the value is a string.
  *
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is a string.
+* @deprecated - Use is_string instead.
  */
-function isString(value) = (str(value) == value);
+function isString(value) = is_string(value);
 
 /**
  * Checks if the value is an array or a vector.
  *
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is an array or a vector.
+ * @deprecated - Use is_list instead.
  */
-function isArray(value) = (concat(value) == value);
+function isArray(value) = is_list(value);
 
 /**
  * Checks if the value is a vector.
@@ -110,7 +115,7 @@ function isArray(value) = (concat(value) == value);
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is a vector.
  */
-function isVector(value) = (concat(value) == value && value * 1 == value);
+function isVector(value) = (is_list(value) && value * 1 == value);
 
 /**
  * Checks if the value is a N-dimensions vector.
@@ -119,7 +124,7 @@ function isVector(value) = (concat(value) == value && value * 1 == value);
  * @param Number length - The required length of the vector.
  * @returns Boolean - Returns `true` whether the value is a vector and has the required length.
  */
-function isVectorN(value, length) = (concat(value) == value && len(value) == float(length) && value * 1 == value);
+function isVectorN(value, length) = (is_list(value) && len(value) == float(length) && value * 1 == value);
 
 /**
  * Checks if the value is a 2D vector.
@@ -127,7 +132,7 @@ function isVectorN(value, length) = (concat(value) == value && len(value) == flo
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is a 2D vector.
  */
-function isVector2D(value) = (concat(value) == value && len(value) == 2 && value * 1 == value);
+function isVector2D(value) = (is_list(value) && len(value) == 2 && value * 1 == value);
 
 /**
  * Checks if the value is a 3D vector.
@@ -135,7 +140,7 @@ function isVector2D(value) = (concat(value) == value && len(value) == 2 && value
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is a 3D vector.
  */
-function isVector3D(value) = (concat(value) == value && len(value) == 3 && value * 1 == value);
+function isVector3D(value) = (is_list(value) && len(value) == 3 && value * 1 == value);
 
 /**
  * Typecasts the value to a number.
@@ -151,7 +156,7 @@ function number(value) = value == true ? 1 : float(value);
  * @param * value - The value to cast.
  * @returns Number - Returns a number. If the value cannot be casted, 0 will be returned.
  */
-function float(value) = value && isNumber(value) ? value : 0;
+function float(value) = value && is_num(value) ? value : 0;
 
 /**
  * Typecasts the value to a float, and ensures it is a safe divisor.
@@ -160,7 +165,7 @@ function float(value) = value && isNumber(value) ? value : 0;
  * @param * value - The value to cast.
  * @returns Number - Returns a number. If the value cannot be casted, of if the value is 0, 1 will be returned.
  */
-function divisor(value) = value && isNumber(value) ? value : 1;
+function divisor(value) = value && is_num(value) ? value : 1;
 
 /**
  * Typecasts the value to an integer.
@@ -190,7 +195,7 @@ function boolean(value) = !value || value == "false" ? false : true;
  * @param * value - The value to cast.
  * @returns String - Returns a string. Strings remain unchanged, other values are "stringified".
  */
-function string(value) = isUndef(value) ? "" : str(value);
+function string(value) = is_undef(value) ? "" : str(value);
 
 /**
  * Typecasts the value to an array.
@@ -199,7 +204,7 @@ function string(value) = isUndef(value) ? "" : str(value);
  * @returns Array - Returns an array. Arrays and vectors remain unchanged.
  *                  `undef` produces an empty array, other values are wrapped in an array.
  */
-function array(value) = isUndef(value) ? [] : concat(value);
+function array(value) = is_undef(value) ? [] : concat(value);
 
 /**
  * Typecasts the value to a vector with the desired length.
@@ -214,9 +219,9 @@ function array(value) = isUndef(value) ? [] : concat(value);
  */
 function vector(value, length) =
     let(
-        array = isArray(value),
+        array = is_list(value),
         length = float(
-            isUndef(length) ? (array ? len(value) : 0)
+            is_undef(length) ? (array ? len(value) : 0)
                             : length
         )
     )

--- a/core/type.scad
+++ b/core/type.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +46,7 @@ function isUndef(value) = (value == undef);
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is NAN.
  */
-function isNAN(value) = (value != value);
+function isNAN(value) = (!isUndef(value) && value != value);
 
 /**
  * Checks if the value is infinite.
@@ -54,7 +54,7 @@ function isNAN(value) = (value != value);
  * @param * value - The value to check.
  * @returns Boolean - Returns `true` whether the value is infinite.
  */
-function isInfinity(value) = (value >= INFINITY || value <= -INFINITY);
+function isInfinity(value) = (isNumber(value) && (value >= INFINITY || value <= -INFINITY));
 
 /**
  * Checks if the value is numeric.

--- a/core/util.scad
+++ b/core/util.scad
@@ -100,8 +100,8 @@ function after(position) = float(position) > 0;
 function cardinal(p) =
     is_num(p) || isVector(p) ?
         let( p = vector2D(p) )
-        [ position(before(p[0]), after(p[0])),
-          position(before(p[1]), after(p[1])) ]
+        [ position(before(p.x), after(p.x)),
+          position(before(p.y), after(p.y)) ]
     :
         let( p = p && p != true ? str(p) : "" )
         [ position(min(len(search("wW", p)), 1), min(len(search("eE", p)), 1)),
@@ -121,7 +121,7 @@ function cardinal(p) =
  */
 function align(value, direction, center) =
     let(
-        direction = cardinal(uor(direction, 2))[1],
+        direction = cardinal(uor(direction, 2)).y,
         value = divisor(value),
         absv = abs(value),
         adjust = direction ? (direction == 2 ? ALIGN2 : ALIGN) : 0,

--- a/core/util.scad
+++ b/core/util.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -98,7 +98,7 @@ function after(position) = float(position) > 0;
  * @returns Vector - A 2D vector that contains position values for horizontal and vertical axis.
  */
 function cardinal(p) =
-    isNumber(p) || isVector(p) ?
+    is_num(p) || isVector(p) ?
         let( p = vector2D(p) )
         [ position(before(p[0]), after(p[0])),
           position(before(p[1]), after(p[1])) ]

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -76,8 +76,9 @@ function divisor2D(v) =
 function apply2D(v, x, y, r, d) =
     let(
         n = isNumber(v),
-        x = uor(x, uor(d, r * 2)),
-        y = uor(y, uor(d, r * 2))
+        d = uor(d, r ? r * 2 : r),
+        x = uor(x, d),
+        y = uor(y, d)
     )
     [
         float(uor(x, n ? v : v[0])),
@@ -636,7 +637,11 @@ function cosp(y, w, h, p, o) =
  * @returns Vector
  */
 function rotp(v, a) =
-    let( a = float(a) )
+    isUndef(v) || isUndef(a) ? [0, 0]
+   :let( 
+       v = vector2D(v),
+       a = float(a)
+    )
     [
         v[0] * cos(a) - v[1] * sin(a),
         v[1] * cos(a) + v[0] * sin(a)
@@ -651,7 +656,10 @@ function rotp(v, a) =
  * @returns Vector
  */
 function mirp(v, a) =
-    let(
+    isUndef(v) || isUndef(a) ? [0, 0]
+   :let(
+        v = vector2D(v),
+        a = vector2D(a),
         ax2 = a[0] * a[0],
         ay2 = a[1] * a[1],
         a2xy = 2 * a[0] * a[1],
@@ -671,7 +679,10 @@ function mirp(v, a) =
  * @returns Vector
  */
 function arcp(r, a) =
-    let( a = float(a) )
+    let(
+        r = vector2D(r),
+        a = float(a)
+    )
     [
         r[0] * cos(a),
         r[1] * sin(a)

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -43,7 +43,7 @@
  */
 function vector2D(v) =
     is_num(v) ? [ v, v ]
-   :[ float(v[0]), float(v[1]) ]
+   :[ float(v.x), float(v.y) ]
 ;
 
 /**
@@ -57,7 +57,7 @@ function vector2D(v) =
  */
 function divisor2D(v) =
     is_num(v) ? let( v = divisor(v) ) [ v, v ]
-   :[ divisor(v[0]), divisor(v[1]) ]
+   :[ divisor(v.x), divisor(v.y) ]
 ;
 
 /**
@@ -81,8 +81,8 @@ function apply2D(v, x, y, r, d) =
         y = uor(y, d)
     )
     [
-        float(uor(x, n ? v : v[0])),
-        float(uor(y, n ? v : v[1]))
+        float(uor(x, n ? v : v.x)),
+        float(uor(y, n ? v : v.y))
     ]
 ;
 
@@ -99,8 +99,8 @@ function quadrant(v, i, x, y) =
     let(
         n = is_num(v),
         i = integer(i) % 4,
-        x = abs(float(uor(x, n ? v : v[0]))),
-        y = abs(float(uor(y, n ? v : v[1])))
+        x = abs(float(uor(x, n ? v : v.x))),
+        y = abs(float(uor(y, n ? v : v.y)))
     )
     i == 1 ? [-x,  y]
    :i == 2 ? [-x, -y]
@@ -147,7 +147,7 @@ function unit2D(v) =
  */
 function normal(v) =
     is_num(v) ? [ v, -v ]
-    :[ float(v[1]), -float(v[0]) ]
+    :[ float(v.y), -float(v.x) ]
 ;
 
 /**
@@ -162,7 +162,7 @@ function normal(v) =
  */
 function flip(v) =
     is_num(v) ? [ v, v ]
-    :[ float(v[1]), float(v[0]) ]
+    :[ float(v.y), float(v.x) ]
 ;
 
 /**
@@ -266,11 +266,11 @@ function intersect2D(a, b, c, d) =
         d = vector2D(d),
         i = b - a,
         j = d - c,
-        n = i[0] * j[1] - i[1] * j[0]
+        n = i.x * j.y - i.y * j.x
     )
     n ? (
         let(
-            k = -(a[0] * j[1] - c[0] * j[1] - j[0] * a[1] + j[0] * c[1]) / n
+            k = -(a.x * j.y - c.x * j.y - j.x * a.y + j.x * c.y) / n
         )
         a + k * i
     )
@@ -298,7 +298,7 @@ function tangent2D(p, c, r) =
     d > r ? (
         let(
             t = pythagoras(0, r, d),
-            a = getAngle(v[0], v[1]) + asin(r / d)
+            a = getAngle(v.x, v.y) + asin(r / d)
         )
         p + arcPoint(t, a)
     )
@@ -323,23 +323,23 @@ function circleLineIntersect2D(i, j, c, r) =
         j = vector2D(j),
         c = vector2D(c),
         r = abs(float(r)),
-        v = i[0] == j[0],
-        h = i[1] == j[1]
+        v = i.x == j.x,
+        h = i.y == j.y
     )
     h && v ? (
-        approx(pow(i[0] - c[0], 2) + pow(i[1] - c[1], 2), r * r) ? [i, j] : []
+        approx(pow(i.x - c.x, 2) + pow(i.y - c.y, 2), r * r) ? [i, j] : []
     )
    :v ? (
         let(
-            a = abs(i[0] - c[0])
+            a = abs(i.x - c.x)
         )
         a <= r ? (
             let(
                 b = pythagoras(a, 0, r)
             )
             [
-                [i[0], c[1] - b],
-                [i[0], c[1] + b]
+                [i.x, c.y - b],
+                [i.x, c.y + b]
             ]
         )
        :[]
@@ -347,15 +347,15 @@ function circleLineIntersect2D(i, j, c, r) =
     )
    :h ? (
        let(
-           a = abs(i[1] - c[1])
+           a = abs(i.y - c.y)
        )
        a <= r ? (
            let(
                b = pythagoras(a, 0, r)
            )
            [
-               [c[0] - b, i[1]],
-               [c[0] + b, i[1]]
+               [c.x - b, i.y],
+               [c.x + b, i.y]
            ]
        )
       :[]
@@ -363,18 +363,18 @@ function circleLineIntersect2D(i, j, c, r) =
    :(
         let(
             v = i - j,
-            a = v[1] / v[0],
-            b = i[1] - a * i[0],
+            a = v.y / v.x,
+            b = i.y - a * i.x,
             x = quadraticEquation(
                 1 + a * a,
-                2 * (-c[0] + (b - c[1]) * a),
-                c[0] * c[0] + c[1] * c[1] + (c[1] * -2 + b) * b - r * r
+                2 * (-c.x + (b - c.y) * a),
+                c.x * c.x + c.y * c.y + (c.y * -2 + b) * b - r * r
             )
         )
         x ? (
             [
-                [x[0], a * x[0] + b],
-                [x[1], a * x[1] + b]
+                [x.x, a * x.x + b],
+                [x.y, a * x.y + b]
             ]
         )
        :[]
@@ -398,13 +398,13 @@ function circleIntersect2D(c1, r1, c2, r2) =
         c2 = vector2D(c2),
         r1 = abs(float(r1)),
         r2 = abs(float(r2)),
-        v = c1[0] == c2[0],
-        h = c1[1] == c2[1]
+        v = c1.x == c2.x,
+        h = c1.y == c2.y
     )
     v && h ? []
    :v ? (
         let(
-            a = c2[1] - c1[1],
+            a = c2.y - c1.y,
             l = abs(a),
             d = r1 + r2
         )
@@ -425,7 +425,7 @@ function circleIntersect2D(c1, r1, c2, r2) =
     )
    :h ? (
        let(
-           a = c2[0] - c1[0],
+           a = c2.x - c1.x,
            l = abs(a),
            d = r1 + r2
        )
@@ -446,21 +446,21 @@ function circleIntersect2D(c1, r1, c2, r2) =
    )
   :(
         let(
-            x12 = c1[0] * c1[0],
-            y12 = c1[1] * c1[1],
+            x12 = c1.x * c1.x,
+            y12 = c1.y * c1.y,
             r12 = r1 * r1,
-            a = (c2[0] * c2[0] + c2[1] * c2[1] - x12 - y12 + r12 - r2 * r2) / (2 * (c2[1] - c1[1])),
-            b = (c2[0] - c1[0]) / (c2[1] - c1[1]),
+            a = (c2.x * c2.x + c2.y * c2.y - x12 - y12 + r12 - r2 * r2) / (2 * (c2.y - c1.y)),
+            b = (c2.x - c1.x) / (c2.y - c1.y),
             x = quadraticEquation(
                 b * b + 1,
-                (-c1[0] + (c1[1] - a) * b) * 2,
-                (2 * -c1[1] + a) * a + x12 + y12 - r12
+                (-c1.x + (c1.y - a) * b) * 2,
+                (2 * -c1.y + a) * a + x12 + y12 - r12
             )
         )
         x ? (
             [
-                [x[0], a - x[0] * b],
-                [x[1], a - x[1] * b]
+                [x.x, a - x.x * b],
+                [x.y, a - x.y * b]
             ]
         )
        :[]
@@ -485,7 +485,7 @@ function isosceles2D(a, b, h, angle) =
         b = vector2D(b),
         v = b - a,
         d = norm2D(v) / 2,
-        w = getAngle(v[0], v[1])
+        w = getAngle(v.x, v.y)
     )
     h != undef ? (
         let(
@@ -520,7 +520,7 @@ function protractor(a, b) =
     let(
         v = vector2D(b) - vector2D(a)
     )
-    getAngle(v[0], v[1])
+    getAngle(v.x, v.y)
 ;
 
 /**
@@ -573,8 +573,8 @@ function vertexOutline2D(a, b, v, distance) =
         v = vector2D(v),
         a = vector2D(a) - v,
         b = vector2D(b) - v,
-        angleA = getAngle(a[0], a[1]),
-        angleB = getAngle(b[0], b[1]),
+        angleA = getAngle(a.x, a.y),
+        angleB = getAngle(b.x, b.y),
         angle = (angleB - angleA) / 2,
         length = float(distance) / divisor(abs(sin(angle)))
     )
@@ -643,8 +643,8 @@ function rotp(v, a) =
        a = float(a)
     )
     [
-        v[0] * cos(a) - v[1] * sin(a),
-        v[1] * cos(a) + v[0] * sin(a)
+        v.x * cos(a) - v.y * sin(a),
+        v.y * cos(a) + v.x * sin(a)
     ]
 ;
 
@@ -660,14 +660,14 @@ function mirp(v, a) =
    :let(
         v = vector2D(v),
         a = vector2D(a),
-        ax2 = a[0] * a[0],
-        ay2 = a[1] * a[1],
-        a2xy = 2 * a[0] * a[1],
+        ax2 = a.x * a.x,
+        ay2 = a.y * a.y,
+        a2xy = 2 * a.x * a.y,
         a2 = divisor(ax2 + ay2)
     )
     [
-        (ax2 * v[0] - ay2 * v[0] + a2xy * v[1]) / a2,
-        (ay2 * v[1] - ax2 * v[1] + a2xy * v[0]) / a2
+        (ax2 * v.x - ay2 * v.x + a2xy * v.y) / a2,
+        (ay2 * v.y - ax2 * v.y + a2xy * v.x) / a2
     ]
 ;
 
@@ -684,8 +684,8 @@ function arcp(r, a) =
         a = float(a)
     )
     [
-        r[0] * cos(a),
-        r[1] * sin(a)
+        r.x * cos(a),
+        r.y * sin(a)
     ]
 ;
 
@@ -728,8 +728,8 @@ function scale2D(points, factor) =
         factor = divisor2D(factor)
     )
     [ for (p = points) [
-        float(p[0]) * factor[0],
-        float(p[1]) * factor[1]
+        float(p.x) * factor.x,
+        float(p.y) * factor.y
     ] ]
 ;
 
@@ -754,14 +754,14 @@ function mirror2D(points, axis) =
     !is_list(points) || !len(points) ? []
    :let(
         a = undef == axis ? [0, 1] : vector2D(axis),
-        ax2 = a[0] * a[0],
-        ay2 = a[1] * a[1],
-        a2xy = 2 * a[0] * a[1],
+        ax2 = a.x * a.x,
+        ay2 = a.y * a.y,
+        a2xy = 2 * a.x * a.y,
         a2 = divisor(ax2 + ay2)
     )
     [ for(p = points) let( v = vector2D(p) ) [
-        (ax2 * v[0] - ay2 * v[0] + a2xy * v[1]) / a2,
-        (ay2 * v[1] - ax2 * v[1] + a2xy * v[0]) / a2
+        (ax2 * v.x - ay2 * v.x + a2xy * v.y) / a2,
+        (ay2 * v.y - ax2 * v.y + a2xy * v.x) / a2
     ] ]
 ;
 
@@ -780,8 +780,8 @@ function scaleFactor2D(points, size) =
         dim = dimensions2D(points)
     )
     [
-        size[0] / divisor(dim[0]),
-        size[1] / divisor(dim[1])
+        size.x / divisor(dim.x),
+        size.y / divisor(dim.y)
     ]
 ;
 
@@ -795,7 +795,7 @@ function dimensions2D(points) =
     let(
         b = boundaries2D(points)
     )
-    b[1] - b[0]
+    b.y - b.x
 ;
 
 /**
@@ -828,24 +828,24 @@ function boundaries2D(points,
                         pt4 = vector2D(points[p + 3])
                     )
                     [
-                        [ min(pt1[0], pt2[0], pt3[0], pt4[0]),
-                          min(pt1[1], pt2[1], pt3[1], pt4[1]) ],
-                        [ max(pt1[0], pt2[0], pt3[0], pt4[0]),
-                          max(pt1[1], pt2[1], pt3[1], pt4[1]) ]
+                        [ min(pt1.x, pt2.x, pt3.x, pt4.x),
+                          min(pt1.y, pt2.y, pt3.y, pt4.y) ],
+                        [ max(pt1.x, pt2.x, pt3.x, pt4.x),
+                          max(pt1.y, pt2.y, pt3.y, pt4.y) ]
                     ]
                 )
                :[
-                    [ min(pt1[0], pt2[0], pt3[0]),
-                      min(pt1[1], pt2[1], pt3[1]) ],
-                    [ max(pt1[0], pt2[0], pt3[0]),
-                      max(pt1[1], pt2[1], pt3[1]) ]
+                    [ min(pt1.x, pt2.x, pt3.x),
+                      min(pt1.y, pt2.y, pt3.y) ],
+                    [ max(pt1.x, pt2.x, pt3.x),
+                      max(pt1.y, pt2.y, pt3.y) ]
                 ]
             )
            :[
-                [ min(pt1[0], pt2[0]),
-                  min(pt1[1], pt2[1]) ],
-                [ max(pt1[0], pt2[0]),
-                  max(pt1[1], pt2[1]) ]
+                [ min(pt1.x, pt2.x),
+                  min(pt1.y, pt2.y) ],
+                [ max(pt1.x, pt2.x),
+                  max(pt1.y, pt2.y) ]
             ]
         )
        :[pt1, pt1]
@@ -856,9 +856,9 @@ function boundaries2D(points,
         right = boundaries2D(points, p + half, l - half)
     )
     [
-        [ min(left[0][0], right[0][0]),
-          min(left[0][1], right[0][1]) ],
-        [ max(left[1][0], right[1][0]),
-          max(left[1][1], right[1][1]) ]
+        [ min(left[0].x, right[0].x),
+          min(left[0].y, right[0].y) ],
+        [ max(left[1].x, right[1].x),
+          max(left[1].y, right[1].y) ]
     ]
 ;

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -42,7 +42,7 @@
  * @returns Vector - Always returns a 2D vector.
  */
 function vector2D(v) =
-    isNumber(v) ? [ v, v ]
+    is_num(v) ? [ v, v ]
    :[ float(v[0]), float(v[1]) ]
 ;
 
@@ -56,7 +56,7 @@ function vector2D(v) =
  * @returns Vector - Always returns a 2D vector that will not contain 0.
  */
 function divisor2D(v) =
-    isNumber(v) ? let( v = divisor(v) ) [ v, v ]
+    is_num(v) ? let( v = divisor(v) ) [ v, v ]
    :[ divisor(v[0]), divisor(v[1]) ]
 ;
 
@@ -75,7 +75,7 @@ function divisor2D(v) =
  */
 function apply2D(v, x, y, r, d) =
     let(
-        n = isNumber(v),
+        n = is_num(v),
         d = uor(d, r ? r * 2 : r),
         x = uor(x, d),
         y = uor(y, d)
@@ -97,7 +97,7 @@ function apply2D(v, x, y, r, d) =
  */
 function quadrant(v, i, x, y) =
     let(
-        n = isNumber(v),
+        n = is_num(v),
         i = integer(i) % 4,
         x = abs(float(uor(x, n ? v : v[0]))),
         y = abs(float(uor(y, n ? v : v[1])))
@@ -146,7 +146,7 @@ function unit2D(v) =
  * @returns Vector - Always returns a 2D vector.
  */
 function normal(v) =
-    isNumber(v) ? [ v, -v ]
+    is_num(v) ? [ v, -v ]
     :[ float(v[1]), -float(v[0]) ]
 ;
 
@@ -161,7 +161,7 @@ function normal(v) =
  * @returns Vector - Always returns a 2D vector.
  */
 function flip(v) =
-    isNumber(v) ? [ v, v ]
+    is_num(v) ? [ v, v ]
     :[ float(v[1]), float(v[0]) ]
 ;
 
@@ -637,7 +637,7 @@ function cosp(y, w, h, p, o) =
  * @returns Vector
  */
 function rotp(v, a) =
-    isUndef(v) || isUndef(a) ? [0, 0]
+    is_undef(v) || is_undef(a) ? [0, 0]
    :let( 
        v = vector2D(v),
        a = float(a)
@@ -656,7 +656,7 @@ function rotp(v, a) =
  * @returns Vector
  */
 function mirp(v, a) =
-    isUndef(v) || isUndef(a) ? [0, 0]
+    is_undef(v) || is_undef(a) ? [0, 0]
    :let(
         v = vector2D(v),
         a = vector2D(a),
@@ -708,7 +708,7 @@ function arcPoint(r, a, x, y) = arcp(apply2D(r, x, y), deg(a));
  * @returns Vector[]
  */
 function rotate2D(points, a) =
-    !isArray(points) || !len(points) ? []
+    !is_list(points) || !len(points) ? []
    :let(
         a = deg(a)
     )
@@ -723,7 +723,7 @@ function rotate2D(points, a) =
  * @returns Vector[]
  */
 function scale2D(points, factor) =
-    !isArray(points) || !len(points) ? []
+    !is_list(points) || !len(points) ? []
    :let(
         factor = divisor2D(factor)
     )
@@ -751,7 +751,7 @@ function resize2D(points, size) = scale2D(points, scaleFactor2D(points, size));
  * @returns Vector[]
  */
 function mirror2D(points, axis) =
-    !isArray(points) || !len(points) ? []
+    !is_list(points) || !len(points) ? []
    :let(
         a = undef == axis ? [0, 1] : vector2D(axis),
         ax2 = a[0] * a[0],

--- a/core/vector-3d.scad
+++ b/core/vector-3d.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -77,9 +77,10 @@ function divisor3D(value) =
 function apply3D(v, x, y, z, r, d) =
     let(
         n = isNumber(v),
-        x = uor(x, uor(d, r * 2)),
-        y = uor(y, uor(d, r * 2)),
-        z = uor(z, uor(d, r * 2))
+        d = uor(d, r ? r * 2 : r),
+        x = uor(x, d),
+        y = uor(y, d),
+        z = uor(z, d)
     )
     [
         float(uor(x, n ? v : v[0])),

--- a/core/vector-3d.scad
+++ b/core/vector-3d.scad
@@ -43,7 +43,7 @@
  */
 function vector3D(value) =
     is_num(value) ? [ value, value, value ]
-   :[ float(value[0]), float(value[1]), float(value[2]) ]
+   :[ float(value.x), float(value.y), float(value.z) ]
 ;
 
 /**
@@ -57,7 +57,7 @@ function vector3D(value) =
  */
 function divisor3D(value) =
     is_num(value) ? let( value = divisor(value) ) [ value, value, value ]
-   :[ divisor(value[0]), divisor(value[1]), divisor(value[2]) ]
+   :[ divisor(value.x), divisor(value.y), divisor(value.z) ]
 ;
 
 /**
@@ -83,9 +83,9 @@ function apply3D(v, x, y, z, r, d) =
         z = uor(z, d)
     )
     [
-        float(uor(x, n ? v : v[0])),
-        float(uor(y, n ? v : v[1])),
-        float(uor(z, n ? v : v[2]))
+        float(uor(x, n ? v : v.x)),
+        float(uor(y, n ? v : v.y)),
+        float(uor(z, n ? v : v.z))
     ]
 ;
 
@@ -187,9 +187,9 @@ function rotate3DX(v, a) =
     )
     !a ? v
    :[
-        v[0],
-        v[1] * cos(a) - v[2] * sin(a),
-        v[1] * sin(a) + v[2] * cos(a)
+        v.x,
+        v.y * cos(a) - v.z * sin(a),
+        v.y * sin(a) + v.z * cos(a)
     ]
 ;
 
@@ -207,9 +207,9 @@ function rotate3DY(v, a) =
     )
     !a ? v
    :[
-        v[2] * cos(a) - v[0] * sin(a),
-        v[1],
-        v[2] * sin(a) + v[0] * cos(a)
+        v.z * cos(a) - v.x * sin(a),
+        v.y,
+        v.z * sin(a) + v.x * cos(a)
     ]
 ;
 
@@ -227,9 +227,9 @@ function rotate3DZ(v, a) =
     )
     !a ? v
    :[
-        v[0] * cos(a) - v[1] * sin(a),
-        v[0] * sin(a) + v[1] * cos(a),
-        v[2]
+        v.x * cos(a) - v.y * sin(a),
+        v.x * sin(a) + v.y * cos(a),
+        v.z
     ]
 ;
 
@@ -248,9 +248,9 @@ function scaleFactor3D(points, size) =
         dim = dimensions3D(points)
     )
     [
-        size[0] / divisor(dim[0]),
-        size[1] / divisor(dim[1]),
-        size[2] / divisor(dim[2])
+        size.x / divisor(dim.x),
+        size.y / divisor(dim.y),
+        size.z / divisor(dim.z)
     ]
 ;
 
@@ -264,7 +264,7 @@ function dimensions3D(points) =
     let(
         b = boundaries3D(points)
     )
-    b[1] - b[0]
+    b.y - b.x
 ;
 
 /**
@@ -297,30 +297,30 @@ function boundaries3D(v,
                         pt4 = vector3D(v[p + 3])
                     )
                     [
-                        [ min(pt1[0], pt2[0], pt3[0], pt4[0]),
-                          min(pt1[1], pt2[1], pt3[1], pt4[1]),
-                          min(pt1[2], pt2[2], pt3[2], pt4[2]) ],
-                        [ max(pt1[0], pt2[0], pt3[0], pt4[0]),
-                          max(pt1[1], pt2[1], pt3[1], pt4[1]),
-                          max(pt1[2], pt2[2], pt3[2], pt4[2]) ]
+                        [ min(pt1.x, pt2.x, pt3.x, pt4.x),
+                          min(pt1.y, pt2.y, pt3.y, pt4.y),
+                          min(pt1.z, pt2.z, pt3.z, pt4.z) ],
+                        [ max(pt1.x, pt2.x, pt3.x, pt4.x),
+                          max(pt1.y, pt2.y, pt3.y, pt4.y),
+                          max(pt1.z, pt2.z, pt3.z, pt4.z) ]
                     ]
                 )
                :[
-                    [ min(pt1[0], pt2[0], pt3[0]),
-                      min(pt1[1], pt2[1], pt3[1]),
-                      min(pt1[2], pt2[2], pt3[2]) ],
-                    [ max(pt1[0], pt2[0], pt3[0]),
-                      max(pt1[1], pt2[1], pt3[1]),
-                      max(pt1[2], pt2[2], pt3[2]) ]
+                    [ min(pt1.x, pt2.x, pt3.x),
+                      min(pt1.y, pt2.y, pt3.y),
+                      min(pt1.z, pt2.z, pt3.z) ],
+                    [ max(pt1.x, pt2.x, pt3.x),
+                      max(pt1.y, pt2.y, pt3.y),
+                      max(pt1.z, pt2.z, pt3.z) ]
                 ]
             )
            :[
-                [ min(pt1[0], pt2[0]),
-                  min(pt1[1], pt2[1]),
-                  min(pt1[2], pt2[2]) ],
-                [ max(pt1[0], pt2[0]),
-                  max(pt1[1], pt2[1]),
-                  max(pt1[2], pt2[2]) ]
+                [ min(pt1.x, pt2.x),
+                  min(pt1.y, pt2.y),
+                  min(pt1.z, pt2.z) ],
+                [ max(pt1.x, pt2.x),
+                  max(pt1.y, pt2.y),
+                  max(pt1.z, pt2.z) ]
             ]
         )
        :[pt1, pt1]
@@ -331,11 +331,11 @@ function boundaries3D(v,
         right = boundaries3D(v, p + half, l - half)
     )
     [
-        [ min(left[0][0], right[0][0]),
-          min(left[0][1], right[0][1]),
-          min(left[0][2], right[0][2]) ],
-        [ max(left[1][0], right[1][0]),
-          max(left[1][1], right[1][1]),
-          max(left[1][2], right[1][2]) ]
+        [ min(left[0].x, right[0].x),
+          min(left[0].y, right[0].y),
+          min(left[0].z, right[0].z) ],
+        [ max(left[1].x, right[1].x),
+          max(left[1].y, right[1].y),
+          max(left[1].z, right[1].z) ]
     ]
 ;

--- a/core/vector-3d.scad
+++ b/core/vector-3d.scad
@@ -42,7 +42,7 @@
  * @returns Vector - Always returns a 3D vector.
  */
 function vector3D(value) =
-    isNumber(value) ? [ value, value, value ]
+    is_num(value) ? [ value, value, value ]
    :[ float(value[0]), float(value[1]), float(value[2]) ]
 ;
 
@@ -56,7 +56,7 @@ function vector3D(value) =
  * @returns Vector - Always returns a 3D vector that will not contain 0.
  */
 function divisor3D(value) =
-    isNumber(value) ? let( value = divisor(value) ) [ value, value, value ]
+    is_num(value) ? let( value = divisor(value) ) [ value, value, value ]
    :[ divisor(value[0]), divisor(value[1]), divisor(value[2]) ]
 ;
 
@@ -76,7 +76,7 @@ function divisor3D(value) =
  */
 function apply3D(v, x, y, z, r, d) =
     let(
-        n = isNumber(v),
+        n = is_num(v),
         d = uor(d, r ? r * 2 : r),
         x = uor(x, d),
         y = uor(y, d),

--- a/core/vector.scad
+++ b/core/vector.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -216,7 +216,7 @@ function vfactorial(n,
                     // internal
                     i=0, fact=1) =
     let(
-        isnum = isNumber(n),
+        isnum = is_num(n),
         n = isnum ? n : 0,
         fact = fact * or(i, 1)
     )
@@ -231,7 +231,7 @@ function vfactorial(n,
  * @returns Vector
  */
 function vfactor(v) =
-    !isArray(v) ? (v ? 1 : -1)
+    !is_list(v) ? (v ? 1 : -1)
    :len(v) == 0 ? v
    :[ for (b = v) b ? 1 : -1 ]
 ;
@@ -248,7 +248,7 @@ function vboolean(a, bool) =
         t = bool ? true : 1,
         f = bool ? false : 0
     )
-    !isArray(a) ? (a ? t : f)
+    !is_list(a) ? (a ? t : f)
     :len(a) == 0 ? a
     :[ for (b = a) b ? t : f ]
 ;

--- a/core/version.scad
+++ b/core/version.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +42,7 @@ CAMEL_SCAD_VERSION = [0, 14, 1];
  * The minimal version of OpenSCAD required by the library.
  * @type Vector
  */
-REQUIRED_OPEN_SCAD_VERSION = [2015, 3, 0];
+REQUIRED_OPEN_SCAD_VERSION = [2019, 5, 0];
 
 /**
  * Gets the version of the library.

--- a/operator/extrude/negative.scad
+++ b/operator/extrude/negative.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,8 +54,8 @@ module negativeExtrude(height, direction, center, convexity, twist, slices, scal
     convexity = numberOr(convexity, 10);
     height = align(value=height, direction=direction, center=center);
 
-    translateZ(height[1]) {
-        linear_extrude(height=height[0], center=center, convexity=convexity, twist=twist, slices=slices, scale=scale) {
+    translateZ(height.y) {
+        linear_extrude(height=height.x, center=center, convexity=convexity, twist=twist, slices=slices, scale=scale) {
             children();
         }
     }

--- a/operator/repeat/translate.scad
+++ b/operator/repeat/translate.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -121,10 +121,10 @@ module repeatShape2D(size, count = 1, center) {
     count = vector2D(count);
 
     repeat2D(
-        countX = count[0],
-        countY = count[1],
-        intervalX = [size[0], 0, 0],
-        intervalY = [0, size[1], 0],
+        countX = count.x,
+        countY = count.y,
+        intervalX = [size.x, 0, 0],
+        intervalY = [0, size.y, 0],
         center = center
     ) {
         children();
@@ -142,12 +142,12 @@ module repeatShape3D(size, count = 1, center) {
     count = vector3D(count);
 
     repeat3D(
-        countX = count[0],
-        countY = count[1],
-        countZ = count[2],
-        intervalX = [size[0], 0, 0],
-        intervalY = [0, size[1], 0],
-        intervalZ = [0, 0, size[2]],
+        countX = count.x,
+        countY = count.y,
+        countZ = count.z,
+        intervalX = [size.x, 0, 0],
+        intervalY = [0, size.y, 0],
+        intervalZ = [0, 0, size.z],
         center = center
     ) {
         children();

--- a/samples/heart.scad
+++ b/samples/heart.scad
@@ -47,7 +47,7 @@ applyMode(renderMode) {
             }
 
             // Heart
-            translateY(-size[1] / 2) {
+            translateY(-size.y / 2) {
                 polygon(
                     points=points
                 );
@@ -55,7 +55,7 @@ applyMode(renderMode) {
         }
 
         // Displays the control points to illustrate how the curve is constrained
-        translate([0, -size[1] / 2, height]) {
+        translate([0, -size.y / 2, height]) {
             controlPoints(controls, size=2);
         }
         buildPlate(center=true);

--- a/samples/honeycombed.scad
+++ b/samples/honeycombed.scad
@@ -20,9 +20,9 @@ include <../core/constants.scad>
 module honeycomb(size, thickness) {
     // Adjust the values to get usable size and thickness
     size = vector3D(size);
-    width = min(size[0], size[1]);
+    width = min(size.x, size.y);
     thickness = min(numberOr(thickness, 1), width / 10);
-    adjust = max(size[0], size[1]) - width;
+    adjust = max(size.x, size.y) - width;
     innerWidth = width - thickness * 2;
 
     difference() {

--- a/samples/simple-box.scad
+++ b/samples/simple-box.scad
@@ -21,15 +21,15 @@ include <../core/constants.scad>
 module simpleBox(size, thickness, radius) {
     // Adjust the values to get usable size, thickness, and rounded corner radius
     size = vector3D(size);
-    lowest = min(size[0], size[1]) / 10;
+    lowest = min(size.x, size.y) / 10;
     thickness = min(numberOr(thickness, 1), lowest);
     radius = numberOr(radius, lowest);
 
     // Compute the size and position of the handle hole
-    handleRadius = size[0] + size[1];
+    handleRadius = size.x + size.y;
     handleCenter = center2D(
-        a=apply2D(x=-size[0] / 2 + radius, y=size[2]),
-        b=apply2D(x=size[0] / 2 - radius, y=size[2]),
+        a=apply2D(x=-size.x / 2 + radius, y=size.z),
+        b=apply2D(x=size.x / 2 - radius, y=size.z),
         r=handleRadius,
         negative=true
     );
@@ -40,13 +40,13 @@ module simpleBox(size, thickness, radius) {
 
         // This is the inside of the box
         translateZ(thickness) {
-            cushion(size=apply3D(size, x=size[0] - thickness * 2, y=size[1] - thickness * 2), r=radius-thickness/2);
+            cushion(size=apply3D(size, x=size.x - thickness * 2, y=size.y - thickness * 2), r=radius-thickness/2);
         }
 
         // This is the handle hole
         rotateX(90) {
             translate(vector3D(handleCenter)) {
-                cylinder(r=handleRadius, h=size[1] + 1, center=true);
+                cylinder(r=handleRadius, h=size.y + 1, center=true);
             }
         }
     }

--- a/scripts/parse-test.awk
+++ b/scripts/parse-test.awk
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2017 Jean-Sebastien CONAN
+# Copyright (c) 2017-2022 Jean-Sebastien CONAN
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -192,7 +192,22 @@ END {
                 printf("%s- %s\n", RED, failedAssertsMessage[i])
             }
             if (failedAssertsDetails[i]) {
-                printf("    %s\n", failedAssertsDetails[i])
+                details = failedAssertsDetails[i];
+                while(match(details, /\{([^:]+):\s?([^\}]+)\}/) != 0) {
+                    if (RSTART > 0) {
+                        detailsPrefix = substr(details, 0, RSTART - 1)
+                    } else {
+                        detailsPrefix = ""
+                    }
+                    detailsBody = substr(details, RSTART + 1, RLENGTH - 2)
+                    detailsSuffix = substr(details, RSTART + RLENGTH)
+
+                    if (match(detailsBody, /[a-z]+:/) != 0) {
+                        detailsBody = sprintf("%s%s%s%s", CYAN, substr(detailsBody, RSTART, RLENGTH), BROWN, substr(detailsBody, RSTART + RLENGTH)) 
+                    }
+                    details = sprintf("%s    %s\n%s", detailsPrefix, detailsBody, detailsSuffix) 
+                }
+                printf("%s", details)
             }
             printf("\n")
         }

--- a/scripts/utils/scad.sh
+++ b/scripts/utils/scad.sh
@@ -2,7 +2,7 @@
 #
 # GPLv3 License
 #
-# Copyright (c) 2019-2020 Jean-Sebastien CONAN
+# Copyright (c) 2019-2022 Jean-Sebastien CONAN
 #
 # This file is part of jsconan/things.
 #
@@ -36,7 +36,7 @@
 export scadcmd="openscad"
 
 # Defines the minimal required version for OpenSCAD
-export scadver="2015.03"
+export scadver="2019.05"
 
 # Defines the file extension for OpenSCAD files
 export scadext="scad"

--- a/shape/2D/ellipse.scad
+++ b/shape/2D/ellipse.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,8 +50,8 @@ function sizeEllipse(r, d, rx, ry, dx, dy) =
     )
     [
         // use divisor() to ensure the values will be forced to anything but 0
-        divisor(d[0] && !rx ? d[0] / 2 : r[0]),
-        divisor(d[1] && !ry ? d[1] / 2 : r[1])
+        divisor(d.x && !rx ? d.x / 2 : r.x),
+        divisor(d.y && !ry ? d.y / 2 : r.y)
     ]
 ;
 
@@ -74,8 +74,8 @@ function sizeRing(r, w, d, rx, ry, dx, dy, wx, wy) =
         out = sizeEllipse(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         w = apply2D(w, wx, wy),
         in = [
-            max(min(out[0], out[0] - w[0]), 0),
-            max(min(out[1], out[1] - w[1]), 0)
+            max(min(out.x, out.x - w.x), 0),
+            max(min(out.y, out.y - w.y), 0)
         ]
     )
     [ out, in ]
@@ -198,8 +198,8 @@ module chord(r, a=RIGHT, d, a1, a2, rx, ry, dx, dy) {
 module ring(r, w, d, rx, ry, dx, dy, wx, wy) {
     size = sizeRing(r=r, w=w, d=d, rx=rx, ry=ry, dx=dx, dy=dy, wx=wx, wy=wy);
     difference() {
-        ellipse(r=size[0]);
-        ellipse(r=size[1]);
+        ellipse(r=size.x);
+        ellipse(r=size.y);
     }
 }
 
@@ -223,8 +223,8 @@ module ringSegment(r, w, a=RIGHT, d, a1, a2, rx, ry, dx, dy, wx, wy) {
     size = sizeRing(r=r, w=w, d=d, rx=rx, ry=ry, dx=dx, dy=dy, wx=wx, wy=wy);
     polygon(
         points = concat(
-            arc(r=size[0], a=a, a1=a1, a2=a2),
-            reverse(arc(r=size[1], a=a, a1=a1, a2=a2))
+            arc(r=size.x, a=a, a1=a1, a2=a2),
+            reverse(arc(r=size.y, a=a, a1=a1, a2=a2))
         ),
         convexity = 10
     );

--- a/shape/2D/polygon.scad
+++ b/shape/2D/polygon.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,8 +45,8 @@ function sizeRectangle(size, l, w) =
         size = apply2D(size, l, w)
     )
     [
-        divisor(size[0]),
-        divisor(size[1])
+        divisor(size.x),
+        divisor(size.y)
     ]
 ;
 
@@ -66,15 +66,15 @@ function sizeChamferedRectangle(size, chamfer, l, w, cl, cw) =
         s = apply2D(size, l, w),
         c = apply2D(chamfer, cl, cw),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[1] * 2)
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.y * 2)
         ],
         chamfer = [
-            min(size[0] / 2, c[0]),
-            min(size[1] / 2, c[1])
+            min(size.x / 2, c.x),
+            min(size.y / 2, c.y)
         ]
     )
-    [ size, chamfer[0] && chamfer[1] ? chamfer : [0, 0] ]
+    [ size, chamfer.x && chamfer.y ? chamfer : [0, 0] ]
 ;
 
 /**
@@ -91,9 +91,9 @@ function sizeTrapezium(size, a, b, w) =
         size = apply3D(size, a, b, w)
     )
     [
-        divisor(size[0]),
-        divisor(size[1]),
-        divisor(size[2])
+        divisor(size.x),
+        divisor(size.y),
+        divisor(size.z)
     ]
 ;
 
@@ -114,8 +114,8 @@ function sizeRegularPolygon(size, n, l, w, s) =
                                         : apply2D(size, l, w)
     )
     [
-        divisor(size[0]),
-        divisor(size[1]),
+        divisor(size.x),
+        divisor(size.y),
         n
     ]
 ;
@@ -180,10 +180,10 @@ function drawRectangle(size, l, w) =
         size = sizeRectangle(size=size, l=l, w=w) / 2
     )
     [
-        [ size[0],  size[1]],
-        [-size[0],  size[1]],
-        [-size[0], -size[1]],
-        [ size[0], -size[1]]
+        [ size.x,  size.y],
+        [-size.x,  size.y],
+        [-size.x, -size.y],
+        [ size.x, -size.y]
     ]
 ;
 
@@ -204,22 +204,22 @@ function drawChamferedRectangle(size, chamfer, l, w, cl, cw) =
         size = specs[0] / 2,
         chamfer = specs[1]
     )
-    chamfer[0]
+    chamfer.x
    ?[
-        [ size[0],  size[1] - chamfer[1]],
-        [ size[0] - chamfer[0],  size[1]],
-        [-size[0] + chamfer[0],  size[1]],
-        [-size[0],  size[1] - chamfer[1]],
-        [-size[0], -size[1] + chamfer[1]],
-        [-size[0] + chamfer[0], -size[1]],
-        [ size[0] - chamfer[0], -size[1]],
-        [ size[0], -size[1] + chamfer[1]]
+        [ size.x,  size.y - chamfer.y],
+        [ size.x - chamfer.x,  size.y],
+        [-size.x + chamfer.x,  size.y],
+        [-size.x,  size.y - chamfer.y],
+        [-size.x, -size.y + chamfer.y],
+        [-size.x + chamfer.x, -size.y],
+        [ size.x - chamfer.x, -size.y],
+        [ size.x, -size.y + chamfer.y]
     ]
    :[
-        [ size[0],  size[1]],
-        [-size[0],  size[1]],
-        [-size[0], -size[1]],
-        [ size[0], -size[1]]
+        [ size.x,  size.y],
+        [-size.x,  size.y],
+        [-size.x, -size.y],
+        [ size.x, -size.y]
     ]
 ;
 
@@ -237,10 +237,10 @@ function drawTrapezium(size, a, b, w) =
         size = sizeTrapezium(size=size, a=a, b=b, w=w) / 2
     )
     [
-        [ size[1],  size[2]],
-        [-size[1],  size[2]],
-        [-size[0], -size[2]],
-        [ size[0], -size[2]]
+        [ size.y,  size.z],
+        [-size.y,  size.z],
+        [-size.x, -size.z],
+        [ size.x, -size.z]
     ]
 ;
 
@@ -336,8 +336,8 @@ function drawStar(size, core, edges, l, w, cl, cw) =
                 a = angle * e + (m ? step : 0) + RIGHT
             )
             [
-                cos(a) * (m ? inner[0] : outer[0]),
-                sin(a) * (m ? inner[1] : outer[1])
+                cos(a) * (m ? inner.x : outer.x),
+                sin(a) * (m ? inner.y : outer.y)
             ]
     ]
 ;
@@ -361,24 +361,24 @@ function drawCross(size, core, l, w, cl, cw) =
     )
     inner == [0, 0] ?
     [
-        [ outer[0],  outer[1]],
-        [-outer[0],  outer[1]],
-        [-outer[0], -outer[1]],
-        [ outer[0], -outer[1]]
+        [ outer.x,  outer.y],
+        [-outer.x,  outer.y],
+        [-outer.x, -outer.y],
+        [ outer.x, -outer.y]
     ]
    :[
-        [ inner[0],  inner[1]],
-        [ inner[0],  outer[1]],
-        [-inner[0],  outer[1]],
-        [-inner[0],  inner[1]],
-        [-outer[0],  inner[1]],
-        [-outer[0], -inner[1]],
-        [-inner[0], -inner[1]],
-        [-inner[0], -outer[1]],
-        [ inner[0], -outer[1]],
-        [ inner[0], -inner[1]],
-        [ outer[0], -inner[1]],
-        [ outer[0],  inner[1]]
+        [ inner.x,  inner.y],
+        [ inner.x,  outer.y],
+        [-inner.x,  outer.y],
+        [-inner.x,  inner.y],
+        [-outer.x,  inner.y],
+        [-outer.x, -inner.y],
+        [-inner.x, -inner.y],
+        [-inner.x, -outer.y],
+        [ inner.x, -outer.y],
+        [ inner.x, -inner.y],
+        [ outer.x, -inner.y],
+        [ outer.x,  inner.y]
     ]
 ;
 

--- a/shape/2D/rounded.scad
+++ b/shape/2D/rounded.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2018 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,8 +49,8 @@ function sizeRounded2D(r, d, rx, ry, dx, dy) =
         d = apply2D(d, dx, dy)
     )
     [
-        d[0] && !rx ? d[0] / 2 : r[0],
-        d[1] && !ry ? d[1] / 2 : r[1]
+        d.x && !rx ? d.x / 2 : r.x,
+        d.y && !ry ? d.y / 2 : r.y
     ]
 ;
 
@@ -73,13 +73,13 @@ function sizeArch(size, r, d, w, h, rx, ry, dx, dy) =
         s = apply2D(size, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[1])
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.y)
         ],
-        horRadius = size[0] / 2,
+        horRadius = size.x / 2,
         radius = [
             horRadius,
-            min(size[1], or(c[1], horRadius))
+            min(size.y, or(c.y, horRadius))
         ]
     )
     [ size, radius ]
@@ -104,13 +104,13 @@ function sizeStadium(size, r, d, w, h, rx, ry, dx, dy) =
         s = apply2D(size, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[1] * 2)
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.y * 2)
         ],
-        horRadius = size[0] / 2,
+        horRadius = size.x / 2,
         radius = [
             horRadius,
-            min(size[1] / 2, or(c[1], horRadius))
+            min(size.y / 2, or(c.y, horRadius))
         ]
     )
     [ size, radius ]
@@ -135,15 +135,15 @@ function sizeRoundedRectangle(size, r, d, w, h, rx, ry, dx, dy) =
         s = apply2D(size, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[1] * 2)
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.y * 2)
         ],
         radius = [
-            min(size[0] / 2, c[0]),
-            min(size[1] / 2, c[1])
+            min(size.x / 2, c.x),
+            min(size.y / 2, c.y)
         ]
     )
-    [ size, radius[0] && radius[1] ? radius : [0, 0] ]
+    [ size, radius.x && radius.y ? radius : [0, 0] ]
 ;
 
 /**
@@ -161,8 +161,8 @@ function sizeRoundedCorner(size, r, d, p, convex) =
         r = d && !r ? float(d) / 2 : float(r),
         s = divisor(size ? size : r),
         p = let(p = cardinal(p)) [
-            p[0] >= 0 ? 1 : -1,
-            p[1] >= 0 ? 1 : -1
+            p.x >= 0 ? 1 : -1,
+            p.y >= 0 ? 1 : -1
         ],
         R = max(s, r),
         S = (s == R),
@@ -171,7 +171,7 @@ function sizeRoundedCorner(size, r, d, p, convex) =
         C = S ? (convex ? [0, 0] : [ s, s ])
               : center2D(A, B, R, !convex),
         arcAngle = S ? RIGHT : angle2D(C - A, C - B),
-        cornerAngle = absdeg(round(atan2(p[1], p[0]) - 45)),
+        cornerAngle = absdeg(round(atan2(p.y, p.x) - 45)),
         startAngle = absdeg(cornerAngle + (convex ? 0 : STRAIGHT) + (RIGHT - arcAngle) / 2)
     )
     [ vector2D(s), vector2D(R), rotp(C, cornerAngle), cornerAngle, startAngle, arcAngle ]
@@ -218,12 +218,12 @@ function drawArch(size, r, d, w, h, rx, ry, dx, dy) =
         size = specs[0],
         radius = specs[1],
         center = [
-            0, size[1] - radius[1]
+            0, size.y - radius.y
         ],
         points = arc(r=radius, o=center, a=STRAIGHT)
     )
     center == [0, 0] ? points
-   :complete(points, [radius[0], 0], -[radius[0], 0])
+   :complete(points, [radius.x, 0], -[radius.x, 0])
 ;
 
 /**
@@ -246,7 +246,7 @@ function drawStadium(size, r, d, w, h, rx, ry, dx, dy) =
         size = specs[0],
         radius = specs[1],
         center = [
-            0, size[1] / 2 - radius[1]
+            0, size.y / 2 - radius.y
         ]
     )
     center == [0, 0] ? arc(r=radius)
@@ -272,20 +272,20 @@ function drawRoundedRectangle(size, r, d, w, h, rx, ry, dx, dy) =
         specs = sizeRoundedRectangle(size=size, r=r, d=d, w=w, h=h, rx=rx, ry=ry, dx=dx, dy=dy),
         size = specs[0],
         radius = specs[1],
-        right = size[0] / 2,
-        top = size[1] / 2,
+        right = size.x / 2,
+        top = size.y / 2,
         center = [
-            right - radius[0],
-            top - radius[1]
+            right - radius.x,
+            top - radius.y
         ]
     )
     radius == [0, 0] ? [ [right, top], [-right, top], [-right, -top], [right, -top] ]
    :center == [0, 0] ? arc(r=radius)
    :concat(
        arc(r=radius, o=center, a1=0, a2=QUADRANT_1),
-       arc(r=radius, o=[-center[0], center[1]], a1=QUADRANT_1, a2=QUADRANT_2),
-       arc(r=radius, o=[-center[0], -center[1]], a1=QUADRANT_2, a2=QUADRANT_3),
-       arc(r=radius, o=[center[0], -center[1]], a1=QUADRANT_3, a2=QUADRANT_4)
+       arc(r=radius, o=[-center.x, center.y], a1=QUADRANT_1, a2=QUADRANT_2),
+       arc(r=radius, o=[-center.x, -center.y], a1=QUADRANT_2, a2=QUADRANT_3),
+       arc(r=radius, o=[center.x, -center.y], a1=QUADRANT_3, a2=QUADRANT_4)
    )
 ;
 
@@ -307,9 +307,9 @@ function drawRoundedCorner(size, r, d, p, convex, adjust) =
         size = specs[0],
         adjust = number(adjust),
         frame = adjust ? [
-            rotp(convex ? [-adjust, size[1]] : [size[0], -adjust], specs[3]),
+            rotp(convex ? [-adjust, size.y] : [size.x, -adjust], specs[3]),
             rotp([-adjust, -adjust], specs[3]),
-            rotp(convex ? [size[0], -adjust] : [-adjust, size[1]], specs[3])
+            rotp(convex ? [size.x, -adjust] : [-adjust, size.y], specs[3])
         ]
        :[ [0, 0] ]
     )
@@ -337,16 +337,16 @@ function drawLinkProfile(neck, bulb, w, h, rx, ry, dx, dy, distance = 0) =
         neck = size[0],
         bulb = size[1],
         startX = ALIGN,
-        startY = neck[1] / 2
+        startY = neck.y / 2
     )
     outline(
         points = path([
             ["P", startX, startY],
-            ["H", -neck[0] - startX],
+            ["H", -neck.x - startX],
             ["C", bulb, 0, 180],
-            ["V", -neck[1]],
+            ["V", -neck.y],
             ["C", bulb, 180, 360],
-            ["H", neck[0] + startX],
+            ["H", neck.x + startX],
         ]),
         distance = distance
     )

--- a/shape/3D/ellipsoid.scad
+++ b/shape/3D/ellipsoid.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,9 +52,9 @@ function sizeEllipsoid(r, d, rx, ry, rz, dx, dy, dz) =
     )
     [
         // use divisor() to ensure the values will be forced to anything but 0
-        divisor(d[0] && !rx ? d[0] / 2 : r[0]),
-        divisor(d[1] && !ry ? d[1] / 2 : r[1]),
-        divisor(d[2] && !rz ? d[2] / 2 : r[2])
+        divisor(d.x && !rx ? d.x / 2 : r.x),
+        divisor(d.y && !ry ? d.y / 2 : r.y),
+        divisor(d.z && !rz ? d.z / 2 : r.z)
     ]
 ;
 
@@ -72,7 +72,7 @@ function sizeEllipsoid(r, d, rx, ry, rz, dx, dy, dz) =
  */
 module shaft(r, h, d, rx, ry, dx, dy, center) {
     size = sizeEllipsoid(r=r, d=d, rx=rx, ry=ry, rz=h, dx=dx, dy=dy);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         ellipse(size);
     }
 }
@@ -94,7 +94,7 @@ module shaft(r, h, d, rx, ry, dx, dy, center) {
  */
 module wedge(r, h, a=90, d, a1, a2, rx, ry, dx, dy, center) {
     size = sizeEllipsoid(r=r, d=d, rx=rx, ry=ry, rz=h, dx=dx, dy=dy);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         pie(size, a=a, a1=a1, a2=a2);
     }
 }
@@ -136,7 +136,7 @@ module ellipsoid(r, d, rx, ry, rz, dx, dy, dz) {
  */
 module pipe(r, h, w=0.1, d, rx, ry, dx, dy, wx, wy, center) {
     size = sizeEllipsoid(r=r, d=d, rx=rx, ry=ry, rz=h, dx=dx, dy=dy);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         ring(r=size, w=w, wx=wx, wy=wy);
     }
 }
@@ -158,7 +158,7 @@ module pipe(r, h, w=0.1, d, rx, ry, dx, dy, wx, wy, center) {
  */
 module pipeSegment(r, h, w=0.1, a=90, d, a1, a2, rx, ry, dx, dy, wx, wy, center) {
     size = sizeEllipsoid(r=r, d=d, rx=rx, ry=ry, rz=h, dx=dx, dy=dy);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         ringSegment(r=size, a=a, a1=a1, a2=a2, w=w, wx=wx, wy=wy);
     }
 }
@@ -185,10 +185,10 @@ module torus(r, w=0.1, d, W, rx, ry, dx, dy, wx, wy, Wx, Wy, center) {
     sizeRing = sizeEllipse(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy);
     sizePipe = sizeEllipse(r=w, d=W, rx=wx, ry=wy, dx=Wx, dy=Wy);
 
-    translate([0, 0, center ? 0 : sizePipe[1]]) {
-        resize(apply3D(vadd(sizeRing, sizePipe[0]), z=sizePipe[1]) * 2) {
+    translate([0, 0, center ? 0 : sizePipe.y]) {
+        resize(apply3D(vadd(sizeRing, sizePipe.x), z=sizePipe.y) * 2) {
             rotate_extrude(convexity=10) {
-                translate([max(sizeRing) - sizePipe[0], 0, 0]) {
+                translate([max(sizeRing) - sizePipe.x, 0, 0]) {
                     ellipse(sizePipe);
                 }
             }

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -46,9 +46,9 @@ function sizeBox(size, l, w, h) =
         size = apply3D(size, l, w, h)
     )
     [
-        divisor(size[0]),
-        divisor(size[1]),
-        divisor(size[2])
+        divisor(size.x),
+        divisor(size.y),
+        divisor(size.z)
     ]
 ;
 
@@ -69,16 +69,16 @@ function sizeChamferedBox(size, chamfer, l, w, h, cl, cw) =
         s = apply3D(size, l, w, h),
         c = apply2D(chamfer, cl, cw),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[1] * 2),
-            divisor(s[2])
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.y * 2),
+            divisor(s.z)
         ],
         chamfer = [
-            min(size[0] / 2, c[0]),
-            min(size[1] / 2, c[1])
+            min(size.x / 2, c.x),
+            min(size.y / 2, c.y)
         ]
     )
-    [ size, chamfer[0] && chamfer[1] ? chamfer : [0, 0] ]
+    [ size, chamfer.x && chamfer.y ? chamfer : [0, 0] ]
 ;
 
 /**
@@ -97,9 +97,9 @@ function sizeTrapeziumBox(size, a, b, w, h) =
         size = apply3D(size, a, b, w)
     )
     [
-        divisor(size[0]),
-        divisor(size[1]),
-        divisor(size[2]),
+        divisor(size.x),
+        divisor(size.y),
+        divisor(size.z),
         divisor(h)
     ]
 ;
@@ -122,9 +122,9 @@ function sizeRegularPolygonBox(size, n, l, w, h, s) =
                                         : apply3D(size, l, w, h)
     )
     [
-        divisor(size[0]),
-        divisor(size[1]),
-        divisor(size[2]),
+        divisor(size.x),
+        divisor(size.y),
+        divisor(size.z),
         n
     ]
 ;
@@ -189,7 +189,7 @@ function sizeCrossBox(size, core, l, w, h, cl, cw) =
  */
 module box(size, l, w, h, center) {
     size = sizeBox(size=size, l=l, w=w, h=h);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         rectangle(size);
     }
 }
@@ -208,7 +208,7 @@ module box(size, l, w, h, center) {
  */
 module chamferedBox(size, chamfer, l, w, h, cl, cw, center) {
     size = sizeBox(size=size, chamfer=chamfer, l=l, w=w, h=h, cl=cl, cw=cw);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         chamferedRectangle(size, chamfer);
     }
 }
@@ -243,7 +243,7 @@ module trapeziumBox(size, a, b, w, h, center) {
  */
 module regularPolygonBox(size, n, l, w, h, s, center) {
     size = sizeRegularPolygonBox(size=size, n=n, l=l, w=w, h=h, s=s);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         regularPolygon(size, size[3]);
     }
 }
@@ -262,7 +262,7 @@ module regularPolygonBox(size, n, l, w, h, s, center) {
  */
 module hexagonBox(size, pointy, adjust, l, w, h, s, center) {
     size = sizeRegularPolygonBox(size=size, n=6, l=l, w=w, h=h, s=s);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         hexagon(size=size, pointy=pointy, adjust=adjust);
     }
 }
@@ -282,7 +282,7 @@ module hexagonBox(size, pointy, adjust, l, w, h, s, center) {
  */
 module starBox(size, core, edges, l, w, h, cl, cw, center) {
     size = sizeStarBox(size=size, core=core, edges=edges, l=l, w=w, h=h, cl=cl, cw=cw);
-    linear_extrude(height=size[0][2], center=center, convexity=10) {
+    linear_extrude(height=size[0].z, center=center, convexity=10) {
         star(size[0], size[1], size[2]);
     }
 }
@@ -301,7 +301,7 @@ module starBox(size, core, edges, l, w, h, cl, cw, center) {
  */
 module regularCrossBox(size, core, l, w, h, cl, cw, center) {
     size = sizeCrossBox(size=size, core=core, l=l, w=w, h=h, cl=cl, cw=cw);
-    linear_extrude(height=size[0][2], center=center, convexity=10) {
+    linear_extrude(height=size[0].z, center=center, convexity=10) {
         regularCross(size[0], size[1]);
     }
 }
@@ -326,7 +326,7 @@ module regularCrossBox(size, core, l, w, h, cl, cw, center) {
  */
 module meshBox(size, count, gap, pointy, linear, even, l, w, h, cx, cy, gx, gy, center) {
     size = apply3D(size, l, w, h);
-    linear_extrude(height=size[2], center=center, convexity=10) {
+    linear_extrude(height=size.z, center=center, convexity=10) {
         mesh(size=size, count=count, gap=gap, pointy=pointy, linear=linear, even=even, cx=cx, cy=cy, gx=gx, gy=gy);
     }
 }

--- a/shape/3D/polyhedron.scad
+++ b/shape/3D/polyhedron.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -93,7 +93,7 @@ function sizeChamferedBox(size, chamfer, l, w, h, cl, cw) =
  */
 function sizeTrapeziumBox(size, a, b, w, h) =
     let(
-        h = uor(h, isNumber(size) ? size : size[3]),
+        h = uor(h, is_num(size) ? size : size[3]),
         size = apply3D(size, a, b, w)
     )
     [

--- a/shape/3D/rounded.scad
+++ b/shape/3D/rounded.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,9 +51,9 @@ function sizeRounded3D(r, d, rx, ry, rz, dx, dy, dz) =
         d = apply3D(d, dx, dy, dz)
     )
     [
-        d[0] && !rx ? d[0] / 2 : r[0],
-        d[1] && !ry ? d[1] / 2 : r[1],
-        d[2] && !rz ? d[2] / 2 : r[2]
+        d.x && !rx ? d.x / 2 : r.x,
+        d.y && !ry ? d.y / 2 : r.y,
+        d.z && !rz ? d.z / 2 : r.z
     ]
 ;
 
@@ -77,14 +77,14 @@ function sizeArchBox(size, r, d, l, w, h, rx, ry, dx, dy) =
         s = apply3D(size, l, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[1]),
-            divisor(s[2])
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.y),
+            divisor(s.z)
         ],
-        horRadius = size[0] / 2,
+        horRadius = size.x / 2,
         radius = [
             horRadius,
-            min(size[1], or(c[1], horRadius))
+            min(size.y, or(c.y, horRadius))
         ]
     )
     [ size, radius ]
@@ -110,14 +110,14 @@ function sizeSlot(size, r, d, l, w, h, rx, ry, dx, dy) =
         s = apply3D(size, l, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[1] * 2),
-            divisor(s[2])
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.y * 2),
+            divisor(s.z)
         ],
-        horRadius = size[0] / 2,
+        horRadius = size.x / 2,
         radius = [
             horRadius,
-            min(size[1] / 2, or(c[1], horRadius))
+            min(size.y / 2, or(c.y, horRadius))
         ]
     )
     [ size, radius ]
@@ -143,16 +143,16 @@ function sizeCushion(size, r, d, l, w, h, rx, ry, dx, dy) =
         s = apply3D(size, l, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[1] * 2),
-            divisor(s[2])
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.y * 2),
+            divisor(s.z)
         ],
         radius = [
-            min(size[0] / 2, c[0]),
-            min(size[1] / 2, c[1])
+            min(size.x / 2, c.x),
+            min(size.y / 2, c.y)
         ]
     )
-    [ size, radius[0] && radius[1] ? radius : [0, 0] ]
+    [ size, radius.x && radius.y ? radius : [0, 0] ]
 ;
 
 /**
@@ -175,14 +175,14 @@ function sizeBullet(size, r, d, l, w, h, rx, ry, dx, dy) =
         s = apply3D(size, l, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[0] * 2),
-            divisor(s[2] ? s[2] : c[1])
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.x * 2),
+            divisor(s.z ? s.z : c.y)
         ],
-        horRadius = max(size[0], size[1]) / 2,
+        horRadius = max(size.x, size.y) / 2,
         radius = [
             horRadius,
-            min(size[2], or(c[1], horRadius))
+            min(size.z, or(c.y, horRadius))
         ]
     )
     [ size, radius ]
@@ -208,14 +208,14 @@ function sizePill(size, r, d, l, w, h, rx, ry, dx, dy) =
         s = apply3D(size, l, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[0] * 2),
-            divisor(s[2] ? s[2] : c[1] * 2)
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.x * 2),
+            divisor(s.z ? s.z : c.y * 2)
         ],
-        horRadius = max(size[0], size[1]) / 2,
+        horRadius = max(size.x, size.y) / 2,
         radius = [
             horRadius,
-            min(size[2] / 2, or(c[1], horRadius))
+            min(size.z / 2, or(c.y, horRadius))
         ]
     )
     [ size, radius ]
@@ -241,16 +241,16 @@ function sizePeg(size, r, d, l, w, h, rx, ry, dx, dy) =
         s = apply3D(size, l, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[0] * 2),
-            divisor(s[2] ? s[2] : c[1] * 2)
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.x * 2),
+            divisor(s.z ? s.z : c.y * 2)
         ],
         radius = [
-            min(max(size[0], size[1]) / 2, c[0]),
-            min(size[2] / 2, c[1])
+            min(max(size.x, size.y) / 2, c.x),
+            min(size.z / 2, c.y)
         ]
     )
-    [ size, radius[0] && radius[1] ? radius : [0, 0] ]
+    [ size, radius.x && radius.y ? radius : [0, 0] ]
 ;
 
 /**
@@ -273,13 +273,13 @@ function sizePlate(size, r, d, l, w, h, rx, ry, dx, dy) =
         s = apply3D(size, l, w, h),
         c = sizeRounded2D(r=r, d=d, rx=rx, ry=ry, dx=dx, dy=dy),
         size = [
-            divisor(s[0] ? s[0] : c[0] * 2),
-            divisor(s[1] ? s[1] : c[0] * 2),
-            divisor(s[2] ? s[2] : c[1] * 2)
+            divisor(s.x ? s.x : c.x * 2),
+            divisor(s.y ? s.y : c.x * 2),
+            divisor(s.z ? s.z : c.y * 2)
         ],
-        verRadius = size[2] / 2,
+        verRadius = size.z / 2,
         radius = [
-            min(max(size[0], size[1]) / 2, or(c[0], verRadius)),
+            min(max(size.x, size.y) / 2, or(c.x, verRadius)),
             verRadius
         ]
     )
@@ -307,11 +307,11 @@ function drawBullet(size, r, d, l, w, h, rx, ry, dx, dy) =
         size = specs[0],
         radius = specs[1],
         center = [
-            0, size[2] - radius[1]
+            0, size.z - radius.y
         ],
         points = arc(r=radius, o=center, a=RIGHT)
     )
-    complete(points, [radius[0], 0], [0, 0])
+    complete(points, [radius.x, 0], [0, 0])
 ;
 
 /**
@@ -335,7 +335,7 @@ function drawPill(size, r, d, l, w, h, rx, ry, dx, dy) =
         size = specs[0],
         radius = specs[1],
         center = [
-            0, size[2] / 2 - radius[1]
+            0, size.z / 2 - radius.y
         ]
     )
     center == [0, 0] ? arc(r=radius, a1=-RIGHT, a2=RIGHT)
@@ -365,18 +365,18 @@ function drawPeg(size, r, d, l, w, h, rx, ry, dx, dy) =
         specs = sizePeg(size=size, r=r, d=d, l=l, w=w, h=h, rx=rx, ry=ry, dx=dx, dy=dy),
         size = specs[0],
         radius = specs[1],
-        right = max(size[0], size[1]) / 2,
-        top = size[2] / 2,
+        right = max(size.x, size.y) / 2,
+        top = size.z / 2,
         center = [
-            right - radius[0],
-            top - radius[1]
+            right - radius.x,
+            top - radius.y
         ]
     )
     radius == [0, 0] ? [ [right, top], [0, top], [0, -top], [right, -top] ]
    :center == [0, 0] ? arc(r=radius, a1=-RIGHT, a2=RIGHT)
    :complete(
         concat(
-            arc(r=radius, o=[center[0], -center[1]], a1=QUADRANT_3, a2=QUADRANT_4),
+            arc(r=radius, o=[center.x, -center.y], a1=QUADRANT_3, a2=QUADRANT_4),
             arc(r=radius, o=center, a1=0, a2=QUADRANT_1)
         ),
         [0, -top],
@@ -405,12 +405,12 @@ function drawPlate(size, r, d, l, w, h, rx, ry, dx, dy) =
         size = specs[0],
         radius = specs[1],
         center = [
-            max(size[0], size[1]) / 2 - radius[0], 0
+            max(size.x, size.y) / 2 - radius.x, 0
         ],
         points = arc(r=radius, o=center, a1=-RIGHT, a2=RIGHT)
     )
     center == [0, 0] ? points
-   :complete(points, -[0, radius[1]], [0, radius[1]])
+   :complete(points, -[0, radius.y], [0, radius.y])
 ;
 
 /**
@@ -430,7 +430,7 @@ function drawPlate(size, r, d, l, w, h, rx, ry, dx, dy) =
  */
 module archBox(size, r, d, l, w, h, rx, ry, dx, dy, center) {
     size = sizeArchBox(size=size, r=r, d=d, l=l, w=w, h=h, rx=rx, ry=ry, dx=dx, dy=dy);
-    linear_extrude(height=size[0][2], center=center, convexity=10) {
+    linear_extrude(height=size[0].z, center=center, convexity=10) {
         arch(size[0], size[1]);
     }
 }
@@ -452,7 +452,7 @@ module archBox(size, r, d, l, w, h, rx, ry, dx, dy, center) {
  */
 module slot(size, r, d, l, w, h, rx, ry, dx, dy, center) {
     size = sizeSlot(size=size, r=r, d=d, l=l, w=w, h=h, rx=rx, ry=ry, dx=dx, dy=dy);
-    linear_extrude(height=size[0][2], center=center, convexity=10) {
+    linear_extrude(height=size[0].z, center=center, convexity=10) {
         stadium(size[0], size[1]);
     }
 }
@@ -474,7 +474,7 @@ module slot(size, r, d, l, w, h, rx, ry, dx, dy, center) {
  */
 module cushion(size, r, d, l, w, h, rx, ry, dx, dy, center) {
     size = sizeCushion(size=size, r=r, d=d, l=l, w=w, h=h, rx=rx, ry=ry, dx=dx, dy=dy);
-    linear_extrude(height=size[0][2], center=center, convexity=10) {
+    linear_extrude(height=size[0].z, center=center, convexity=10) {
         roundedRectangle(size[0], size[1]);
     }
 }

--- a/shape/context/build-box.scad
+++ b/shape/context/build-box.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,16 +48,16 @@ function sizeBuildPlate(size, cell, l, w, cl, cw) =
         size = apply2D(uor(size, DEFAULT_BUILD_PLATE_SIZE), l, w),
         cell = apply2D(uor(cell, DEFAULT_BUILD_PLATE_CELL), cl, cw),
         nb = [
-            cell[0] ? floor(size[0] / cell[0]) : 0,
-            cell[1] ? floor(size[1] / cell[1]) : 0
+            cell.x ? floor(size.x / cell.x) : 0,
+            cell.y ? floor(size.y / cell.y) : 0
         ],
         count = [
-            nb[0] + 1,
-            nb[1] + 1
+            nb.x + 1,
+            nb.y + 1
         ],
         offset = [
-            cell[0] ? -nb[0] * cell[0] / 2 : 0,
-            cell[1] ? -nb[1] * cell[1] / 2 : 0
+            cell.x ? -nb.x * cell.x / 2 : 0,
+            cell.y ? -nb.y * cell.y / 2 : 0
         ]
     )
     [ size, cell, count, offset ]
@@ -91,14 +91,14 @@ module buildPlate(size=DEFAULT_BUILD_PLATE_SIZE, cell=DEFAULT_BUILD_PLATE_CELL, 
             }
         }
         negativeExtrude(height=-plateHeight, direction=2) {
-            translate(center ? [cellOffset[0], -plateSize[1] / 2, 0] : [0, 0, 0]) {
-                repeat(count=cellCount[0], intervalX=cellSize[0]) {
-                    square([lineWidth, plateSize[1]]);
+            translate(center ? [cellOffset.x, -plateSize.y / 2, 0] : [0, 0, 0]) {
+                repeat(count=cellCount.x, intervalX=cellSize.x) {
+                    square([lineWidth, plateSize.y]);
                 }
             }
-            translate(center ? [-plateSize[0] / 2, cellOffset[1], 0] : [0, 0, 0]) {
-                repeat(count=cellCount[1], intervalY=cellSize[1]) {
-                    square([plateSize[0], lineWidth]);
+            translate(center ? [-plateSize.x / 2, cellOffset.y, 0] : [0, 0, 0]) {
+                repeat(count=cellCount.y, intervalY=cellSize.y) {
+                    square([plateSize.x, lineWidth]);
                 }
             }
         }

--- a/test/core/line.scad
+++ b/test/core/line.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -64,7 +64,7 @@ module testCoreLine() {
                 assertEqual(arc([1, 2], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(arc([1, 2], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(arc([1, 2], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 6 facets (hexagon)");
-                assertEqual(arc([5, 6], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
+                assertEqual(arc([5, 6], $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
                 assertEqual(arc([10, 20], $fn=36), [ for (a = [10 : 10 : 360]) _rotP(a, 10, 20) ], "Should return a list of points to draw an ellipse with a radius of [10, 20] and 36 facets");
             }
             testUnit("circle arc from origin", 12) {

--- a/test/core/vector-2d.scad
+++ b/test/core/vector-2d.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -739,14 +739,14 @@ module testCoreVector2D() {
         // test core/vector-2d/rotp()
         testModule("rotp()", 3) {
             testUnit("no parameter", 1) {
-                assertEqual(rotp(), [undef, undef], "Cannot compute rotation if no parameter is provided");
+                assertEqual(rotp(), [0, 0], "Cannot compute rotation if no parameter is provided");
             }
             testUnit("wrong types", 5) {
-                assertEqual(rotp("1", "2"), [undef, undef], "Cannot compute rotation from strings");
-                assertEqual(rotp(1, 2), [undef, undef], "Cannot compute rotation from number");
-                assertEqual(rotp([1], [2]), [undef, undef], "Cannot compute rotation from arrays");
-                assertEqual(rotp([1], 90), [undef, undef], "Cannot compute rotation from incomplete vector");
-                assertEqual(rotp(true, true), [undef, undef], "Cannot compute rotation from booleans");
+                assertEqual(rotp("1", "2"), [0, 0], "Cannot compute rotation from strings");
+                assertEqual(rotp(1, 2), [cos(2) - sin(2), cos(2) + sin(2)], "Cannot compute rotation from number");
+                assertEqual(rotp([1], [2]), [1, 0], "Cannot compute rotation from arrays");
+                assertEqual(rotp([1], 90), [0, 1], "Cannot compute rotation from incomplete vector");
+                assertEqual(rotp(true, true), [0, 0], "Cannot compute rotation from booleans");
             }
             testUnit("vector and angle", 4) {
                 assertEqual(rotp([23, 67], 0), [23, 67], "Should return [23, 67]");
@@ -758,14 +758,14 @@ module testCoreVector2D() {
         // test core/vector-2d/mirp()
         testModule("mirp()", 3) {
             testUnit("no parameter", 1) {
-                assertEqual(mirp(), [undef, undef], "Cannot compute mirror if no parameter is provided");
+                assertEqual(mirp(), [0, 0], "Cannot compute mirror if no parameter is provided");
             }
             testUnit("wrong types", 5) {
-                assertEqual(mirp("1", "2"), [undef, undef], "Cannot compute mirror from strings");
-                assertEqual(mirp(1, 2), [undef, undef], "Cannot compute mirror from number");
-                assertEqual(mirp([1], [2]), [undef, undef], "Cannot compute mirror from arrays");
-                assertEqual(mirp([1], 90), [undef, undef], "Cannot compute mirror from incomplete vector");
-                assertEqual(mirp(true, true), [undef, undef], "Cannot compute mirror from booleans");
+                assertEqual(mirp("1", "2"), [0, 0], "Cannot compute mirror from strings");
+                assertEqual(mirp(1, 2), [1, 1], "Cannot compute mirror from number");
+                assertEqual(mirp([1], [2]), [1, 0], "Cannot compute mirror from arrays");
+                assertEqual(mirp([1], 90), [0, 1], "Cannot compute mirror from incomplete vector");
+                assertEqual(mirp(true, true), [0, 0], "Cannot compute mirror from booleans");
             }
             testUnit("vector and axis", 3) {
                 assertApproxEqual(mirp([23, 67], [1, 0]), [23, -67], "Should return [23, 67] mirrored around X");
@@ -776,17 +776,17 @@ module testCoreVector2D() {
         // test core/vector-2d/arcp()
         testModule("arcp()", 3) {
             testUnit("no parameter", 1) {
-                assertEqual(arcp(), [undef, undef], "Cannot compute the point if no parameter is provided");
+                assertEqual(arcp(), [0, 0], "Cannot compute the point if no parameter is provided");
             }
             testUnit("wrong types", 4) {
-                assertEqual(arcp("1", "2"), [undef, undef], "Cannot compute the point from strings");
-                assertEqual(arcp(1, 1), [undef, undef], "Cannot compute the point from numbers");
-                assertEqual(arcp(true, true), [undef, undef], "Cannot compute the point from booleans");
-                assertEqual(arcp(["1", "2"]), [undef, undef], "Cannot compute the point from arrays");
+                assertEqual(arcp("1", "2"), [0, 0], "Cannot compute the point from strings");
+                assertEqual(arcp(1, 1), [cos(1), sin(1)], "Cannot compute the point from numbers");
+                assertEqual(arcp(true, true), [0, 0], "Cannot compute the point from booleans");
+                assertEqual(arcp(["1", "2"]), [0, 0], "Cannot compute the point from arrays");
             }
             testUnit("vector", 6) {
-                assertEqual(arcp([]), [undef, undef], "Cannot compute the point from empty vector");
-                assertEqual(arcp([], 30), [undef, undef], "Cannot compute the point from empty vector, event if angle is provided");
+                assertEqual(arcp([]), [0, 0], "Cannot compute the point from empty vector");
+                assertEqual(arcp([], 30), [0, 0], "Cannot compute the point from empty vector, event if angle is provided");
                 assertEqual(arcp([10, 10]), [10, 0], "Default angle is 0");
                 assertEqual(arcp([10, 10], 45), [cos(45)*10, sin(45)*10], "Angle of 45 degrees");
                 assertEqual(arcp([20, 10], 30), [cos(30)*20, sin(30)*10], "Angle of 30 degrees");

--- a/test/shape/2D/ellipse.scad
+++ b/test/shape/2D/ellipse.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -175,22 +175,22 @@ module testShape2dEllipse() {
                 assertEqual(drawEllipse([1, 2], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawEllipse([1, 2], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(drawEllipse([1, 2], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawEllipse([5, 6], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
+                assertEqual(drawEllipse([5, 6], $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
 
                 assertEqual(drawEllipse(d=[1, 2], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawEllipse(d=[1, 2], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 4 facets (square)");
                 assertEqual(drawEllipse(d=[1, 2], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawEllipse(d=[10, 12], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a diameter of [10, 12] and 20 facets");
+                assertEqual(drawEllipse(d=[10, 12], $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a diameter of [10, 12] and 20 facets");
 
                 assertEqual(drawEllipse(rx=1, ry=2, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 3 facets (triangle)");
                 assertEqual(drawEllipse(rx=1, ry=2, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 4 facets (square)");
                 assertEqual(drawEllipse(rx=1, ry=2, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 6 facets (hexagon)");
-                assertEqual(drawEllipse(rx=5, ry=6, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of x=5, y=6 and 20 facets");
+                assertEqual(drawEllipse(rx=5, ry=6, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of x=5, y=6 and 20 facets");
 
                 assertEqual(drawEllipse(dx=1, dy=2, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 3 facets (triangle)");
                 assertEqual(drawEllipse(dx=1, dy=2, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 4 facets (square)");
                 assertEqual(drawEllipse(dx=1, dy=2, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 6 facets (hexagon)");
-                assertEqual(drawEllipse(dx=10, dy=12, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a diameter of x=10, y=12 and 20 facets");
+                assertEqual(drawEllipse(dx=10, dy=12, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a diameter of x=10, y=12 and 20 facets");
             }
         }
         // test shape/2D/ellipse/drawPie()
@@ -216,22 +216,22 @@ module testShape2dEllipse() {
                 assertEqual(drawPie([1, 2], a=360, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawPie([1, 2], a=360, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(drawPie([1, 2], a=360, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawPie([5, 6], a=360, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
+                assertEqual(drawPie([5, 6], a=360, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
 
                 assertEqual(drawPie(d=[1, 2], a=360, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawPie(d=[1, 2], a=360, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 4 facets (square)");
                 assertEqual(drawPie(d=[1, 2], a=360, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawPie(d=[10, 12], a=360, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a diameter of [10, 12] and 20 facets");
+                assertEqual(drawPie(d=[10, 12], a=360, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a diameter of [10, 12] and 20 facets");
 
                 assertEqual(drawPie(rx=1, ry=2, a1=0, a2=360, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 3 facets (triangle)");
                 assertEqual(drawPie(rx=1, ry=2, a1=0, a2=360, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 4 facets (square)");
                 assertEqual(drawPie(rx=1, ry=2, a1=0, a2=360, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 6 facets (hexagon)");
-                assertEqual(drawPie(rx=5, ry=6, a1=0, a2=360, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of x=5, y=6 and 20 facets");
+                assertEqual(drawPie(rx=5, ry=6, a1=0, a2=360, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of x=5, y=6 and 20 facets");
 
                 assertEqual(drawPie(dx=1, dy=2, a1=0, a2=360, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 3 facets (triangle)");
                 assertEqual(drawPie(dx=1, dy=2, a1=0, a2=360, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 4 facets (square)");
                 assertEqual(drawPie(dx=1, dy=2, a1=0, a2=360, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 6 facets (hexagon)");
-                assertEqual(drawPie(dx=10, dy=12, a1=0, a2=360, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a diameter of x=10, y=12 and 20 facets");
+                assertEqual(drawPie(dx=10, dy=12, a1=0, a2=360, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a diameter of x=10, y=12 and 20 facets");
             }
             testUnit("circle pie", 8) {
                 assertEqual(drawPie(1, a=30, $fn=3), concat([[0, 0]], [ for (a = [0 : 30 : 30]) _rotP(a, 1, 1) ]), "Should return a list of points to draw a 30° pie with a radius of 1 and 3 facets (triangle)");

--- a/test/shape/2D/rounded.scad
+++ b/test/shape/2D/rounded.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -501,27 +501,27 @@ module testShape2dRounded() {
                 assertEqual(drawStadium([2, 1], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 0.5) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawStadium([2, 1], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 0.5) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(drawStadium([2, 1], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 0.5) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawStadium([12, 10], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 6, 5) ], "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
+                assertEqual(drawStadium([12, 10], $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 6, 5) ], _rotP(0, 6, 5), _rotP(360, 6, 5)), "Should return a list of points to draw an ellipse with a radius of [6, 5] and 20 facets");
 
                 assertEqual(drawStadium(r=[1, 2], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawStadium(r=[1, 2], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(drawStadium(r=[1, 2], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawStadium(r=[5, 6], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
+                assertEqual(drawStadium(r=[5, 6], $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
 
                 assertEqual(drawStadium(d=[1, 2], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawStadium(d=[1, 2], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 4 facets (square)");
                 assertEqual(drawStadium(d=[1, 2], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawStadium(d=[10, 12], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a diameter of [10, 12] and 20 facets");
+                assertEqual(drawStadium(d=[10, 12], $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a diameter of [10, 12] and 20 facets");
 
                 assertEqual(drawStadium(rx=1, ry=2, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 3 facets (triangle)");
                 assertEqual(drawStadium(rx=1, ry=2, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 4 facets (square)");
                 assertEqual(drawStadium(rx=1, ry=2, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 6 facets (hexagon)");
-                assertEqual(drawStadium(rx=5, ry=6, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of x=5, y=6 and 20 facets");
+                assertEqual(drawStadium(rx=5, ry=6, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of x=5, y=6 and 20 facets");
 
                 assertEqual(drawStadium(dx=1, dy=2, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 3 facets (triangle)");
                 assertEqual(drawStadium(dx=1, dy=2, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 4 facets (square)");
                 assertEqual(drawStadium(dx=1, dy=2, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 6 facets (hexagon)");
-                assertEqual(drawStadium(dx=10, dy=12, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a diameter of x=10, y=12 and 20 facets");
+                assertEqual(drawStadium(dx=10, dy=12, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a diameter of x=10, y=12 and 20 facets");
             }
             testUnit("circle stadium, straight walls", 4) {
                 assertEqual(drawStadium([2, 4], r=1, $fn=3), [ _rotP(0, 1, 1) + [0, 1], _rotP(120, 1, 1) + [0, 1], _rotP(180, 1, 1) + [0, 1], _rotP(180, 1, 1) - [0, 1], _rotP(300, 1, 1) - [0, 1], _rotP(360, 1, 1) - [0, 1] ], "Should return a list of points to draw an stadium with wall of 1 and a radius of 1 and 3 facets (triangle)");
@@ -573,22 +573,22 @@ module testShape2dRounded() {
                 assertEqual(drawRoundedRectangle(r=[1, 2], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawRoundedRectangle(r=[1, 2], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 4 facets (square)");
                 assertEqual(drawRoundedRectangle(r=[1, 2], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawRoundedRectangle(r=[5, 6], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
+                assertEqual(drawRoundedRectangle(r=[5, 6], $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of [5, 6] and 20 facets");
 
                 assertEqual(drawRoundedRectangle(d=[1, 2], $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 3 facets (triangle)");
                 assertEqual(drawRoundedRectangle(d=[1, 2], $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 4 facets (square)");
                 assertEqual(drawRoundedRectangle(d=[1, 2], $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of [1, 2] and 6 facets (hexagon)");
-                assertEqual(drawRoundedRectangle(d=[10, 12], $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a diameter of [10, 12] and 20 facets");
+                assertEqual(drawRoundedRectangle(d=[10, 12], $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a diameter of [10, 12] and 20 facets");
 
                 assertEqual(drawRoundedRectangle(rx=1, ry=2, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 3 facets (triangle)");
                 assertEqual(drawRoundedRectangle(rx=1, ry=2, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 4 facets (square)");
                 assertEqual(drawRoundedRectangle(rx=1, ry=2, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 1, 2) ], "Should return a list of points to draw an ellipse with a radius of x=1, y=2 and 6 facets (hexagon)");
-                assertEqual(drawRoundedRectangle(rx=5, ry=6, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a radius of x=5, y=6 and 20 facets");
+                assertEqual(drawRoundedRectangle(rx=5, ry=6, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a radius of x=5, y=6 and 20 facets");
 
                 assertEqual(drawRoundedRectangle(dx=1, dy=2, $fn=3), [ for (a = [360/3 : 360/3 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 3 facets (triangle)");
                 assertEqual(drawRoundedRectangle(dx=1, dy=2, $fn=4), [ for (a = [360/4 : 360/4 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 4 facets (square)");
                 assertEqual(drawRoundedRectangle(dx=1, dy=2, $fn=6), [ for (a = [360/6 : 360/6 : 360]) _rotP(a, 0.5, 1) ], "Should return a list of points to draw an ellipse with a diameter of x=1, y=2 and 6 facets (hexagon)");
-                assertEqual(drawRoundedRectangle(dx=10, dy=12, $fa=12, $fs=2), [ for (a = [0 : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], "Should return a list of points to draw an ellipse with a diameter of x=10, y=12 and 20 facets");
+                assertEqual(drawRoundedRectangle(dx=10, dy=12, $fa=12, $fs=2), complete([ for (a = [astep(6, $fa=12, $fs=2) : astep(6, $fa=12, $fs=2) : 360]) _rotP(a, 5, 6) ], _rotP(0, 5, 6), _rotP(360, 5, 6)), "Should return a list of points to draw an ellipse with a diameter of x=10, y=12 and 20 facets");
             }
             testUnit("size and radius", 12) {
                 assertEqual(

--- a/test/util/test-utils.scad
+++ b/test/util/test-utils.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -203,10 +203,10 @@ module testUtilTestUtils() {
                 assertEqual(assertDetails(), "", "An empty content should be returned");
             }
             testUnit("single detail", 1) {
-                assertEqual(assertDetails(["testValue"]), "[value: testValue]", "The detail for a single value should be returned");
+                assertEqual(assertDetails(["testValue"]), "{value: testValue}", "The detail for a single value should be returned");
             }
             testUnit("full details", 1) {
-                assertEqual(assertDetails(["testActual", "testExpected"]), "[expected: testExpected] [actual: testActual]", "The details for expected and actual values should be returned");
+                assertEqual(assertDetails(["testActual", "testExpected"]), "{expected: testExpected}{actual: testActual}", "The details for expected and actual values should be returned");
             }
         }
         // test util/test/checkExpectedAsserts()

--- a/util/ansi.scad
+++ b/util/ansi.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -67,7 +67,7 @@ ANSI_COLOR_BACKGROUND = 40;
 function ansiCode(code) =  str(
     chr(27),
     "[",
-    or(isArray(code) ? join(code, ";") : code, "0"),
+    or(is_list(code) ? join(code, ";") : code, "0"),
     "m"
 );
 

--- a/util/html.scad
+++ b/util/html.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,7 @@
  * @returns String
  */
 function htmlAttribute(name, value) =
-    name ? str(name, "=\"", isArray(value) ? htmlProperties(value) : string(value), "\"")
+    name ? str(name, "=\"", is_list(value) ? htmlProperties(value) : string(value), "\"")
          : ""
 ;
 
@@ -63,9 +63,9 @@ function htmlProperty(name, value) =
  * @returns String
  */
 function htmlAttributes(attr) =
-    attr && isArray(attr) ? join(glue=" ", terms=[
+    attr && is_list(attr) ? join(glue=" ", terms=[
                                 for (a = attr)
-                                    isArray(a) ? htmlAttribute(a[0], a[1])
+                                    is_list(a) ? htmlAttribute(a[0], a[1])
                                                : a
                             ])
                           : attr ? string(attr)
@@ -79,9 +79,9 @@ function htmlAttributes(attr) =
  * @returns String
  */
 function htmlProperties(props) =
-    props && isArray(props) ? join(glue=" ", terms=[
+    props && is_list(props) ? join(glue=" ", terms=[
                                   for (p = props)
-                                      isArray(p) ? htmlProperty(p[0], p[1])
+                                      is_list(p) ? htmlProperty(p[0], p[1])
                                                  : p
                               ])
                             : props ? string(props)

--- a/util/test-utils.scad
+++ b/util/test-utils.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -389,7 +389,7 @@ function assertContext() = str(
  * @returns String
  */
 function assertDetails(details) =
-    details && isArray(details) ? (
+    details && is_list(details) ? (
         len(details) > 1 ? str("[expected: ", details[1], "] [actual: ", details[0], "]")
                          : str("[value: ", details[0], "]")
     )
@@ -407,7 +407,7 @@ function assertDetails(details) =
 function checkExpectedAsserts(actual, expected) =
     let(
         actual = integer(actual),
-        single = isUndef(expected),
+        single = is_undef(expected),
         expected = integer(expected)
     )
     single ? !!actual : actual == expected
@@ -426,7 +426,7 @@ function messageExpectedAsserts(actual, expected, type) =
     let(
         type = string(type),
         actual = integer(actual),
-        single = isUndef(expected),
+        single = is_undef(expected),
         expected = integer(expected)
     )
     str(

--- a/util/test-utils.scad
+++ b/util/test-utils.scad
@@ -390,8 +390,8 @@ function assertContext() = str(
  */
 function assertDetails(details) =
     details && is_list(details) ? (
-        len(details) > 1 ? str("[expected: ", details[1], "] [actual: ", details[0], "]")
-                         : str("[value: ", details[0], "]")
+        len(details) > 1 ? str("{expected: ", details[1], "}{actual: ", details[0], "}")
+                         : str("{value: ", details[0], "}")
     )
    :""
 ;

--- a/util/test.scad
+++ b/util/test.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -194,7 +194,7 @@ module failed(message) {
  * @param String [message]
  */
 module assertUndef(value, message) {
-    result = isUndef(value);
+    result = is_undef(value);
     message = or(message, "Should be an undefined value");
     details = [value];
 
@@ -208,7 +208,7 @@ module assertUndef(value, message) {
  * @param String [message]
  */
 module assertNumber(value, message) {
-    result = isNumber(value);
+    result = is_num(value);
     message = or(message, "Should be a number");
     details = [value];
 
@@ -236,7 +236,7 @@ module assertInteger(value, message) {
  * @param String [message]
  */
 module assertBoolean(value, message) {
-    result = isBoolean(value);
+    result = is_bool(value);
     message = or(message, "Should be a boolean");
     details = [value];
 
@@ -264,7 +264,7 @@ module assertVector(value, message) {
  * @param String [message]
  */
 module assertArray(value, message) {
-    result = isArray(value);
+    result = is_list(value);
     message = or(message, "Should be an array");
     details = [value];
 
@@ -292,7 +292,7 @@ module assertEmptyArray(value, message) {
  * @param String [message]
  */
 module assertNotEmptyArray(value, message) {
-    result = isArray(value) && value != [];
+    result = is_list(value) && value != [];
     message = or(message, "Should not be an empty array");
     details = [value];
 
@@ -306,7 +306,7 @@ module assertNotEmptyArray(value, message) {
  * @param String [message]
  */
 module assertString(value, message) {
-    result = isString(value);
+    result = is_string(value);
     message = or(message, "Should be a string");
     details = [value];
 
@@ -334,7 +334,7 @@ module assertEmptyString(value, message) {
  * @param String [message]
  */
 module assertNotEmptyString(value, message) {
-    result = isString(value) && value != "";
+    result = is_string(value) && value != "";
     message = or(message, "Should not be an empty string");
     details = [value];
 


### PR DESCRIPTION
Support update for OpenSCAD 2019 and OpenSCAD 2021.

Fixes:
- Warnings messages appearing after the update to OpenSCAD 2019.05.
- Failing unit tests after the update to OpenSCAD 2021.01.

Features:
- Improve the readability of the unit tests error report from the CLI script (at least with dark background).

**Breaking changes:**
- The default return value of some API have been changed (`rotp()`, `mirp()`, `arcp()`), when used with wrong parameters.
- Use new API added by OpenSCAD 2019.05 to test types.
- Require OpenSCAD 2019.05 as minimal version.

Refactoring:
- Use dot notation indexing instead of list indexing when relevant.