### PR TITLE
Fix/Comparison precision when completing lists

### DIFF
--- a/core/list.scad
+++ b/core/list.scad
@@ -157,10 +157,19 @@ function inArray(collection, elem) = find(collection, elem) > -1;
 function complete(collection, start, end) =
     let(
         collection = array(collection),
-        first = start && start != collection[0] && start != collection[len(collection) - 1] ? concat([start], collection) : collection,
-        second = end && end != first[0] && end != first[len(first) - 1] ? concat(first, [end]) : first
+        start = !is_undef(start) && 
+                start != collection[0] && 
+                start != collection[len(collection) - 1]
+               ?[start]
+               :[],
+        end = !is_undef(end) &&
+              end != start[0] && 
+              end != collection[0] && 
+              end != collection[len(collection) - 1]
+             ?[end]
+             :[]
     )
-    second
+    concat(start, collection, end)
 ;
 
 /**

--- a/core/list.scad
+++ b/core/list.scad
@@ -152,20 +152,21 @@ function inArray(collection, elem) = find(collection, elem) > -1;
  * @param Array collection - The list  to complete.
  * @param * start - The start element to add.
  * @param * end - The end element to add.
+ * @param Number [precision] - The wanted decimal precision (default: 5).
  * @returns Array
  */
-function complete(collection, start, end) =
+function complete(collection, start, end, precision=5) =
     let(
         collection = array(collection),
         start = !is_undef(start) && 
-                start != collection[0] && 
-                start != collection[len(collection) - 1]
+                !approx(start, collection[0], precision) && 
+                !approx(start, collection[len(collection) - 1], precision)
                ?[start]
                :[],
         end = !is_undef(end) &&
-              end != start[0] && 
-              end != collection[0] && 
-              end != collection[len(collection) - 1]
+              !approx(end, start[0], precision) && 
+              !approx(end, collection[0], precision) && 
+              !approx(end, collection[len(collection) - 1], precision)
              ?[end]
              :[]
     )

--- a/test/core/list.scad
+++ b/test/core/list.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -327,14 +327,17 @@ module testCoreList() {
                 assertEqual(complete("1"), ["1"], "String should be casted to array");
                 assertEqual(complete(true), [true], "Boolean should be casted to array");
                 assertEqual(complete("1", "foo", "bar"), ["foo", "1", "bar"], "String should be casted to array, should return an array containing the provided start and end points");
-                assertEqual(complete(true, true, false), [true], "Cannot complete a boolean, but should return an array containing the provided start and end points");
+                assertEqual(complete(true, true, false), [true, false], "Cannot complete a boolean, but should return an array containing the provided start and end points");
             }
-            testUnit("array", 5) {
+            testUnit("array", 8) {
                 assertEqual(complete([], 1, 2), [1, 2], "Should accept numbers as elements");
                 assertEqual(complete([], [1, 0], [2, 3]), [[1, 0], [2, 3]], "Should accept vectors as elements");
                 assertEqual(complete([[1, 0], [5, 7], [2, 3]], [1, 0], [2, 3]), [[1, 0], [5, 7], [2, 3]], "Should not complete the elements if start and end are already there");
                 assertEqual(complete([[5, 7], [2, 3]], [1, 0], [2, 3]), [[1, 0], [5, 7], [2, 3]], "Should only complete the elements if start and end are not already there (missing start)");
                 assertEqual(complete([[1, 0], [5, 7]], [1, 0], [2, 3]), [[1, 0], [5, 7], [2, 3]], "Should only complete the elements if start and end are not already there (missing end)");
+                assertEqual(complete([[5, 7], [2, 3]], [1, 0], [1, 0]), [[1, 0], [5, 7], [2, 3]], "Should only complete the elements if start and end are not equal");
+                assertEqual(complete([[5, 7], [2, 3]], start=[1, 0]), [[1, 0], [5, 7], [2, 3]], "Should complete the elements with a new start");
+                assertEqual(complete([[5, 7], [2, 3]], end=[1, 0]), [[5, 7], [2, 3], [1, 0]], "Should complete the elements with a new end");
             }
         }
         // test core/list/slice()

--- a/test/core/list.scad
+++ b/test/core/list.scad
@@ -329,7 +329,7 @@ module testCoreList() {
                 assertEqual(complete("1", "foo", "bar"), ["foo", "1", "bar"], "String should be casted to array, should return an array containing the provided start and end points");
                 assertEqual(complete(true, true, false), [true, false], "Cannot complete a boolean, but should return an array containing the provided start and end points");
             }
-            testUnit("array", 8) {
+            testUnit("array", 10) {
                 assertEqual(complete([], 1, 2), [1, 2], "Should accept numbers as elements");
                 assertEqual(complete([], [1, 0], [2, 3]), [[1, 0], [2, 3]], "Should accept vectors as elements");
                 assertEqual(complete([[1, 0], [5, 7], [2, 3]], [1, 0], [2, 3]), [[1, 0], [5, 7], [2, 3]], "Should not complete the elements if start and end are already there");
@@ -338,6 +338,8 @@ module testCoreList() {
                 assertEqual(complete([[5, 7], [2, 3]], [1, 0], [1, 0]), [[1, 0], [5, 7], [2, 3]], "Should only complete the elements if start and end are not equal");
                 assertEqual(complete([[5, 7], [2, 3]], start=[1, 0]), [[1, 0], [5, 7], [2, 3]], "Should complete the elements with a new start");
                 assertEqual(complete([[5, 7], [2, 3]], end=[1, 0]), [[5, 7], [2, 3], [1, 0]], "Should complete the elements with a new end");
+                assertEqual(complete([[1.123456, 0.123456], [5.123456, 7.123456], [2.123456, 3.123456]], [1.12345678, 0.12345678], [2.12345678, 3.12345678]), [[1.123456, 0.123456], [5.123456, 7.123456], [2.123456, 3.123456]], "Should not complete the elements if start and end are approx equal to elements");
+                assertEqual(complete([[1.123456, 0.123456], [5.123456, 7.123456], [2.123456, 3.123456]], [1.12345678, 0.12345678], [2.12345678, 3.12345678], 8), [[1.12345678, 0.12345678], [1.123456, 0.123456], [5.123456, 7.123456], [2.123456, 3.123456], [2.12345678, 3.12345678]], "Should complete the elements if start and end are different even if very close to elements");
             }
         }
         // test core/list/slice()


### PR DESCRIPTION
Fix a comparison issue occurring with `complete(collection, start, end)`, when the collection start and end elements are very close to the elements to add. When these elements are different only after the Nth decimal, when N > 5, the function can add duplicate values.