### PR TITLE
Feature/animate

### DIFF
--- a/core/maths.scad
+++ b/core/maths.scad
@@ -441,18 +441,18 @@ function iToX(i, count) = float(i) % divisor(count);
 function iToY(i, count) = floor(float(i) / divisor(count));
 
 /**
- * Gets a percentage value as a number between -1 and 1.
+ * Gets a percentage ratio as a number between 0 and 1.
  *
- * @param Number v - The percentage value. It can be either a number between 1 and `scale` (default: 100), or a value between -1 and 1.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number v - The percentage value. It can be either a number between 1 and `domain` (default: 100), or a value between 0 and 1.
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio (default: 100).
  * @returns Number
  */
-function percentage(v, scale) =
+function percentage(v, domain) =
     let(
         v = float(v),
-        scale = float(scale)
+        domain = float(domain)
     )
-    v < -1 || v > 1 ? v / (scale ? scale : 100)
+    v < -1 || v > 1 ? v / (domain ? domain : 100)
                     : v
 ;
 
@@ -464,15 +464,15 @@ function percentage(v, scale) =
  * @param Number high - The top value of the range to interpolate.
  * @param Number [start] - The start threshold under what the low value will persist and above what it will be interpolated.
  * @param Number [end] - The end threshold above what the high value will persist and under what it will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @returns Vector
  */
-function simpleInterpolationRange(low, high, start, end, scale) =
+function simpleInterpolationRange(low, high, start, end, domain) =
     let(
         low = float(low),
         high = float(high),
-        start = abs(percentage(numberOr(start, 0), scale=scale)),
-        end = abs(percentage(numberOr(end, 1), scale=scale)),
+        start = abs(percentage(numberOr(start, 0), domain=domain)),
+        end = abs(percentage(numberOr(end, 1), domain=domain)),
         first = min(start, end),
         last = max(start, end)
     )
@@ -490,15 +490,15 @@ function simpleInterpolationRange(low, high, start, end, scale) =
  * @param Vector values - The list of values composing the range to interpolate.
  * @param Number [start] - The start threshold under what the first value of the range will persist and above what it will be interpolated.
  * @param Number [end] - The end threshold above what the last value of the range will persist and under what it will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @returns Vector
  */
