### PR TITLE
Release 1.10.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # camelSCAD history
 
+## [Version 1.10.1](https://github.com/jsconan/camelSCAD/releases/tag/v1.10.1)
+
+Fixes in scripts:
+
+-   `scadrenderallrecurse`: render the child files from the root folder when recursing
+-   `slic3rsliceallrecurse`: slice the child files from the root folder when recursing
+
 ## [Version 1.10.0](https://github.com/jsconan/camelSCAD/releases/tag/v1.10.0)
 
 Features:

--- a/core/version.scad
+++ b/core/version.scad
@@ -36,7 +36,7 @@
  * The version of the library.
  * @type Vector
  */
-CAMEL_SCAD_VERSION = [1, 10, 0];
+CAMEL_SCAD_VERSION = [1, 10, 1];
 
 /**
  * The minimal version of OpenSCAD required by the library.

--- a/scripts/utils/scad.sh
+++ b/scripts/utils/scad.sh
@@ -325,9 +325,14 @@ scadrenderall() {
 scadrenderallrecurse() {
     local src=$1; shift
     local dst=$1; shift
-    local folders=($(recursepath "${src}" "*.${scadext}"))
-    if [ "${folders}" == "" ]; then
+    local mask="*.${scadext}"
+    local files=($(find "${src}" -maxdepth 1 -name "${mask}"))
+    local folders=($(recursepath "${src}" "${mask}"))
+    if [ ${#files[@]} -eq 0 ] && [ ${#folders[@]} -eq 0 ]; then
         printerror "There is nothing to render at ${src}!" ${E_EMPTY}
+    fi
+    if [ ${#files[@]} -gt 0 ]; then
+        scadrenderall "${src}" "${dst}" "$@"
     fi
     for folder in "${folders[@]}"; do
         scadrenderall "${src}${folder}" "${dst}${folder}" "$@"

--- a/scripts/utils/slic3r.sh
+++ b/scripts/utils/slic3r.sh
@@ -289,9 +289,14 @@ slic3rsliceall() {
 slic3rsliceallrecurse() {
     local src=$1; shift
     local dst=$1; shift
-    local folders=($(recursepath "${src}" "*.${slic3rext}"))
-    if [ "${folders}" == "" ]; then
+    local mask="*.${slic3rext}"
+    local files=($(find "${src}" -maxdepth 1 -name "${mask}"))
+    local folders=($(recursepath "${src}" "${mask}"))
+    if [ ${#files[@]} -eq 0 ] && [ ${#folders[@]} -eq 0 ]; then
         printerror "There is nothing to slice at ${src}!" ${E_EMPTY}
+    fi
+    if [ ${#files[@]} -gt 0 ]; then
+        slic3rsliceall "${src}" "${dst}" "$@"
     fi
     for folder in "${folders[@]}"; do
         slic3rsliceall "${src}${folder}" "${dst}${folder}" "$@"

--- a/test/core/version.scad
+++ b/test/core/version.scad
@@ -45,10 +45,10 @@ module testCoreVersion() {
         // test camelSCAD()
         testModule("camelSCAD()", 2) {
             testUnit("as vector", 1) {
-                assertEqual(camelSCAD(), [1, 10, 0], "The current version of the library is 1.10.0");
+                assertEqual(camelSCAD(), [1, 10, 1], "The current version of the library is 1.10.1");
             }
             testUnit("as string", 1) {
-                assertEqual(camelSCAD(true), "1.10.0", "The current version of the library is 1.10.0");
+                assertEqual(camelSCAD(true), "1.10.1", "The current version of the library is 1.10.1");
             }
         }
     }


### PR DESCRIPTION
Fixes in scripts:
- `scadrenderallrecurse`: render the child files from the root folder when recursing
- `slic3rsliceallrecurse`: slice the child files from the root folder when recursing
