### PR TITLE
Feature/repeat alternate operator

### DIFF
--- a/core/constants.scad
+++ b/core/constants.scad
@@ -99,13 +99,13 @@ QUADRANT_3 = DEGREES - RIGHT;
 QUADRANT_4 = DEGREES;
 
 /**
- * 2D-vector for the orgigin coordinates.
+ * 2D-vector for the origin coordinates.
  * @type Number
  */
 ORIGIN_2D = [0, 0];
 
 /**
- * 3D-vector for the orgigin coordinates.
+ * 3D-vector for the origin coordinates.
  * @type Number
  */
 ORIGIN_3D = [0, 0, 0];

--- a/core/constants.scad
+++ b/core/constants.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2019 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -97,6 +97,18 @@ QUADRANT_3 = DEGREES - RIGHT;
  * @type Number
  */
 QUADRANT_4 = DEGREES;
+
+/**
+ * 2D-vector for the orgigin coordinates.
+ * @type Number
+ */
+ORIGIN_2D = [0, 0];
+
+/**
+ * 3D-vector for the orgigin coordinates.
+ * @type Number
+ */
+ORIGIN_3D = [0, 0, 0];
 
 /**
  * Useful value for computations based on hexagons.

--- a/core/hex.scad
+++ b/core/hex.scad
@@ -103,7 +103,7 @@ function buildHexGrid(count, linear, cx, cy) =
  */
 function offsetHexGrid(size, count, pointy, linear, even, l, w, cx, cy) =
     !linear