-function interpolationRange(values, start, end, scale) =
+function interpolationRange(values, start, end, domain) =
     let(
         values = array(values),
         count = len(values),
-        start = abs(percentage(numberOr(start, 0), scale=scale)),
-        end = abs(percentage(numberOr(end, 1), scale=scale)),
+        start = abs(percentage(numberOr(start, 0), domain=domain)),
+        end = abs(percentage(numberOr(end, 1), domain=domain)),
         first = min(start, end),
         last = max(start, end),
         step = (last - first) / divisor(count - 1)
@@ -515,16 +515,16 @@ function interpolationRange(values, start, end, scale) =
  * @param Number [high] - The top value of the range to interpolate.
  * @param Number [start] - The start threshold under what the low value will persist and above what it will be interpolated.
  * @param Number [end] - The end threshold above what the high value will persist and under what it will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @param Vector [values] - A list of values composing the range to interpolate.
- * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `low`, `high`, `start`, `end`, `scale`.
+ * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `low`, `high`, `start`, `end`, `domain`.
  * @returns Number
  */
-function interpolateStep(step, low, high, start, end, scale, values, range) =
+function interpolateStep(step, low, high, start, end, domain, values, range) =
     lookup(
         float(step),
         is_list(range) ? range
-       :is_list(values) ? interpolationRange(values=values, start=start, end=end, scale=scale)
-       :simpleInterpolationRange(low=low, high=high, start=start, end=end, scale=scale)
+       :is_list(values) ? interpolationRange(values=values, start=start, end=end, domain=domain)
+       :simpleInterpolationRange(low=low, high=high, start=start, end=end, domain=domain)
     )
 ;

--- a/core/vector-2d.scad
+++ b/core/vector-2d.scad
@@ -887,17 +887,17 @@ function boundaries2D(points,
  * @param Vector high - The top coordinates of the range to interpolate.
  * @param Number [start] - The start threshold under what the low value will persist and above what it will be interpolated.
  * @param Number [end] - The end threshold above what the high value will persist and under what it will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @returns Vector
  */
-function simpleInterpolationRange2D(low, high, start, end, scale) =
+function simpleInterpolationRange2D(low, high, start, end, domain) =
     let(
         low = vector2D(low),
         high = vector2D(high)
     )
     [
-        simpleInterpolationRange(low=low.x, high=high.x, start=start, end=end, scale=scale),
-        simpleInterpolationRange(low=low.y, high=high.y, start=start, end=end, scale=scale)
+        simpleInterpolationRange(low=low.x, high=high.x, start=start, end=end, domain=domain),
+        simpleInterpolationRange(low=low.y, high=high.y, start=start, end=end, domain=domain)
     ]
 ;
 
@@ -909,15 +909,15 @@ function simpleInterpolationRange2D(low, high, start, end, scale) =
  * @param Vector values - The list of coordinates composing the range to interpolate.
  * @param Number [start] - The start threshold under what the first coordinate of the range will persist and above what it will be interpolated.
  * @param Number [end] - The end threshold above what the last coordinate of the range will persist and under what it will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @returns Vector
  */
-function interpolationRange2D(values, start, end, scale) =
+function interpolationRange2D(values, start, end, domain) =
     let(
         values = array(values),
         count = len(values),
-        start = abs(percentage(numberOr(start, 0), scale=scale)),
-        end = abs(percentage(numberOr(end, 1), scale=scale)),
+        start = abs(percentage(numberOr(start, 0), domain=domain)),
+        end = abs(percentage(numberOr(end, 1), domain=domain)),
         first = min(start, end),
         last = max(start, end),
         step = (last - first) / divisor(count - 1),
@@ -939,16 +939,16 @@ function interpolationRange2D(values, start, end, scale) =
  * @param Vector high - The top coordinates of the range to interpolate.
  * @param Number [start] - The start threshold under what the low coordinates will persist and above what they will be interpolated.
  * @param Number [end] - The end threshold above what the high coordinates will persist and under what they will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @param Vector [values] - A list of coordinates composing the range to interpolate.
- * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `low`, `high`, `start`, `end`, `scale`.
+ * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `low`, `high`, `start`, `end`, `domain`.
  * @returns Number
  */
-function interpolateStep2D(step, low, high, start, end, scale, values, range) =
+function interpolateStep2D(step, low, high, start, end, domain, values, range) =
     let(
         range = is_list(range) ? range
-               :is_list(values) ? interpolationRange2D(values=values, start=start, end=end, scale=scale)
-               :simpleInterpolationRange2D(low=low, high=high, start=start, end=end, scale=scale)
+               :is_list(values) ? interpolationRange2D(values=values, start=start, end=end, domain=domain)
+               :simpleInterpolationRange2D(low=low, high=high, start=start, end=end, domain=domain)
     )
     [
         interpolateStep(step, range=range.x),

--- a/core/vector-3d.scad
+++ b/core/vector-3d.scad
@@ -372,18 +372,18 @@ function boundaries3D(v,
  * @param Vector high - The top coordinates of the range to interpolate.
  * @param Number [start] - The start threshold under what the low value will persist and above what it will be interpolated.
  * @param Number [end] - The end threshold above what the high value will persist and under what it will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @returns Vector
  */
-function simpleInterpolationRange3D(low, high, start, end, scale) =
+function simpleInterpolationRange3D(low, high, start, end, domain) =
     let(
         low = vector3D(low),
         high = vector3D(high)
     )
     [
-        simpleInterpolationRange(low=low.x, high=high.x, start=start, end=end, scale=scale),
-        simpleInterpolationRange(low=low.y, high=high.y, start=start, end=end, scale=scale),
-        simpleInterpolationRange(low=low.z, high=high.z, start=start, end=end, scale=scale)
+        simpleInterpolationRange(low=low.x, high=high.x, start=start, end=end, domain=domain),
+        simpleInterpolationRange(low=low.y, high=high.y, start=start, end=end, domain=domain),
+        simpleInterpolationRange(low=low.z, high=high.z, start=start, end=end, domain=domain)
     ]
 ;
 
@@ -395,15 +395,15 @@ function simpleInterpolationRange3D(low, high, start, end, scale) =
  * @param Vector values - The list of coordinates composing the range to interpolate.
  * @param Number [start] - The start threshold under what the first coordinate of the range will persist and above what it will be interpolated.
  * @param Number [end] - The end threshold above what the last coordinate of the range will persist and under what it will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @returns Vector
  */
-function interpolationRange3D(values, start, end, scale) =
+function interpolationRange3D(values, start, end, domain) =
     let(
         values = array(values),
         count = len(values),
-        start = abs(percentage(numberOr(start, 0), scale=scale)),
-        end = abs(percentage(numberOr(end, 1), scale=scale)),
+        start = abs(percentage(numberOr(start, 0), domain=domain)),
+        end = abs(percentage(numberOr(end, 1), domain=domain)),
         first = min(start, end),
         last = max(start, end),
         step = (last - first) / divisor(count - 1),
@@ -426,16 +426,16 @@ function interpolationRange3D(values, start, end, scale) =
  * @param Vector high - The top coordinates of the range to interpolate.
  * @param Number [start] - The start threshold under what the low coordinates will persist and above what they will be interpolated.
  * @param Number [end] - The end threshold above what the high coordinates will persist and under what they will be interpolated.
- * @param Number [scale] - The percentage scale (default: 100).
+ * @param Number [domain] - The percentage domain applied to compute the percentage ratio for the thresholds (default: 100).
  * @param Vector [values] - A list of coordinates composing the range to interpolate.
- * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `low`, `high`, `start`, `end`, `scale`.
+ * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `low`, `high`, `start`, `end`, `domain`.
  * @returns Number
  */
-function interpolateStep3D(step, low, high, start, end, scale, values, range) =
+function interpolateStep3D(step, low, high, start, end, domain, values, range) =
     let(
         range = is_list(range) ? range
-               :is_list(values) ? interpolationRange3D(values=values, start=start, end=end, scale=scale)
-               :simpleInterpolationRange3D(low=low, high=high, start=start, end=end, scale=scale)
+               :is_list(values) ? interpolationRange3D(values=values, start=start, end=end, domain=domain)
+               :simpleInterpolationRange3D(low=low, high=high, start=start, end=end, domain=domain)
     )
     [
         interpolateStep(step, range=range.x),

--- a/operator/animate/mirror.scad
+++ b/operator/animate/mirror.scad
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operators that animate child modules with respect to particular rules.
+ *
+ * @package operator/animate
+ * @author jsconan
+ */
+
+/**
+ * Mirrors the child modules, interpolating the axis with respect to the `$t` variable.
+ *
+ * @param Vector [from] - The axis from where starts the interpolation.
+ * @param Vector [to] - The axis to where ends the interpolation.
+ * @param Number [start] - The start threshold under what the from-axis will persist and above what it will be interpolated.
+ * @param Number [end] - The end threshold above what the to-axis will persist and under what it will be interpolated.
+ * @param Number [domain] - The percentage domain used to compute the thresholds (default: 100).
+ * @param Vector [values] - A list of axis composing the range to interpolate.
+ * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `from`, `to`, `start`, `end`, `domain`.
+ * @returns Number
+ */
+module mirrorAnimate(from, to, start, end, domain, values, range) {
+    mirror(interpolateStep3D(step=$t, low=from, high=to, start=start, end=end, domain=domain, values=values, range=range)) {
+        children();
+    }
+}

--- a/operator/animate/resize.scad
+++ b/operator/animate/resize.scad
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operators that animate child modules with respect to particular rules.
+ *
+ * @package operator/animate
+ * @author jsconan
+ */
+
+/**
+ * Resizes the child modules, interpolating the sizes with respect to the `$t` variable.
+ *
+ * @param Vector [from] - The sizes from where starts the interpolation.
+ * @param Vector [to] - The sizes to where ends the interpolation.
+ * @param Number [start] - The start threshold under what the from-sizes will persist and above what it will be interpolated.
+ * @param Number [end] - The end threshold above what the to-sizes will persist and under what it will be interpolated.
+ * @param Number [domain] - The percentage domain used to compute the thresholds (default: 100).
+ * @param Vector [values] - A list of sizes composing the range to interpolate.
+ * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `from`, `to`, `start`, `end`, `domain`.
+ * @param Boolean [auto] - When set to `true`, it auto-scales any 0-dimensions to match. It can also be used to auto-scale a single dimension and leave the other as-is.
+ * @returns Number
+ */
+module resizeAnimate(from, to, start, end, domain, auto, values, range) {
+    resize(interpolateStep3D(step=$t, low=from, high=to, start=start, end=end, domain=domain, values=values, range=range), auto=auto) {
+        children();
+    }
+}

--- a/operator/animate/rotate.scad
+++ b/operator/animate/rotate.scad
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operators that animate child modules with respect to particular rules.
+ *
+ * @package operator/animate
+ * @author jsconan
+ */
+
+/**
+ * Rotates the child modules, interpolating the angles with respect to the `$t` variable.
+ *
+ * @param Vector [from] - The angles from where start the interpolation.
+ * @param Vector [to] - The angles to where end the interpolation.
+ * @param Number [start] - The start threshold under what the from-angles will persist and above what it will be interpolated.
+ * @param Number [end] - The end threshold above what the to-angles will persist and under what it will be interpolated.
+ * @param Number [domain] - The percentage domain used to compute the thresholds (default: 100).
+ * @param Vector [values] - A list of angles composing the range to interpolate.
+ * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `from`, `to`, `start`, `end`, `domain`.
+ * @returns Number
+ */
+module rotateAnimate(from, to, start, end, domain, values, range) {
+    rotate(interpolateStep3D(step=$t, low=from, high=to, start=start, end=end, domain=domain, values=values, range=range)) {
+        children();
+    }
+}

--- a/operator/animate/scale.scad
+++ b/operator/animate/scale.scad
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operators that animate child modules with respect to particular rules.
+ *
+ * @package operator/animate
+ * @author jsconan
+ */
+
+/**
+ * Scales the child modules, interpolating the scale ratios with respect to the `$t` variable.
+ *
+ * @param Vector [from] - The scale ratios from where starts the interpolation.
+ * @param Vector [to] - The scale ratios to where ends the interpolation.
+ * @param Number [start] - The start threshold under what the from-scale ratios will persist and above what it will be interpolated.
+ * @param Number [end] - The end threshold above what the to-scale ratios will persist and under what it will be interpolated.
+ * @param Number [domain] - The percentage domain used to compute the thresholds (default: 100).
+ * @param Vector [values] - A list of scale ratios composing the range to interpolate.
+ * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `from`, `to`, `start`, `end`, `domain`.
+ * @returns Number
+ */
+module scaleAnimate(from, to, start, end, domain, values, range) {
+    scale(interpolateStep3D(step=$t, low=from, high=to, start=start, end=end, domain=domain, values=values, range=range)) {
+        children();
+    }
+}

--- a/operator/animate/translate.scad
+++ b/operator/animate/translate.scad
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operators that animate child modules with respect to particular rules.
+ *
+ * @package operator/animate
+ * @author jsconan
+ */
+
+/**
+ * Translates the child modules, interpolating the coordinates with respect to the `$t` variable.
+ *
+ * @param Vector [from] - The coordinates from where starts the interpolation.
+ * @param Vector [to] - The coordinates to where ends the interpolation.
+ * @param Number [start] - The start threshold under what the from-coordinates will persist and above what it will be interpolated.
+ * @param Number [end] - The end threshold above what the to-coordinates will persist and under what it will be interpolated.
+ * @param Number [domain] - The percentage domain used to compute the thresholds (default: 100).
+ * @param Vector [values] - A list of coordinates composing the range to interpolate.
+ * @param Vector [range] - A pre-built interpolation range. If missing, it will be built from the parameters `from`, `to`, `start`, `end`, `domain`.
+ * @returns Number
+ */
+module translateAnimate(from, to, start, end, domain, values, range) {
+    translate(interpolateStep3D(step=$t, low=from, high=to, start=start, end=end, domain=domain, values=values, range=range)) {
+        children();
+    }
+}

--- a/operators.scad
+++ b/operators.scad
@@ -35,6 +35,12 @@
 include <core.scad>
 
 /* OPERATORS */
+include <operator/animate/mirror.scad>
+include <operator/animate/resize.scad>
+include <operator/animate/rotate.scad>
+include <operator/animate/scale.scad>
+include <operator/animate/translate.scad>
+
 include <operator/distribute/grid.scad>
 include <operator/distribute/mirror.scad>
 include <operator/distribute/rotate.scad>


### PR DESCRIPTION
Add operators to ease scenes animation:
- `mirrorAnimate()`: Mirrors the child modules, interpolating the axis with respect to the `$t` variable.
- `resizeAnimate()`: Resizes the child modules, interpolating the sizes with respect to the `$t` variable.
- `rotateAnimate()`: Rotates the child modules, interpolating the angles with respect to the `$t` variable.
- `scaleAnimate()`: Scales the child modules, interpolating the scale ratios with respect to the `$t` variable.
- `translateAnimate()`: Translates the child modules, interpolating the coordinates with respect to the `$t` variable.

Fixes:
- Use a less confusing parameter name for the domain of values applied to compute percentage ratio. This impacts `percentage()`, `simpleInterpolationRange()`, `interpolationRange()`, `interpolationStep()`, `simpleInterpolationRange2D()`, `interpolationRange2D()`, `interpolationStep2D()`, `simpleInterpolationRange3D()`, `interpolationRange3D()`, `interpolationStep3D()`