### PR TITLE
Release 1.6.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # camelSCAD history
 
+## [Version 1.6.1](https://github.com/jsconan/camelSCAD/releases/tag/v1.6.1)
+
+Fix script utils:
+
+-   use the provided path to Slic3r to get the version in `slic3rversion`
+-   use the function `slic3rversion` to get the version of Slic3r
+
 ## [Version 1.6.0](https://github.com/jsconan/camelSCAD/releases/tag/v1.6.0)
 
 Add core functions:

--- a/core/version.scad
+++ b/core/version.scad
@@ -36,7 +36,7 @@
  * The version of the library.
  * @type Vector
  */
-CAMEL_SCAD_VERSION = [1, 6, 0];
+CAMEL_SCAD_VERSION = [1, 6, 1];
 
 /**
  * The minimal version of OpenSCAD required by the library.

--- a/scripts/utils/slic3r.sh
+++ b/scripts/utils/slic3r.sh
@@ -142,7 +142,7 @@ slic3rcheck() {
     else
         printmessage "${C_SPE}${slic3rname}${C_RST} has been detected."
     fi
-    local version="$(${slic3rcmd} --help | egrep -o '[0-9].[0-9]' | head -1 2>&1)"
+    local version="$(slic3rversion)"
     if [[ "${version}" < "${slic3rver}" ]]; then
         printerror "The installed version of ${slic3rname} does not meet the requirement.\n\tInstalled: ${version}\n\tRequired: ${slic3rver}" ${E_SLIC3R}
     fi

--- a/scripts/utils/slic3r.sh
+++ b/scripts/utils/slic3r.sh
@@ -109,7 +109,7 @@ slic3rversion() {
     if [ "$1" != "" ]; then
         cmd="$1"
     fi
-    version="$(${slic3rcmd} --help | egrep -o '[0-9].[0-9]' | head -1 2>&1)"
+    version="$(${cmd} --help | egrep -o '[0-9].[0-9]' | head -1 2>&1)"
     if [ "$?" != "0" ]; then
         return ${E_SLIC3R}
     fi

--- a/test/core/version.scad
+++ b/test/core/version.scad
@@ -45,10 +45,10 @@ module testCoreVersion() {
         // test camelSCAD()
         testModule("camelSCAD()", 2) {
             testUnit("as vector", 1) {
-                assertEqual(camelSCAD(), [1, 6, 0], "The current version of the library is 1.6.0");
+                assertEqual(camelSCAD(), [1, 6, 1], "The current version of the library is 1.6.1");
             }
             testUnit("as string", 1) {
-                assertEqual(camelSCAD(true), "1.6.0", "The current version of the library is 1.6.0");
+                assertEqual(camelSCAD(true), "1.6.1", "The current version of the library is 1.6.1");
             }
         }
     }


### PR DESCRIPTION
Fix script utils:
- use the provided path to Slic3r to get the version in `slic3rversion`
- use the function `slic3rversion` to get the version of Slic3r