-   ?[0, 0]
+   ?ORIGIN_2D
    :let(
        size = apply2D(size, l, w),
        count = divisor2D(apply2D(count, cx, cy)),

--- a/core/maths.scad
+++ b/core/maths.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -282,6 +282,22 @@ function factorial(n) =
     let( n = float(n) )
     n > 0 ? factorial(n - 1) * n : 1
 ;
+
+/**
+ * Tells whether a value is even or not.
+ *
+ * @param Number n
+ * @returns Boolean
+ */
+function even(n) = float(n) % 2 == 0;
+
+/**
+ * Tells whether a value is odd or not.
+ *
+ * @param Number n
+ * @returns Boolean
+ */
+function odd(n) = float(n) % 2 != 0;
 
 /**
  * Forces a value to be within the provided domain.

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -653,7 +653,7 @@ function cosp(y, w, h, p, o) =
  * @returns Vector
  */
 function rotp(v, a) =
-    is_undef(v) || is_undef(a) ? [0, 0]
+    is_undef(v) || is_undef(a) ? ORIGIN_2D
    :let(
        v = vector2D(v),
        a = float(a)
@@ -672,7 +672,7 @@ function rotp(v, a) =
  * @returns Vector
  */
 function mirp(v, a) =
-    is_undef(v) || is_undef(a) ? [0, 0]
+    is_undef(v) || is_undef(a) ? ORIGIN_2D
    :let(
         v = vector2D(v),
         a = vector2D(a),

--- a/core/vector.scad
+++ b/core/vector.scad
@@ -262,8 +262,8 @@ function vboolean(a, bool) =
  */
 function vangle(a, b) =
     let(
-        a = a ? vector(a, 3) : [0, 0, 0],
-        b = b ? vector(b, 3) : [0, 0, 0]
+        a = a ? vector(a, 3) : ORIGIN_3D,
+        b = b ? vector(b, 3) : ORIGIN_3D
     )
     float(acos((a * b) / (norm(a) * norm(b))))
 ;

--- a/operator/distribute/grid.scad
+++ b/operator/distribute/grid.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,8 +49,8 @@ module distributeGrid(intervalX = xAxis3D(),
     intervalY = vector3D(intervalY);
     count = $children;
     line = max(floor(abs(float(line))), 1);
-    offsetX = center ? -intervalX * ((count > line ? line : count) - 1) / 2 : [0, 0, 0];
-    offsetY = center ? -intervalY * (floor(count / line) - (count % line ? 0 : 1)) / 2 : [0, 0, 0];
+    offsetX = center ? -intervalX * ((count > line ? line : count) - 1) / 2 : ORIGIN_3D;
+    offsetY = center ? -intervalY * (floor(count / line) - (count % line ? 0 : 1)) / 2 : ORIGIN_3D;
 
     for (i = [0 : count - 1]) {
         translate(offsetX + intervalX * (i % line) + offsetY + intervalY * floor(i / line)) {

--- a/operator/distribute/mirror.scad
+++ b/operator/distribute/mirror.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,7 +52,7 @@
  * @param Number [axisZ] - The Z-coordinate of the normal vector of the mirroring plan around which mirror the elements
  *                         (will overwrite the Z coordinate in the `axis` vector).
  */
-module distributeMirror(interval = [0, 0, 0],
+module distributeMirror(interval = 0,
                         axis     = xAxis3D(),
                         center   = false,
                         intervalX, intervalY, intervalZ,
@@ -60,7 +60,7 @@ module distributeMirror(interval = [0, 0, 0],
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
     axis = apply3D(axis, axisX, axisY, axisZ);
-    offset = center ? -interval * ($children - 1) / 2 : [0, 0, 0];
+    offset = center ? -interval * ($children - 1) / 2 : ORIGIN_3D;
 
     for (i = [0 : $children - 1]) {
         translate(offset + interval * i) {

--- a/operator/distribute/rotate.scad
+++ b/operator/distribute/rotate.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -56,8 +56,8 @@
  */
 module distributeRotate(angle    = DEGREES,
                         axis     = zAxis3D(),
-                        interval = [0, 0, 0],
-                        origin   = [0, 0, 0],
+                        interval = 0,
+                        origin   = 0,
                         center   = false,
                         intervalX, intervalY, intervalZ,
                         axisX, axisY, axisZ,
@@ -68,7 +68,7 @@ module distributeRotate(angle    = DEGREES,
     angle = deg(angle);
     partAngle = angle / (angle % DEGREES ? $children - 1 : $children);
     axis = apply3D(axis, axisX, axisY, axisZ) * partAngle;
-    offset = center ? -interval * ($children - 1) / 2 : [0, 0, 0];
+    offset = center ? -interval * ($children - 1) / 2 : ORIGIN_3D;
 
     for (i = [0 : $children - 1]) {
         translate(offset + interval * i) {

--- a/operator/distribute/translate.scad
+++ b/operator/distribute/translate.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,12 +44,12 @@
  * @param Number [intervalZ] - The Z interval between each repeated children
  *                             (will overwrite the Z coordinate in the `interval` vector).
  */
-module distribute(interval = [0, 0, 0],
+module distribute(interval = 0,
                   center   = false,
                   intervalX, intervalY, intervalZ) {
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
-    offset = center ? -interval * ($children - 1) / 2 : [0, 0, 0];
+    offset = center ? -interval * ($children - 1) / 2 : ORIGIN_3D;
 
     for (i = [0 : $children - 1]) {
         translate(offset + interval * i) {

--- a/operator/repeat/alternate.scad
+++ b/operator/repeat/alternate.scad
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operators that repeat children modules with respect to particular rules.
+ *
+ * @package operator/repeat
+ * @author jsconan
+ */
+
+/**
+ * Repeats the children modules `count` times with the provided `interval`,
+ * only rendering the odd or even positions. This means that the children
+ * will be rendered less than `count` times as half of the positions will
+ * be left empty.
+ *
+ * @param Number [count] - The number of times the children must be repeated.
+ * @param Vector [interval] - The interval between each repeated children.
+ * @param Boolean [renderEven] - Only render on even positions.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
+ * @param Number [intervalX] - The X interval between each repeated children
+ *                             (will overwrite the X coordinate in the `interval` vector).
+ * @param Number [intervalY] - The Y interval between each repeated children
+ *                             (will overwrite the Y coordinate in the `interval` vector).
+ * @param Number [intervalZ] - The Z interval between each repeated children
+ *                             (will overwrite the Z coordinate in the `interval` vector).
+ */
+module repeatAlternate(count      = 2,
+                       interval   = 0,
+                       renderEven = false,
+                       center     = false,
+                       intervalX, intervalY, intervalZ) {
+
+    renderEven = boolean(renderEven);
+    interval = apply3D(interval, intervalX, intervalY, intervalZ);
+    offset = center ? -interval * (count - 1) / 2 : ORIGIN_3D;
+
+    for (i = [0 : count - 1]) {
+        if (renderEven == even(i)) {
+            translate(offset + interval * i) {
+                children();
+            }
+        }
+    }
+}
+
+/**
+ * Repeats the children modules in two directions `count` times with the provided `interval`,
+ * only rendering the odd or even positions. This means that the children
+ * will be rendered less than `count` times as half of the positions will
+ * be left empty.
+ *
+ * @param Number [countX] - The number of times the children must be repeated along the X axis.
+ * @param Number [countY] - The number of times the children must be repeated along the Y axis.
+ * @param Vector [intervalX] - The interval between each repeated children along the X axis.
+ * @param Vector [intervalY] - The interval between each repeated children along the Y axis.
+ * @param Boolean [renderEven] - Only render on even positions.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
+ */
+module repeatAlternate2D(countX     = 2,
+                         countY     = 2,
+                         intervalX  = 0,
+                         intervalY  = 0,
+                         renderEven = false,
+                         center     = false) {
+
+    renderEven = boolean(renderEven);
+    intervalX = vector3D(intervalX);
+    intervalY = vector3D(intervalY);
+    offsetX = center ? -intervalX * (countX - 1) / 2 : ORIGIN_3D;
+    offsetY = center ? -intervalY * (countY - 1) / 2 : ORIGIN_3D;
+    offset = offsetX + offsetY;
+
+    for (y = [0 : countY - 1] ) {
+        for (x = [0 : countX - 1] ) {
+            alignedXY = even(x) == even(y);
+            if (renderEven == alignedXY) {
+                translate(offset + intervalX * x + intervalY * y) {
+                    children();
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Repeats the children modules in three directions `count` times with the provided `interval`,
+ * only rendering the odd or even positions. This means that the children
+ * will be rendered less than `count` times as half of the positions will
+ * be left empty.
+ *
+ * @param Number [countX] - The number of times the children must be repeated along the X axis.
+ * @param Number [countY] - The number of times the children must be repeated along the Y axis.
+ * @param Number [countZ] - The number of times the children must be repeated along the Z axis.
+ * @param Vector [intervalX] - The interval between each repeated children along the X axis.
+ * @param Vector [intervalY] - The interval between each repeated children along the Y axis.
+ * @param Vector [intervalZ] - The interval between each repeated children along the Z axis.
+ * @param Boolean [renderEven] - Only render on even positions.
+ * @param Boolean [center] - Whether or not center the repeated shapes.
+ */
+module repeatAlternate3D(countX     = 2,
+                         countY     = 2,
+                         countZ     = 2,
+                         intervalX  = 0,
+                         intervalY  = 0,
+                         intervalZ  = 0,
+                         renderEven = false,
+                         center     = false) {
+
+    renderEven = boolean(renderEven);
+    intervalX = vector3D(intervalX);
+    intervalY = vector3D(intervalY);
+    intervalZ = vector3D(intervalZ);
+    offsetX = center ? -intervalX * (countX - 1) / 2 : ORIGIN_3D;
+    offsetY = center ? -intervalY * (countY - 1) / 2 : ORIGIN_3D;
+    offsetZ = center ? -intervalZ * (countZ - 1) / 2 : ORIGIN_3D;
+    offset = offsetX + offsetY + offsetZ;
+
+    for (z = [0 : countZ - 1] ) {
+        for (y = [0 : countY - 1] ) {
+            for (x = [0 : countX - 1] ) {
+                alignedXY = even(x) == even(y);
+                evenZ = even(z);
+                if ((renderEven == alignedXY && evenZ) || (renderEven != alignedXY && !evenZ)) {
+                    translate(offset + intervalX * x + intervalY * y + intervalZ * z) {
+                        children();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/operator/repeat/grid.scad
+++ b/operator/repeat/grid.scad
@@ -51,8 +51,8 @@ module repeatGrid(count     = 2,
     intervalY = vector3D(intervalY);
     count = max(floor(abs(float(count))), 1);
     line = max(floor(abs(float(line))), 1);
-    offsetX = center ? -intervalX * ((count > line ? line : count) - 1) / 2 : [0, 0, 0];
-    offsetY = center ? -intervalY * (floor(count / line) - (count % line ? 0 : 1)) / 2 : [0, 0, 0];
+    offsetX = center ? -intervalX * ((count > line ? line : count) - 1) / 2 : ORIGIN_3D;
+    offsetY = center ? -intervalY * (floor(count / line) - (count % line ? 0 : 1)) / 2 : ORIGIN_3D;
 
     for (i = [0 : count - 1]) {
         translate(offsetX + intervalX * (i % line) + offsetY + intervalY * floor(i / line)) {

--- a/operator/repeat/mirror.scad
+++ b/operator/repeat/mirror.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,7 +54,7 @@
  *                         (will overwrite the Z coordinate in the `axis` vector).
  */
 module repeatMirror(count    = 2,
-                    interval = [0, 0, 0],
+                    interval = 0,
                     axis     = xAxis3D(),
                     center   = false,
                     intervalX, intervalY, intervalZ,
@@ -62,7 +62,7 @@ module repeatMirror(count    = 2,
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
     axis = apply3D(axis, axisX, axisY, axisZ);
-    offset = center ? -interval * (count - 1) / 2 : [0, 0, 0];
+    offset = center ? -interval * (count - 1) / 2 : ORIGIN_3D;
 
     for (i = [0 : count - 1]) {
         translate(offset + interval * i) {
@@ -93,8 +93,8 @@ module repeatMirror2D(countX    = 2,
                       countY    = 2,
                       axisX     = xAxis3D(),
                       axisY     = yAxis3D(),
-                      intervalX = [0, 0, 0],
-                      intervalY = [0, 0, 0],
+                      intervalX = 0,
+                      intervalY = 0,
                       center    = false) {
 
     repeatMirror(count=countY, interval=vector3D(intervalY), axis=vector3D(axisY), center=center) {
@@ -125,9 +125,9 @@ module repeatMirror3D(countX    = 2,
                       axisX     = xAxis3D(),
                       axisY     = yAxis3D(),
                       axisZ     = zAxis3D(),
-                      intervalX = [0, 0, 0],
-                      intervalY = [0, 0, 0],
-                      intervalZ = [0, 0, 0],
+                      intervalX = 0,
+                      intervalY = 0,
+                      intervalZ = 0,
                       center    = false) {
 
     repeatMirror(count=countZ, interval=vector3D(intervalZ), axis=vector3D(axisZ), center=center) {

--- a/operator/repeat/rotate.scad
+++ b/operator/repeat/rotate.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -56,8 +56,8 @@
 module repeatRotate(count    = 2,
                     angle    = DEGREES,
                     axis     = zAxis3D(),
-                    interval = [0, 0, 0],
-                    origin   = [0, 0, 0],
+                    interval = 0,
+                    origin   = 0,
                     center   = false,
                     intervalX, intervalY, intervalZ,
                     axisX, axisY, axisZ,
@@ -68,7 +68,7 @@ module repeatRotate(count    = 2,
     angle = deg(angle);
     partAngle = angle / (angle % DEGREES ? count - 1 : count);
     axis = apply3D(axis, axisX, axisY, axisZ) * partAngle;
-    offset = center ? -interval * (count - 1) / 2 : [0, 0, 0];
+    offset = center ? -interval * (count - 1) / 2 : ORIGIN_3D;
 
     for (i = [0 : count - 1]) {
         translate(offset + interval * i) {
@@ -100,10 +100,10 @@ module repeatRotate2D(countX    = 2,
                       angleY    = DEGREES,
                       axisX     = zAxis3D(),
                       axisY     = yAxis3D(),
-                      intervalX = [0, 0, 0],
-                      intervalY = [0, 0, 0],
-                      originX   = [0, 0, 0],
-                      originY   = [0, 0, 0],
+                      intervalX = 0,
+                      intervalY = 0,
+                      originX   = 0,
+                      originY   = 0,
                       center    = false) {
 
     repeatRotate(count=countY, interval=vector3D(intervalY), angle=angleY, axis=vector3D(axisY), origin=originY, center=center) {
@@ -142,12 +142,12 @@ module repeatRotate3D(countX    = 2,
                       axisX     = zAxis3D(),
                       axisY     = yAxis3D(),
                       axisZ     = xAxis3D(),
-                      intervalX = [0, 0, 0],
-                      intervalY = [0, 0, 0],
-                      intervalZ = [0, 0, 0],
-                      originX   = [0, 0, 0],
-                      originY   = [0, 0, 0],
-                      originZ   = [0, 0, 0],
+                      intervalX = 0,
+                      intervalY = 0,
+                      intervalZ = 0,
+                      originX   = 0,
+                      originY   = 0,
+                      originZ   = 0,
                       center    = false) {
 
     repeatRotate(count=countZ, interval=vector3D(intervalZ), angle=angleZ, axis=vector3D(axisZ), origin=originZ, center=center) {

--- a/operator/repeat/translate.scad
+++ b/operator/repeat/translate.scad
@@ -46,12 +46,12 @@
  *                             (will overwrite the Z coordinate in the `interval` vector).
  */
 module repeat(count    = 2,
-              interval = [0, 0, 0],
+              interval = 0,
               center   = false,
               intervalX, intervalY, intervalZ) {
 
     interval = apply3D(interval, intervalX, intervalY, intervalZ);
-    offset = center ? -interval * (count - 1) / 2 : [0, 0, 0];
+    offset = center ? -interval * (count - 1) / 2 : ORIGIN_3D;
 
     for (i = [0 : count - 1]) {
         translate(offset + interval * i) {
@@ -71,8 +71,8 @@ module repeat(count    = 2,
  */
 module repeat2D(countX    = 2,
                 countY    = 2,
-                intervalX = [0, 0, 0],
-                intervalY = [0, 0, 0],
+                intervalX = 0,
+                intervalY = 0,
                 center    = false) {
 
     repeat(count=countY, interval=vector3D(intervalY), center=center) {
@@ -96,9 +96,9 @@ module repeat2D(countX    = 2,
 module repeat3D(countX    = 2,
                 countY    = 2,
                 countZ    = 2,
-                intervalX = [0, 0, 0],
-                intervalY = [0, 0, 0],
-                intervalZ = [0, 0, 0],
+                intervalX = 0,
+                intervalY = 0,
+                intervalZ = 0,
                 center    = false) {
 
     repeat(count=countZ, interval=vector3D(intervalZ), center=center) {

--- a/operator/repeat/translate.scad
+++ b/operator/repeat/translate.scad
@@ -75,9 +75,17 @@ module repeat2D(countX    = 2,
                 intervalY = 0,
                 center    = false) {
 
-    repeat(count=countY, interval=vector3D(intervalY), center=center) {
-        repeat(count=countX, interval=vector3D(intervalX), center=center) {
-            children();
+    intervalX = vector3D(intervalX);
+    intervalY = vector3D(intervalY);
+    offsetX = center ? -intervalX * (countX - 1) / 2 : ORIGIN_3D;
+    offsetY = center ? -intervalY * (countY - 1) / 2 : ORIGIN_3D;
+    offset = offsetX + offsetY;
+
+    for (y = [0 : countY - 1] ) {
+        for (x = [0 : countX - 1] ) {
+            translate(offset + intervalX * x + intervalY * y) {
+                children();
+            }
         }
     }
 }
@@ -101,10 +109,20 @@ module repeat3D(countX    = 2,
                 intervalZ = 0,
                 center    = false) {
 
-    repeat(count=countZ, interval=vector3D(intervalZ), center=center) {
-        repeat(count=countY, interval=vector3D(intervalY), center=center) {
-            repeat(count=countX, interval=vector3D(intervalX), center=center) {
-                children();
+    intervalX = vector3D(intervalX);
+    intervalY = vector3D(intervalY);
+    intervalZ = vector3D(intervalZ);
+    offsetX = center ? -intervalX * (countX - 1) / 2 : ORIGIN_3D;
+    offsetY = center ? -intervalY * (countY - 1) / 2 : ORIGIN_3D;
+    offsetZ = center ? -intervalZ * (countZ - 1) / 2 : ORIGIN_3D;
+    offset = offsetX + offsetY + offsetZ;
+
+    for (z = [0 : countZ - 1] ) {
+        for (y = [0 : countY - 1] ) {
+            for (x = [0 : countX - 1] ) {
+                translate(offset + intervalX * x + intervalY * y + intervalZ * z) {
+                    children();
+                }
             }
         }
     }
@@ -123,8 +141,8 @@ module repeatShape2D(size, count = 1, center) {
     repeat2D(
         countX = count.x,
         countY = count.y,
-        intervalX = [size.x, 0, 0],
-        intervalY = [0, size.y, 0],
+        intervalX = xAxis3D(size.x),
+        intervalY = yAxis3D(size.y),
         center = center
     ) {
         children();
@@ -145,9 +163,9 @@ module repeatShape3D(size, count = 1, center) {
         countX = count.x,
         countY = count.y,
         countZ = count.z,
-        intervalX = [size.x, 0, 0],
-        intervalY = [0, size.y, 0],
-        intervalZ = [0, 0, size.z],
+        intervalX = xAxis3D(size.x),
+        intervalY = yAxis3D(size.y),
+        intervalZ = zAxis3D(size.z),
         center = center
     ) {
         children();

--- a/operators.scad
+++ b/operators.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,7 @@ include <operator/distribute/translate.scad>
 
 include <operator/extrude/negative.scad>
 
+include <operator/repeat/alternate.scad>
 include <operator/repeat/grid.scad>
 include <operator/repeat/mirror.scad>
 include <operator/repeat/rotate.scad>

--- a/shape/context/build-box.scad
+++ b/shape/context/build-box.scad
@@ -91,12 +91,12 @@ module buildPlate(size=DEFAULT_BUILD_PLATE_SIZE, cell=DEFAULT_BUILD_PLATE_CELL, 
             }
         }
         negativeExtrude(height=-plateHeight, direction=2) {
-            translate(center ? [cellOffset.x, -plateSize.y / 2, 0] : [0, 0, 0]) {
+            translate(center ? [cellOffset.x, -plateSize.y / 2, 0] : ORIGIN_3D) {
                 repeat(count=cellCount.x, intervalX=cellSize.x) {
                     square([lineWidth, plateSize.y]);
                 }
             }
-            translate(center ? [-plateSize.x / 2, cellOffset.y, 0] : [0, 0, 0]) {
+            translate(center ? [-plateSize.x / 2, cellOffset.y, 0] : ORIGIN_3D) {
                 repeat(count=cellCount.y, intervalY=cellSize.y) {
                     square([plateSize.x, lineWidth]);
                 }
@@ -117,7 +117,7 @@ module buildPlate(size=DEFAULT_BUILD_PLATE_SIZE, cell=DEFAULT_BUILD_PLATE_CELL, 
 module buildVolume(size=DEFAULT_BUILD_VOLUME_SIZE, l, w, h, center=false) {
     %color([1, 1, 1, .1]) {
         size = apply3D(size, l, w, w);
-        translate(center ? apply3D(-size / 2, z=0) : [0, 0, 0]) {
+        translate(center ? apply3D(-size / 2, z=0) : ORIGIN_3D) {
             cube(size);
         }
     }

--- a/test/core/maths.scad
+++ b/test/core/maths.scad
@@ -2,7 +2,7 @@
  * @license
  * MIT License
  *
- * Copyright (c) 2017-2020 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2022 Jean-Sebastien CONAN
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ use <../../full.scad>
  * @author jsconan
  */
 module testCoreMaths() {
-    testPackage("core/maths.scad", 24) {
+    testPackage("core/maths.scad", 26) {
         // test core/maths/deg()
         testModule("deg()", 3) {
             testUnit("no parameter", 1) {
@@ -590,6 +590,50 @@ module testCoreMaths() {
                 assertEqual(factorial(8), 40320, "The factorial of 8 is 40320");
                 assertEqual(factorial(9), 362880, "The factorial of 9 is 362880");
                 assertEqual(factorial(10), 3628800, "The factorial of 10 is 3628800");
+            }
+        }
+        // test core/maths/even()
+        testModule("even()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(even(), true, "No parameter gives a 0, so even");
+            }
+            testUnit("not a number", 3) {
+                assertEqual(even(true), true, "A boolean is casted to 0, so even");
+                assertEqual(even("10"), true, "A atring is casted to 0, so even");
+                assertEqual(even([14]), true, "A vector is casted to 0, so even");
+            }
+            testUnit("number", 9) {
+                assertEqual(even(0), true, "0 is considered even");
+                assertEqual(even(1), false, "1 is not even");
+                assertEqual(even(3), false, "3 is not even");
+                assertEqual(even(-1), false, "-1 is not even");
+                assertEqual(even(-3), false, "-3 is not even");
+                assertEqual(even(2), true, "2 is even");
+                assertEqual(even(-2), true, "-2 is even");
+                assertEqual(even(6), true, "6 is even");
+                assertEqual(even(-6), true, "-6 is even");
+            }
+        }
+        // test core/maths/odd()
+        testModule("odd()", 3) {
+            testUnit("no parameter", 1) {
+                assertEqual(odd(), false, "No parameter gives a 0, so not odd");
+            }
+            testUnit("not a number", 3) {
+                assertEqual(odd(true), false, "A boolean is casted to 0, so not odd");
+                assertEqual(odd("10"), false, "A string is casted to 0, so not odd");
+                assertEqual(odd([14]), false, "A vector is casted to 0, so not odd");
+            }
+            testUnit("number", 9) {
+                assertEqual(odd(0), false, "0 is not considered odd");
+                assertEqual(odd(1), true, "1 is odd");
+                assertEqual(odd(3), true, "3 is odd");
+                assertEqual(odd(-1), true, "-1 is odd");
+                assertEqual(odd(-3), true, "-3 is odd");
+                assertEqual(odd(2), false, "2 is not odd");
+                assertEqual(odd(-2), false, "-2 is not odd");
+                assertEqual(odd(6), false, "6 is not odd");
+                assertEqual(odd(-6), false, "-6 is not odd");
             }
         }
         // test core/maths/limit()


### PR DESCRIPTION
Add core functions:
- `even()`: Tells whether a value is even or not.
- `odd()`: Tells whether a value is odd or not.

Add constants:
- `ORIGIN_2D`: A 2D-vector for the origin coordinates.
- `ORIGIN_3D`: A 3D-vector for the origin coordinates.

Add operators:
- `repeatAlternate()`: Repeats the children modules `count` times with the provided `interval`, only rendering the odd or even positions. This means that the children will be rendered less than `count` times as half of the positions will be left empty.
- `repeatAlternate2D()`: Repeats the children modules in two directions `count` times with the provided `interval`, only rendering the odd or even positions. This means that the children will be rendered less than `count` times as half of the positions will be left empty.
- `repeatAlternate3D()`: Repeats the children modules in three directions `count` times with the provided `interval`, only rendering the odd or even positions. This means that the children will be rendered less than `count` times as half of the positions will be left empty.

Refactor operators:
- `repeat2D()`: Use direct loop instead of nesting operators and duplicating the translates.
- `repeat3D()`: Use direct loop instead of nesting operators and duplicating the translates.
