### PR TITLE
Fix/script slic3r version

### DIFF
--- a/scripts/utils/slic3r.sh
+++ b/scripts/utils/slic3r.sh
@@ -142,7 +142,7 @@ slic3rcheck() {
     else
         printmessage "${C_SPE}${slic3rname}${C_RST} has been detected."
     fi
-    local version="$(${slic3rcmd} --help | egrep -o '[0-9].[0-9]' | head -1 2>&1)"
+    local version="$(slic3rversion)"
     if [[ "${version}" < "${slic3rver}" ]]; then
         printerror "The installed version of ${slic3rname} does not meet the requirement.\n\tInstalled: ${version}\n\tRequired: ${slic3rver}" ${E_SLIC3R}
     fi

--- a/scripts/utils/slic3r.sh
+++ b/scripts/utils/slic3r.sh
@@ -109,7 +109,7 @@ slic3rversion() {
     if [ "$1" != "" ]; then
         cmd="$1"
     fi
-    version="$(${slic3rcmd} --help | egrep -o '[0-9].[0-9]' | head -1 2>&1)"
+    version="$(${cmd} --help | egrep -o '[0-9].[0-9]' | head -1 2>&1)"
     if [ "$?" != "0" ]; then
         return ${E_SLIC3R}
     fi


### PR DESCRIPTION
Fix script utils:
- use the provided path to Slic3r to get the version in `slic3rversion`
- use the function `slic3rversion` to get the version of Slic3r