### PR TITLE
Feature/extrude polygon

### DIFF
--- a/operator/extrude/polygon.scad
+++ b/operator/extrude/polygon.scad
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Operators that extrude polygons.
+ *
+ * @package operator/extrude
+ * @author jsconan
+ */
+
+/**
+ * Extrudes a polygon defined by the given points, optionally increasing the size by
+ * adding a distance to the outline.
+ *
+ * Note: for better results, the points should follow an anti-clockwise order.
+ *
+ * @param Vector[] points - The points that define the polygon.
+ * @param Number [height] - The height of the extrusion. If the value is negative,
+ *                          the extrusion will be made top to bottom (below the origin).
+ * @param Number|String [direction] - Tells on what sides adjust the height to make sure
+ *                                    the difference won't produce dummy walls.
+ * @param Boolean [center] - Whether or not center the extrusion on the vertical axis.
+ * @param Number [convexity] - If the extrusion fails for a non-trivial 2D shape,
+ *                             try setting the convexity parameter.
+ * @param Number [twist] - The number of degrees of through which the shape is extruded.
+ * @param Number [slices] - Defines the number of intermediate points along the Z axis
+ *                          of the extrusion.
+ * @param Number|Vector [scale] - Scales the 2D shape by this value over the height of
+ *                                the extrusion.
+ * @param Number [distance] - A distance added to the polygon's outline.
+ */
+module extrudePolygon(points, height, direction, center, convexity, twist, slices, scale, distance) {
+    points = array(points);
+
+    negativeExtrude(height=height, direction=direction, center=center, convexity=convexity, twist=twist, slices=slices, scale=scale) {
+        polygon(distance ? outline(points=points, distance=distance) : points);
+    }
+}

--- a/operator/extrude/polygon.scad
+++ b/operator/extrude/polygon.scad
@@ -60,3 +60,37 @@ module extrudePolygon(points, height, direction, center, convexity, twist, slice
         polygon(distance ? outline(points=points, distance=distance) : points);
     }
 }
+
+/**
+ * Extrudes a box defined by the given polygon points, optionally increasing the size by
+ * adding a distance to the outline.
+ *
+ * Note: for better results, the points should follow an anti-clockwise order.
+ *
+ * @param Vector[] points - The points that define the polygon.
+ * @param Number [height] - The height of the extrusion. If the value is negative,
+ *                          the extrusion will be made top to bottom (below the origin).
+ * @param Number [ground] - The thickness of the box floor.
+ * @param Number [wall] - The thickness of the box walls.
+ * @param Boolean [center] - Whether or not center the extrusion on the vertical axis.
+ * @param Number [convexity] - If the extrusion fails for a non-trivial 2D shape,
+ *                             try setting the convexity parameter.
+ * @param Number [twist] - The number of degrees of through which the shape is extruded.
+ * @param Number [slices] - Defines the number of intermediate points along the Z axis
+ *                          of the extrusion.
+ * @param Number|Vector [scale] - Scales the 2D shape by this value over the height of
+ *                                the extrusion.
+ * @param Number [distance] - A distance added to the polygon's outline.
+ */
+module extrudePolygonBox(points, height, ground, wall, center, convexity, twist, slices, scale, distance) {
+    wall = divisor(wall);
+    ground = divisor(ground);
+    distance = float(distance);
+
+    difference() {
+        extrudePolygon(points=points, height=height, center=center, convexity=convexity, twist=twist, slices=slices, scale=scale, distance=wall + distance);
+        translateZ(ground) {
+            extrudePolygon(points=points, height=height, center=center, convexity=convexity, twist=twist, slices=slices, scale=scale, distance=distance);
+        }
+    }
+}

--- a/operators.scad
+++ b/operators.scad
@@ -48,6 +48,7 @@ include <operator/distribute/rotate.scad>
 include <operator/distribute/translate.scad>
 
 include <operator/extrude/negative.scad>
+include <operator/extrude/polygon.scad>
 
 include <operator/repeat/alternate.scad>
 include <operator/repeat/grid.scad>

--- a/test/visual/operator/extrude/polygon/extrude-polygon-box.scad
+++ b/test/visual/operator/extrude/polygon/extrude-polygon-box.scad
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Entry point for visual testing.
+ *
+ * Test the operator: extrudePolygonBox()
+ *
+ * @package test/suite
+ * @author jsconan
+ */
+
+include <../../../../../full.scad>
+
+TESTBED_SELECT = -1;
+TESTBED_RANGE = [0, 17];
+TESTBED_SHOW = true;
+
+visualTestSuite(length=10, width=10, cols=3, margin=2, center=true) {
+    /*  0 */ testElement() extrudePolygonBox();
+    /*  1 */ testElement() extrudePolygonBox([[0,0], [1,0], [1,1], [0,1]]);
+    /*  2 */ testElement() extrudePolygonBox([[0,0], [1,0], [1,1], [0,1]], 2);
+
+    /*  3 */ testElement() extrudePolygonBox(points=[[0,0], [1,0], [1,1], [0,1]], wall=.5, ground=.1, center=true);
+    /*  4 */ testElement() extrudePolygonBox(points=[[0,0], [1,0], [1,1], [0,1]], wall=.5, ground=.1, height=2, center=true);
+    /*  5 */ testElement() extrudePolygonBox(points=[[0,0], [1,0], [1,1], [0,1]], wall=.5, ground=.1, height=-2, center=true);
+
+    /*  6 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, twist=45);
+    /*  7 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, height=2, twist=45);
+    /*  8 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, height=-2, twist=45);
+
+    /*  9 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, twist=45, slices=10);
+    /* 10 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, height=2, twist=45, slices=10);
+    /* 11 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, height=-2, twist=45, slices=10);
+
+    /* 12 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, scale=2);
+    /* 13 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, height=2, scale=2);
+    /* 14 */ testElement() extrudePolygonBox(points=[[-1,-1], [1,-1], [1,1], [-1,1]], wall=.5, ground=.1, height=-2, scale=2);
+
+    /* 15 */ testElement() extrudePolygonBox(points=[[0,0], [1,0], [1,1], [0,1]], height=1, wall=.5, ground=.1, distance=.5);
+    /* 16 */ testElement() extrudePolygonBox(points=[[0,0], [1,0], [1,1], [0,1]], height=1, wall=.5, ground=.1, distance=-.5);
+}

--- a/test/visual/operator/extrude/polygon/extrude-polygon.scad
+++ b/test/visual/operator/extrude/polygon/extrude-polygon.scad
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2022 Jean-Sebastien CONAN
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Part of the camelSCAD library.
+ *
+ * Entry point for visual testing.
+ *
+ * Test the operator: extrudePolygon()
+ *
+ * @package test/suite
+ * @author jsconan
+ */
+
+include <../../../../../full.scad>
+
+TESTBED_SELECT = -1;
+TESTBED_RANGE = [0, 17];
+TESTBED_SHOW = true;
+
+visualTestSuite(length=10, width=10, cols=3, margin=2, center=true) {
+    /*  0 */ testElement() extrudePolygon();
+    /*  1 */ testElement() extrudePolygon([[0,0], [0,1], [1,1], [1,0]]);
+    /*  2 */ testElement() extrudePolygon([[0,0], [0,1], [1,1], [1,0]], 1);
+
+    /*  3 */ testElement() extrudePolygon(points=[[0,0], [0,1], [1,1], [1,0]], center=true);
+    /*  4 */ testElement() extrudePolygon(points=[[0,0], [0,1], [1,1], [1,0]], height=2, center=true);
+    /*  5 */ testElement() extrudePolygon(points=[[0,0], [0,1], [1,1], [1,0]], height=-2, center=true);
+
+    /*  6 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], twist=45);
+    /*  7 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], height=2, twist=45);
+    /*  8 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], height=-2, twist=45);
+
+    /*  9 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], twist=45, slices=10);
+    /* 10 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], height=2, twist=45, slices=10);
+    /* 11 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], height=-2, twist=45, slices=10);
+
+    /* 12 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], scale=2);
+    /* 13 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], height=2, scale=2);
+    /* 14 */ testElement() extrudePolygon(points=[[-1,-1], [-1,1], [1,1], [1,-1]], height=-2, scale=2);
+
+    /* 15 */ testElement() extrudePolygon(points=[[0,0], [0,1], [1,1], [1,0]], height=1, distance=.5);
+    /* 16 */ testElement() extrudePolygon(points=[[0,0], [0,1], [1,1], [1,0]], height=1, distance=-.5);
+    /* 17 */ testElement() extrudePolygon(points=[[0,0], [1,0], [1,1], [0,1]], height=1, distance=.5);
+}


### PR DESCRIPTION
Add operators extruding polygons given as points.
- `extrudePolygon()`: Extrudes a polygon defined by the given points, optionally increasing the size by adding a distance to the outline.
- `extrudePolygonBox()`: Extrudes a box defined by the given polygon points, optionally increasing the size by adding a distance to the outline.